### PR TITLE
Reducing size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,14 +6,14 @@ RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/ap
 ENV JENKINS_VERSION 1.565.3
 RUN mkdir /usr/share/jenkins/
 RUN useradd -d /home/jenkins -m -s /bin/bash jenkins
-RUN curl -L http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.war -o /usr/share/jenkins/jenkins.war
+
+COPY init.groovy /tmp/WEB-INF/init.groovy
+RUN curl -L http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.war -o /usr/share/jenkins/jenkins.war \
+  && cd /tmp && zip -g /usr/share/jenkins/jenkins.war WEB-INF/init.groovy && rm -rf /tmp/WEB-INF
 
 ENV JENKINS_HOME /var/jenkins_home
 RUN usermod -m -d "$JENKINS_HOME" jenkins && chown -R jenkins "$JENKINS_HOME"
 VOLUME /var/jenkins_home
-
-COPY init.groovy /tmp/WEB-INF/init.groovy
-RUN cd /tmp && zip -g /usr/share/jenkins/jenkins.war WEB-INF/init.groovy && rm -rf /tmp/WEB-INF
 
 # define url prefix for running jenkins behind Apache (https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache)
 ENV JENKINS_PREFIX /


### PR DESCRIPTION
A couple ideas to reduce the size of the image

Current image is 521.4MB
With JRE instead of JDK, and without git I got 476.7MB
Preventing the war copies it went down to 408.6MB

I wanted to ask you if there's another way to inject groovy init scripts without putting them into the zip file, to avoid downstream images repackaging of the war. Right now the only I can think of is:
- expand the war
- copy script into /var/jenkins_home/war/WEB-INF/init.groovy.d/
- start the war
  all of it at run time. At build time I would end with two copies of the war contents.
  If I just put the scripts before expanding the war they get deleted.

Is it possible to expand the war, delete it and run jenkins from the expanded dir? or that would prevent auto update and other features?
It'd be nice if groovy scripts could be added to /var/jenkins_home/.jenkins or any other dir outside of the war
