### PR TITLE
A demo on how to organize multiple jenkins environment

### DIFF
--- a/environments/example/Dockerfile
+++ b/environments/example/Dockerfile
@@ -1,0 +1,13 @@
+FROM jenkins:1.609.3
+
+# list of jenkins plugins to install
+COPY plugins.txt /usr/share/jenkins/ref/
+
+# download jenkins plugins from JENKINS_UC
+RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
+
+# uncomment to local plugin file(s) into docker image
+#ADD *.?pi /usr/share/jenkins/ref/plugins/
+
+# additional groovy scripts to be executed on startup
+COPY *.groovy /usr/share/jenkins/ref/init.groovy.d/

--- a/environments/example/Dockerfile
+++ b/environments/example/Dockerfile
@@ -1,5 +1,22 @@
 FROM jenkins:1.609.3
 
+# root is required to modify uid
+USER root
+
+ENV JENKINS_USER jenkins
+
+###########################################################
+# $ docker run --name jenkins -d jenkins:1.609.3; docker exec -it jenkins id -a; docker stop jenkins; docker rm -vf jenkins
+# uid=1000(jenkins) gid=1000(jenkins) groups=1000(jenkins)
+#RUN usermod --uid xxx --login $JENKINS_USER jenkins
+###########################################################
+
+# insure VOLUME is mountable now by above changes
+RUN chown -R $JENKINS_USER "$JENKINS_HOME" /usr/share/jenkins/ref
+
+# restore ENTRYPOINT to startup as jenkins user
+USER $JENKINS_USER
+
 # list of jenkins plugins to install
 COPY plugins.txt /usr/share/jenkins/ref/
 

--- a/environments/example/README.md
+++ b/environments/example/README.md
@@ -1,0 +1,24 @@
+A demo on how to organize multiple jenkins, where each environment can
+
+ * specify its own FROM jenkins base image for a particular revision
+ * modify its own list of plugins.txt to install on top of that image
+ * customize its own groovy script to invoke on startup for a container of that image
+ * maintain docker-compose.yml to represent the docker run parameters to supply representing the relationship between master and slave(s)
+
+### Setup
+```
+cp -R ./environments/example ./environments/&lt;your machine&gt;
+vi ./environments/&lt;your machine&gt;/docker-compose.yml
+vi ./environments/&lt;your machine&gt;/Dockerfile
+vi ./environments/&lt;your machine&gt;/plugins.txt
+vi ./environments/&lt;your machine&gt;/*.groovy
+```
+
+### Build / Run
+```
+ssh &lt;your machine&gt;
+git clone https://github.com/jenkinsci/docker; cd docker
+cd ./environments/&lt;your machine&gt;
+docker-compose build [--no-cache]
+docker-compose up [-d]
+```

--- a/environments/example/docker-compose.yml
+++ b/environments/example/docker-compose.yml
@@ -1,0 +1,9 @@
+master:
+  build: .
+  environment:
+    JAVA_OPTS: "-Djava.awt.headless=true"
+  ports:
+    - "5000:5000"
+    - "8080:8080"
+  volumes:
+    - /var/jenkins_home

--- a/environments/example/init.groovy
+++ b/environments/example/init.groovy
@@ -1,0 +1,16 @@
+import hudson.model.*;
+import jenkins.model.*;
+
+Thread.start {
+      sleep 11000
+
+      def instance = Jenkins.getInstance()
+      def env = System.getenv()
+
+      // avoid overloading CPU on jenkins master, use slaves for executors
+      instance.setNumExecutors(0)
+      println "--> set jenkins master to 0 executors"
+
+      instance.save()
+      println "--> saved " + env['JENKINS_HOME'] + "/config.xml"
+}

--- a/environments/example/plugins.txt
+++ b/environments/example/plugins.txt
@@ -1,0 +1,1 @@
+github-api:latest


### PR DESCRIPTION
A demo on how to organize multiple jenkins environment where each can specify its own jenkins version, plugins, and groovy script to invoke on setup.

 - ./config/&lt;your machine&gt;/docker-compose.yml simplify the set of parameters and flags to pass to docker run
 - ./config/&lt;your machine&gt;/Dockerfile is based on FROM jenkins:1.609.2 ... edit version if a different one is desired for your image
 - ./config/&lt;your machine&gt;/plugins.txt to specify which plugins should be downloaded into /usr/share/jenkins/ref/plugins/ as part of the image
 - ./config/&lt;your machine&gt;/*.groovy scripts to be excuted in /usr/share/jenkins/ref/init.groovy.d/ during startup as part of the image

### Recommend build with no-cache to avoid using old image
```
cd config/example
docker-compose build --no-cache
```

### Run jenkins in daemon mode
```
cd config/example
docker-compose up -d
```
