### PR TITLE
Create drop directories for plugins and init scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,16 @@ ENV JENKINS_VERSION 1.565.3
 RUN mkdir /usr/share/jenkins/
 RUN useradd -d /home/jenkins -m -s /bin/bash jenkins
 
-COPY init.groovy /tmp/WEB-INF/init.groovy
-RUN curl -L http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.war -o /usr/share/jenkins/jenkins.war \
-  && cd /tmp && zip -g /usr/share/jenkins/jenkins.war WEB-INF/init.groovy && rm -rf /tmp/WEB-INF
+RUN curl -L http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.war -o /usr/share/jenkins/jenkins.war
 
 ENV JENKINS_HOME /var/jenkins_home
 RUN usermod -m -d "$JENKINS_HOME" jenkins && chown -R jenkins "$JENKINS_HOME"
 VOLUME /var/jenkins_home
+
+COPY ./jenkins.sh /usr/local/bin/jenkins.sh
+
+COPY ./jnlp.groovy /usr/share/jenkins/init.groovy.d/
+RUN mkdir -p /usr/share/jenkins/plugins && chown -R jenkins /usr/share/jenkins/plugins /usr/share/jenkins/init.groovy.d
 
 # define url prefix for running jenkins behind Apache (https://wiki.jenkins-ci.org/display/JENKINS/Running+Jenkins+behind+Apache)
 ENV JENKINS_PREFIX /
@@ -26,4 +29,4 @@ EXPOSE 50000
 
 USER jenkins
 
-ENTRYPOINT java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war --prefix=$JENKINS_PREFIX
+ENTRYPOINT /usr/local/bin/jenkins.sh

--- a/README.md
+++ b/README.md
@@ -61,15 +61,31 @@ docker run --name myjenkins -p 8080:8080 -env JAVA_OPTS=-Dhudson.footerURL=http:
 
 # Installing more tools
 
-You can run your container as root - and unstall via apt-get, install as part of build steps via jenkins tool installers, or you can create your own Dockerfile to customise, for example: 
+You can run your container as root - and install via apt-get, install as part of build steps via jenkins tool installers, or you can create your own Dockerfile to customise, for example:
 
 ```
 FROM jenkins
 USER root # if we want to install via apt
 RUN apt-get install -y ruby make more-thing-here
 USER jenkins # drop back to the regular jenkins user - good practice
+```
+
+Plugins and Groovy init scripts can be dropped into `/usr/share/jenkins/init.groovy.d/` and `/usr/share/jenkins/plugins/`
+in order to build a new customized image.
+At runtime these files are copied to `$JENKINS_HOME` and used from there.
+They can't be copied directly to `$JENKINS_HOME` at build time as it is configured as a volume.
 
 ```
+FROM jenkins
+
+# a groovy script to customize something
+COPY ./my-script.groovy /usr/share/jenkins/init.groovy.d/
+
+# install the swarm plugin
+RUN curl -sSL -o /usr/share/jenkins/plugins/swarm.hpi https://updates.jenkins-ci.org/latest/swarm.hpi
+```
+
+
 # Upgrading
 
 All the data needed is in the /var/jenkins_home directory - so depending on how you manage that - depends on how you upgrade. Generally - you can copy it out - and then "docker pull" the image again - and you will have the latest LTS - you can then start up with -v pointing to that data (/var/jenkins_home) and everything will be as you left it.

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+echo "Copying init scripts"
+mkdir -p $JENKINS_HOME/init.groovy.d
+find /usr/share/jenkins/init.groovy.d/ -type f -exec cp {} $JENKINS_HOME/init.groovy.d/ \;
+
+echo "Copying plugins"
+mkdir -p $JENKINS_HOME/plugins
+find /usr/share/jenkins/plugins/ -type f -exec cp {} $JENKINS_HOME/plugins/ \;
+
+exec java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war --prefix=$JENKINS_PREFIX "$@"

--- a/jnlp.groovy
+++ b/jnlp.groovy
@@ -1,7 +1,6 @@
 import hudson.model.*;
 import jenkins.model.*;
 
-
 Thread.start {
       sleep 10000
       println "--> setting agent port for jnlp"


### PR DESCRIPTION
So that the image can be easily customized downstream

The problem with build time customization is that plugins can't be copied into JENKIS_HOME, being a volume.
Here a drop dir is created at /usr/share/jenkins/plugins (same for groovy init scripts) and files are copied at runtime into JENKINS_HOME
So if you want to customize the image just copy plugins there and they will be automatically installed:

```
FROM jenkins
RUN curl -sSL -o /usr/share/jenkins/plugins/swarm.hpi https://updates.jenkins-ci.org/latest/swarm.hpi
```

Some of that is done in #19 too

WDYT?
