### PR TITLE
Upgrade to JDK 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-7u65-jdk
+FROM java:8u45-jdk
 
 RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
It is time to upgrade to jdk8 now that 7 is EOL