### PR TITLE
Updated to the latest LTS version 1.625.1, including a fresh sha1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,8 @@ RUN curl -fL https://github.com/krallin/tini/releases/download/v0.5.0/tini-stati
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 
-ENV JENKINS_VERSION 1.609.3
-ENV JENKINS_SHA f5ad5f749c759da7e1a18b96be5db974f126b71e
+ENV JENKINS_VERSION 1.625.1
+ENV JENKINS_SHA c96d44d4914a154c562f21cd20abdd675ac7f5f3
 
 # could use ADD but this one does not check Last-Modified header 
 # see https://github.com/docker/docker/issues/8331


### PR DESCRIPTION
I've updated to the latest LTS version 1.625.1, including a fresh sha1
I've tested it by making a build on the docker hub here https://hub.docker.com/r/svilstrup/docker-jenkins-official/
After that, I started up the docker image and checked that it ran the right version by accessing the web interface.