### PR TITLE
Allow setting up of custom number of executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ This is highly recommended. Treat the jenkins_home directory as you would a data
 If your volume is inside a container - you can use ```docker cp $ID:/var/jenkins_home``` command to extract the data.
 Note that some symlinks on some OSes may be converted to copies (this can confuse jenkins with lastStableBuild links etc)
 
+# Setting the number of executors 
+
+You can specify and set the number of executors of your Jenkins instance via the `init.groovy` file. By default its set to 2 executors, but you can add the following line to change it to your desired number of executors :
+
+```
+Jenkins.instance.setNumExecutors(5)
+```
+
 # Attaching build executors
 
 You can run builds on the master (out of the box) but if you want to attach build slave servers: make sure you map the port: ```-p 50000:50000``` - which will be used when you connect a slave agent.

--- a/init.groovy
+++ b/init.groovy
@@ -6,4 +6,6 @@ Thread.start {
       sleep 10000
       println "--> setting agent port for jnlp"
       Jenkins.instance.setSlaveAgentPort(50000)
+//      println " --> setting number of executors (default is 2) "
+//      Jenkins.instance.setNumExecutors(2)
 }


### PR DESCRIPTION
The number of executors can be set via init.groovy file,
this allows changing the default num of executors from 2
whatever user specifies in init.groovy file.

Change-Id: I410ff043235d1dc9d5e1a72addd7669c2f2d5101