### PR TITLE
Corrected access to env and added type conversion

### DIFF
--- a/init.groovy
+++ b/init.groovy
@@ -1,10 +1,10 @@
 import hudson.model.*;
 import jenkins.model.*;
 
-
 Thread.start {
       sleep 10000
+      def env = System.getenv()
       println "--> setting agent port for jnlp"
-      Jenkins.instance.setSlaveAgentPort(env['JENKINS_SLAVE_AGENT_PORT'])
+      Jenkins.instance.setSlaveAgentPort(env['JENKINS_SLAVE_AGENT_PORT'].toInteger())
       println "--> setting agent port for jnlp... done"
 }


### PR DESCRIPTION
* Docker commands that you execute

  `docker build -t "local-jenkins" .`
  `docker run --rm local-jenkins`
* Actual result

  `--> setting agent port for jnlp
Exception in thread "Thread-5" groovy.lang.MissingPropertyException: No such property: env for class: tcp-slave-agent-port`
and
`Exception in thread "Thread-5" org.codehaus.groovy.runtime.InvokerInvocationException: groovy.lang.MissingMethodException: No signature of method: hudson.model.Hudson.setSlaveAgentPort() is applicable for argument types: (java.lang.String) values: [50000]`
* Expected outcome: No Exception
* Output of docker version

  `Client version: 1.7.1
Client API version: 1.19
Go version (client): go1.4.2
Git commit (client): 786b29d
OS/Arch (client): linux/amd64
Server version: 1.7.1
Server API version: 1.19
Go version (server): go1.4.2
Git commit (server): 786b29d
OS/Arch (server): linux/amd64
`
* Other relevant information
