### PR TITLE
Update to next LTS version of Jenkins : 1.625.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,9 @@ RUN curl -fL https://github.com/krallin/tini/releases/download/v0.5.0/tini-stati
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 
-ENV JENKINS_VERSION 1.625.1
-ENV JENKINS_SHA c96d44d4914a154c562f21cd20abdd675ac7f5f3
+ENV JENKINS_VERSION 1.625.2
+ENV JENKINS_SHA 395fe6975cf75d93d9fafdafe96d9aab1996233b
+
 
 # could use ADD but this one does not check Last-Modified header 
 # see https://github.com/docker/docker/issues/8331


### PR DESCRIPTION
Hi,

Update Dockerfile to use last release of LTS Jenkins version 1.625.2 which contain "Important security fixes".

Regards,
Jean-Pascal

PS : This is my first PR, i'ma sorry if it's not done in right way. 