### PR TITLE
Allow usage of mirror JENKINS_UC for downloading plugins

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN curl -fL http://mirrors.jenkins-ci.org/war-stable/$JENKINS_VERSION/jenkins.w
   && echo "$JENKINS_SHA /usr/share/jenkins/jenkins.war" | sha1sum -c -
 
 ENV JENKINS_UC https://updates.jenkins-ci.org
+ENV JENKINS_UC_DOWNLOAD $JENKINS_UC/download
 RUN chown -R jenkins "$JENKINS_HOME" /usr/share/jenkins/ref
 
 # for main web interface:

--- a/plugins.sh
+++ b/plugins.sh
@@ -19,5 +19,5 @@ while read spec || [ -n "$spec" ]; do
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
     echo "Downloading ${plugin[0]}:${plugin[1]}"
-    curl -s -L -f ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
+    curl -s -L -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
 done  < $1


### PR DESCRIPTION
Sometimes (like today ... and many other times unfortunately) the main
Jenkins update center is down and you cannot build a Jenkins Docker image.
It is much better than to include the full base URL in JENKINS_UC so that
the ENV variable can be overridden to point to an up-and-running site.

Example:
ENV JENKINS_UC_DOWNLOAD http://mirrors.clinkerhq.com/jenkins