### PR TITLE
Rename plugins to jpi and pin them on initial installation

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -16,7 +16,9 @@ copy_reference_file() {
 	then
 		echo "copy $rel to JENKINS_HOME" >> $COPY_REFERENCE_FILE_LOG
 		mkdir -p /var/jenkins_home/${dir:23}
-		cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel}; 
+		cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel};
+		# pin plugins on initial copy
+		[[ ${rel} == plugins/*.jpi ]] && touch /var/jenkins_home/${rel}.pinned
 	fi; 
 }
 export -f copy_reference_file

--- a/plugins.sh
+++ b/plugins.sh
@@ -17,5 +17,5 @@ while read spec || [ -n "$spec" ]; do
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
     echo "Downloading ${plugin[0]}:${plugin[1]}"
-    curl -s -L -f ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.hpi || echo "Failed to download ${plugin[0]}:${plugin[1]}"
+    curl -s -L -f ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi || echo "Failed to download ${plugin[0]}:${plugin[1]}"
 done  < $1


### PR DESCRIPTION
If not renamed we end with hpi and jpi plugins in the home
rework of #93 

@reviewbybees