### PR TITLE
Verify that downloaded plugin is really a Zip archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:8-jdk
 
-RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y wget git curl zip file && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_SLAVE_AGENT_PORT 50000

--- a/plugins.sh
+++ b/plugins.sh
@@ -24,4 +24,11 @@ while read spec || [ -n "$spec" ]; do
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
     curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
+    if ls -l $REF/${plugin[0]}.jpi && file $REF/${plugin[0]}.jpi | grep 'Zip archive'
+    then
+      echo Download okay. ${plugin[0]}.jpi seems to be a Zip archive
+    else
+      echo "Downloading via '${cmd}' failed"
+      exit 3
+    fi
 done  < $1


### PR DESCRIPTION
This fixed the problem raised in https://github.com/jenkinsci/docker/issues/145

The solution is a little bit different to be minimal compared to the master branch.

Also I have no longer problems loading the role-strategy plugin, as somebody updated the link.