### PR TITLE
Add bzip2 to the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:openjdk-7u65-jdk
 
-RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget git curl zip bzip2 && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_VERSION 1.565.3
 RUN mkdir /usr/share/jenkins/


### PR DESCRIPTION
Some build need bzip2, for instance node application installing phantomJS.