### PR TITLE
Make copy_reference_file quieter

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ EXPOSE 8080
 # will be used by attached slave agents:
 EXPOSE 50000
 
+ENV COPY_REFERENCE_FILE_LOG /var/log/copy_reference_file.log
+RUN touch $COPY_REFERENCE_FILE_LOG && chown jenkins.jenkins $COPY_REFERENCE_FILE_LOG
+
 USER jenkins
 
 COPY jenkins.sh /usr/local/bin/jenkins.sh

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,10 +6,13 @@
 # can then change this, upgrade plugins, etc.
 copy_reference_file() {
 	f=${1%/} 
+	echo "$f" >> /tmp/copy_reference_file.log
     rel=${f:23}
-    dir=$(dirname ${f})
+    dir=$(dirname ${f}) >> /tmp/copy_reference_file.log
+    echo " $f -> $rel"
 	if [[ ! -e /var/jenkins_home/${rel} ]] 
 	then
+		echo "copy $rel to JENKINS_HOME" >> /tmp/copy_reference_file.log
 		mkdir -p /var/jenkins_home/${dir:23}
 		cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel}; 
 	fi; 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -8,8 +8,8 @@ copy_reference_file() {
 	f=${1%/} 
 	echo "$f" >> /tmp/copy_reference_file.log
     rel=${f:23}
-    dir=$(dirname ${f}) >> /tmp/copy_reference_file.log
-    echo " $f -> $rel"
+    dir=$(dirname ${f})
+    echo " $f -> $rel" >> /tmp/copy_reference_file.log
 	if [[ ! -e /var/jenkins_home/${rel} ]] 
 	then
 		echo "copy $rel to JENKINS_HOME" >> /tmp/copy_reference_file.log

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,13 +6,10 @@
 # can then change this, upgrade plugins, etc.
 copy_reference_file() {
 	f=${1%/} 
-	echo "$f"
     rel=${f:23}
     dir=$(dirname ${f})
-    echo " $f -> $rel"    
 	if [[ ! -e /var/jenkins_home/${rel} ]] 
 	then
-		echo "copy $rel to JENKINS_HOME"
 		mkdir -p /var/jenkins_home/${dir:23}
 		cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel}; 
 	fi; 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,18 +6,19 @@
 # can then change this, upgrade plugins, etc.
 copy_reference_file() {
 	f=${1%/} 
-	echo "$f" >> /tmp/copy_reference_file.log
+	echo "$f" >> $COPY_REFERENCE_FILE_LOG
     rel=${f:23}
     dir=$(dirname ${f})
-    echo " $f -> $rel" >> /tmp/copy_reference_file.log
+    echo " $f -> $rel" >> $COPY_REFERENCE_FILE_LOG
 	if [[ ! -e /var/jenkins_home/${rel} ]] 
 	then
-		echo "copy $rel to JENKINS_HOME" >> /tmp/copy_reference_file.log
+		echo "copy $rel to JENKINS_HOME" >> $COPY_REFERENCE_FILE_LOG
 		mkdir -p /var/jenkins_home/${dir:23}
 		cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel}; 
 	fi; 
 }
 export -f copy_reference_file
+echo "--- Copying files at $(date)" >> $COPY_REFERENCE_FILE_LOG
 find /usr/share/jenkins/ref/ -type f -exec bash -c 'copy_reference_file {}' \;
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments


### PR DESCRIPTION
Produces way too much output if you have a lot of files in `/usr/share/jenkins/ref`. @reviewbybees