### PR TITLE
Update readme for inclusion of plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Those need to be packaged inside the executed jenkins.war, so use :
 RUM mkdir /tmp/WEB-INF/plugins
 RUN curl -L https://updates.jenkins-ci.org/latest/git.hpi -o /tmp/WEB-INF/plugins/git.hpi
 RUN curl -L https://updates.jenkins-ci.org/latest/git-client.hpi -o /tmp/WEB-INF/plugins/git-client.hpi
-RUN cd /tmp; zip --grow /usr/share/jenkins/jenkins.war WEB-INF/* 
+RUN cd /tmp; zip --grow /usr/share/jenkins/jenkins.war WEB-INF/**/*
 ```
 
 Also see [JENKINS-24986](https://issues.jenkins-ci.org/browse/JENKINS-24986)


### PR DESCRIPTION
I tried to do as your readme suggested, but the plugins were not getting included in the jenkins.war file. Changing to a recursive file glob fixed it.
