### PR TITLE
Clean up the change-executors example in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ For more info check Docker docs section on [Managing data in containers](https:/
 
 You can specify and set the number of executors of your Jenkins master instance using a groovy script. By default its set to 2 executors, but you can extend the image and change it to your desired number of executors :
 
+`executors.groovy`
 ```
-# executors.groovy
+import jenkins.model.*
 Jenkins.instance.setNumExecutors(5)
 ```
 


### PR DESCRIPTION
Without importing symbols, there's nothing else in the Groovy script's binding, so the example would otherwise fail