### PR TITLE
dowload jenkins.war, no need for debian package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/ap
 ENV JENKINS_VERSION 1.565.2
 RUN mkdir /usr/share/jenkins/
 RUN useradd -d /home/jenkins -m -s /bin/bash jenkins
-ADD http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.war /usr/share/jenkins/
+RUN curl -L http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.war -o /usr/share/jenkins/jenkins.war
 
 ENV JENKINS_HOME /var/jenkins_home
 RUN usermod -m -d "$JENKINS_HOME" jenkins && chown -R jenkins "$JENKINS_HOME"


### PR DESCRIPTION
the later include daemon setup that doesn’t make sense in a Docker container
also require to register custom apt-key, just to get the jenkins package available.
but we only need a war !
