### PR TITLE
plugins.sh ought to fail if a plugin download failed

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -8,6 +8,8 @@
 # RUN /usr/local/bin/plugins.sh /plugins.txt
 #
 
+set -e
+
 REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
 
@@ -17,5 +19,5 @@ while read spec || [ -n "$spec" ]; do
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
     echo "Downloading ${plugin[0]}:${plugin[1]}"
-    curl -s -L -f ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi || echo "Failed to download ${plugin[0]}:${plugin[1]}"
+    curl -s -L -f ${JENKINS_UC}/download/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
 done  < $1


### PR DESCRIPTION
Test case:

```
FROM jenkins:snapshot
RUN echo durable-task:1.99 > /tmp/bogus
RUN /usr/local/bin/plugins.sh /tmp/bogus
```

With this PR, `docker build` fails here as it should, alerting the `Dockerfile` author that something needs to be fixed.

Especially important when updating a `Dockerfile` immediately after doing a plugin release. If the new version is in the Maven repository but not yet on the update center, without this PR the build will seem to work, but you will get some trash at runtime.

@reviewbybees