### PR TITLE
demo how to start jenkins with jnlp /computer/slave1 that has docker and docker-compose

### DIFF
--- a/slave/ubuntu/docker/Dockerfile
+++ b/slave/ubuntu/docker/Dockerfile
@@ -1,0 +1,10 @@
+FROM java:8-jdk
+
+# https://urllib3.readthedocs.org/en/latest/security.html#pyopenssl
+RUN apt-get update && apt-get install -y build-essential python-dev python-pip libffi-dev libssl-dev && rm -rf /var/lib/apt/lists/* && \
+    pip install --upgrade pip && \
+    pip install urllib3 pyOpenSSL ndg-httpsclient pyasn1 docker-compose
+
+ADD jenkins-slave.sh /usr/local/bin/
+
+ENTRYPOINT /usr/local/bin/jenkins-slave.sh

--- a/slave/ubuntu/docker/docker-compose.yml
+++ b/slave/ubuntu/docker/docker-compose.yml
@@ -1,0 +1,24 @@
+master:
+  image: jenkins:1.609.3
+  environment:
+    JAVA_OPTS: "-Djava.awt.headless=true"
+  ports:
+    - "50000:50000"
+    - "8080:8080"
+  volumes:
+    - /var/jenkins_home
+    - ./init.groovy:/usr/share/jenkins/ref/init.groovy.d/jnlp-slave.groovy
+
+slave:
+  build: .
+  environment:
+    master: "http://master:8080"
+    slave: "slave1"
+    # Docker does not support multiple inheritance. The environment and volume flags below install /usr/local/bin/docker on top of java:8u45-jdk
+    # without having to rewrite Dockerfile to append https://registry.hub.docker.com/u/library/docker-dev
+    DOCKER_HOST: "unix:///docker.sock"
+  volumes:
+    - /var/run/docker.sock:/docker.sock
+    - /usr/local/bin/docker:/usr/local/bin/docker
+  links:
+    - master

--- a/slave/ubuntu/docker/init.groovy
+++ b/slave/ubuntu/docker/init.groovy
@@ -1,0 +1,42 @@
+import hudson.model.*;
+import hudson.slaves.*;
+import jenkins.model.*;
+
+Thread.start {
+      sleep 10000
+      def env = System.getenv()
+      def instance = Jenkins.getInstance()
+
+      // avoid overloading jenkins master
+      println "--> setting jenkins master to 0 executors"
+      instance.setNumExecutors(0)
+      println "--> setting jenkins master to 0 executors... done"
+
+      // modify below to your needs
+      println "--> adding JNLP slave(s)"
+      List<String> clients = new ArrayList<String>()
+      clients.add("slave1")
+      // clients.add("...")
+
+      // http://javadoc.jenkins-ci.org/hudson/slaves/DumbSlave.html
+      for (String client : clients) {
+        println "--> creating 2 executor stub for /computer/" + client + " available via /label/docker based on java:8u45-jdk with docker and docker-compose"
+        instance.addNode(
+	  new DumbSlave(
+		client,
+                "JNLP slave with docker and docker-compose",
+                "/root",
+                "5",
+                Node.Mode.NORMAL,
+                "docker",
+                new JNLPLauncher(),
+                new RetentionStrategy.Always(),
+                new LinkedList()
+          )
+        )
+      }
+      println "--> adding JNLP slave(s)... done"
+
+      instance.save()
+      println "--> saving " + env['JENKINS_HOME'] + "/config.xml... done"
+}

--- a/slave/ubuntu/docker/jenkins-slave.sh
+++ b/slave/ubuntu/docker/jenkins-slave.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -le
+# description: connect slave to jenkins master via JNLP w/ resilency for recovery from bad connection state
+# i.e. java -jar slave.jar -jnlpUrl http://jenkins:8080/computer/client1/slave-agent.jnlp
+
+: ${master:=$1}
+: ${master:="http://jenkins:8080"}
+
+: ${slave:=$2}
+: ${slave:=`hostname -s`}
+
+JAR_FILE=slave.jar
+LOG="./jenkins_slave.log"
+
+# kill pid of existing connection if slave is offline since it is likely possible a stale network would prevent recovery after jenkins restart, upgrade, etc.
+terminateOfflineSlave() {
+  RUNNING=$(ps u -U $(whoami) | grep ${JAR_FILE} | awk '/java/{print $2}')
+  if [ ! -z "${RUNNING}" ]; then
+    curl --silent -L ${master}/computer/${slave}/api/xml | grep '<offline>false</offline>' 1>/dev/null && echo "Slave process is already running" && exit 0
+    echo 'Offline slave process terminated'
+    kill -s KILL ${RUNNING}
+  else
+    echo "Slave process is not running"
+  fi
+}
+
+# always download from master to match communication incase jenkins was upgraded
+downloadJar() {
+  rm -f ${JAR_FILE}
+  url="${master}/jnlpJars/${JAR_FILE}"
+  echo "Downloading latest JAR from $url" >> $LOG
+  curl -OL ${master}/jnlpJars/${JAR_FILE} >> $LOG
+}
+
+startJar() {
+  echo "Starting ${JAR_FILE}"  >> $LOG
+  java -jar ${JAR_FILE} -jnlpUrl ${master}/computer/${slave}/slave-agent.jnlp
+}
+
+terminateOfflineSlave
+
+# for-loop where initial jenkins setup > +10 min whereas subsequent startup ~1 min
+i=15; until [ $i -eq 0 ]; do let i-=1 && downloadJar && startJar && i=0 || sleep 60; done
+
+# check if running
+RUNNING=$(ps u -U $(whoami) | grep ${JAR_FILE} | awk '/java/{print $2}')
+[ ! -z "${RUNNING}" ] && exit 0 || exit 1

--- a/slave/ubuntu/jdk8/Dockerfile
+++ b/slave/ubuntu/jdk8/Dockerfile
@@ -1,0 +1,5 @@
+FROM java:8-jdk
+
+ADD jenkins-slave.sh /usr/local/bin/
+
+ENTRYPOINT /usr/local/bin/jenkins-slave.sh

--- a/slave/ubuntu/jdk8/docker-compose.yml
+++ b/slave/ubuntu/jdk8/docker-compose.yml
@@ -1,0 +1,18 @@
+master:
+  image: jenkins:1.609.3
+  environment:
+    JAVA_OPTS: "-Djava.awt.headless=true"
+  ports:
+    - "50000:50000"
+    - "8080:8080"
+  volumes:
+    - /var/jenkins_home
+    - ./init.groovy:/usr/share/jenkins/ref/init.groovy.d/jnlp-slave.groovy
+
+slave:
+  build: .
+  environment:
+    master: "http://master:8080"
+    slave: "slave1"
+  links:
+    - master

--- a/slave/ubuntu/jdk8/init.groovy
+++ b/slave/ubuntu/jdk8/init.groovy
@@ -1,0 +1,42 @@
+import hudson.model.*;
+import hudson.slaves.*;
+import jenkins.model.*;
+
+Thread.start {
+      sleep 10000
+      def env = System.getenv()
+      def instance = Jenkins.getInstance()
+
+      // avoid overloading jenkins master
+      println "--> setting jenkins master to 0 executors"
+      instance.setNumExecutors(0)
+      println "--> setting jenkins master to 0 executors... done"
+
+      // modify below to your needs
+      println "--> adding JNLP slave(s)"
+      List<String> clients = new ArrayList<String>()
+      clients.add("slave1")
+      // clients.add("...")
+
+      // http://javadoc.jenkins-ci.org/hudson/slaves/DumbSlave.html
+      for (String client : clients) {
+        println "--> creating 2 executor stub for /computer/" + client + " available via /label/jdk8 based on java:8-jdk"
+        instance.addNode(
+	  new DumbSlave(
+		client,
+                "JNLP slave",
+                "/root",
+                "2",
+                Node.Mode.NORMAL,
+                "jdk8",
+                new JNLPLauncher(),
+                new RetentionStrategy.Always(),
+                new LinkedList()
+          )
+        )
+      }
+      println "--> adding JNLP slave(s)... done"
+
+      instance.save()
+      println "--> saving " + env['JENKINS_HOME'] + "/config.xml... done"
+}

--- a/slave/ubuntu/jdk8/jenkins-slave.sh
+++ b/slave/ubuntu/jdk8/jenkins-slave.sh
@@ -1,0 +1,46 @@
+#!/bin/bash -le
+# description: connect slave to jenkins master via JNLP w/ resilency for recovery from bad connection state
+# i.e. java -jar slave.jar -jnlpUrl http://jenkins:8080/computer/client1/slave-agent.jnlp
+
+: ${master:=$1}
+: ${master:="http://jenkins:8080"}
+
+: ${slave:=$2}
+: ${slave:=`hostname -s`}
+
+JAR_FILE=slave.jar
+LOG="./jenkins_slave.log"
+
+# kill pid of existing connection if slave is offline since it is likely possible a stale network would prevent recovery after jenkins restart, upgrade, etc.
+terminateOfflineSlave() {
+  RUNNING=$(ps u -U $(whoami) | grep ${JAR_FILE} | awk '/java/{print $2}')
+  if [ ! -z "${RUNNING}" ]; then
+    curl --silent -L ${master}/computer/${slave}/api/xml | grep '<offline>false</offline>' 1>/dev/null && echo "Slave process is already running" && exit 0
+    echo 'Offline slave process terminated'
+    kill -s KILL ${RUNNING}
+  else
+    echo "Slave process is not running"
+  fi
+}
+
+# always download from master to match communication incase jenkins was upgraded
+downloadJar() {
+  rm -f ${JAR_FILE}
+  url="${master}/jnlpJars/${JAR_FILE}"
+  echo "Downloading latest JAR from $url" >> $LOG
+  curl -OL ${master}/jnlpJars/${JAR_FILE} >> $LOG
+}
+
+startJar() {
+  echo "Starting ${JAR_FILE}"  >> $LOG
+  java -jar ${JAR_FILE} -jnlpUrl ${master}/computer/${slave}/slave-agent.jnlp
+}
+
+terminateOfflineSlave
+
+# for-loop where initial jenkins setup > +10 min whereas subsequent startup ~1 min
+i=15; until [ $i -eq 0 ]; do let i-=1 && downloadJar && startJar && i=0 || sleep 60; done
+
+# check if running
+RUNNING=$(ps u -U $(whoami) | grep ${JAR_FILE} | awk '/java/{print $2}')
+[ ! -z "${RUNNING}" ] && exit 0 || exit 1


### PR DESCRIPTION
Demonstrate how to demo jenkins with a simple jnlp slave based on java:8u45 via
``docker-compose -f slave/jdk8u45/docker-compose.yml [rm | build | up | ps | stop]``

And how to organize additional other jnlp slave like with with docker and docker-compose included via
 `` docker-compose -f slave/docker/docker-compose.yml [rm | build | up | ps | stop]``
