### PR TITLE
Make the Jenkins UID an environment variable.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,11 @@ RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/ap
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_SLAVE_AGENT_PORT 50000
 
-# Jenkins is run with user `jenkins`, uid = 1000
+# Jenkins is run with user `jenkins`, uid = 1000 (by default)
 # If you bind mount a volume from the host or a data container, 
-# ensure you use the same uid
-RUN useradd -d "$JENKINS_HOME" -u 1000 -m -s /bin/bash jenkins
+# ensure you use the same uid, or change the JENKINS_UID environment variable to match.
+ENV JENKINS_UID 1000
+RUN useradd -d "$JENKINS_HOME" -u "$JENKINS_UID" -m -s /bin/bash jenkins
 
 # Jenkins home directory is a volume, so configuration and build history 
 # can be persisted and survive image upgrades


### PR DESCRIPTION
I thought it would be nice to make the Jenkins UID configurable so we can tell the image which UID we want it to run as.

Not sure this is exactly the right way to go about this, but I figured I'd submit a PR and see what people thought.

Thanks.