### PR TITLE
Fix copy of files with a $ in filename

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -23,7 +23,7 @@ copy_reference_file() {
 }
 export -f copy_reference_file
 echo "--- Copying files at $(date)" >> $COPY_REFERENCE_FILE_LOG
-find /usr/share/jenkins/ref/ -type f -exec bash -c 'copy_reference_file {}' \;
+find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then


### PR DESCRIPTION
This fixes support for configuration files under jenkins_home containing
a $ character. With the previous version, bash would evaluate the part
starting with $, replacing it with nothing, so the file wasn't copied.

@reviewbybees