### PR TITLE
Fix plugins downloading

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -2,18 +2,20 @@
 
 # Parse a support-core plugin -style txt file as specification for jenkins plugins to be installed
 # in the reference directory, so user can define a derived Docker image with just :
-# 
+#
 # FROM jenkins
 # COPY plugins.txt /plugins.txt
 # RUN /usr/local/bin/plugins.sh /plugins.txt
-# 
+#
 
 REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
 
 while read spec; do
-    plugin=(${spec//:/ }); 
+    plugin=(${spec//:/ });
     [[ ${plugin[0]} =~ ^# ]] && continue
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
-    curl -L ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.hpi;
+    [[ -z ${plugin[1]} ]] && plugin[1]="latest"
+    echo "Downloading ${plugin[0]}:${plugin[1]}"
+    curl -s -L -f ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.hpi || echo "Failed to download ${plugin[0]}:${plugin[1]}"
 done  < $1


### PR DESCRIPTION
- Add `-f` flag for curl to fail script on http error
- Add plugin version check, use `latest` if empty
- Show message on plugin download start and failure
- Silent downloading