### PR TITLE
Adding url prefix for running jenkins behind Apache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,15 @@ RUN apt-get update && apt-get install -y jenkins
 RUN mkdir -p /var/jenkins_home && chown -R jenkins /var/jenkins_home
 ADD init.groovy /tmp/WEB-INF/init.groovy
 RUN cd /tmp && zip -g /usr/share/jenkins/jenkins.war WEB-INF/init.groovy
+ADD ./jenkins.sh /usr/local/bin/jenkins.sh
+RUN chmod +x /usr/local/bin/jenkins.sh
 USER jenkins
 
 # VOLUME /var/jenkins_home - bind this in via -v if you want to make this persistent.
 ENV JENKINS_HOME /var/jenkins_home
+
+# define url prefix for running jenkins behind Apache (https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache)
+ENV JENKINS_PREFIX /
 
 # for main web interface:
 EXPOSE 8080 
@@ -23,4 +28,4 @@ EXPOSE 8080
 # will be used by attached slave agents:
 EXPOSE 50000 
 
-CMD ["/usr/bin/java",  "-jar",  "/usr/share/jenkins/jenkins.war"]
+CMD ["/usr/local/bin/jenkins.sh"]

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exec java -jar /usr/share/jenkins/jenkins.war --prefix=$JENKINS_PREFIX


### PR DESCRIPTION
Adding url prefix for running jenkins behind Apache as describe https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache: _"For this set up to work, the context path of Jenkins must be the same between your Apache and Jenkins (that is, you can't run Jenkins on http://localhost:8081/ci and have it exposed at http://localhost:80/jenkins)"_
