### PR TITLE
Verify tini using sha1sum

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,11 @@ VOLUME /var/jenkins_home
 # or config file with your custom jenkins Docker image.
 RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
 
+ENV TINI_SHA 066ad710107dc7ee05d3aa6e4974f01dc98f3888
+
 # Use tini as subreaper in Docker container to adopt zombie processes 
-RUN curl -fL https://github.com/krallin/tini/releases/download/v0.5.0/tini-static -o /bin/tini && chmod +x /bin/tini
+RUN curl -fL https://github.com/krallin/tini/releases/download/v0.5.0/tini-static -o /bin/tini && chmod +x /bin/tini \
+  && echo "$TINI_SHA /bin/tini" | sha1sum -c -
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 


### PR DESCRIPTION
Tini should be verified with the hash of a known good binary, much like
Jenkins war is verified at the moment. This is in case someone manages to
upload a backdoored binary on the project's download page.
