### PR TITLE
Set sane JVM memory options based on cgroups limits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,6 +58,7 @@ ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 USER ${user}
 
 COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY docker-jvm-opts.sh /usr/local/bin/docker-jvm-opts.sh
 ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle

--- a/docker-jvm-opts.sh
+++ b/docker-jvm-opts.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Return reasonable JVM options to run inside a Docker container where memory and
+# CPU can be limited with cgroups.
+# https://docs.oracle.com/javase/8/docs/technotes/guides/vm/gctuning/parallel.html
+
+# Options:
+#   JVM_HEAP_RATIO=0.5 Ratio of heap size to available memory
+
+# If Xmx is not set the JVM will use by default 1/4th (in most cases) of the host memory
+# This can cause the Kernel to kill the container if the JVM memory grows over the cgroups limit
+# because the JVM is not aware of that limit and doesn't invoke the GC
+# Setting it by default to 0.5 times the memory limited by cgroups, customizable with JVM_HEAP_RATIO
+CGROUPS_MEM=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
+MEMINFO_MEM=$(($(awk '/MemTotal/ {print $2}' /proc/meminfo)*1024))
+MEM=$(($MEMINFO_MEM>$CGROUPS_MEM?$CGROUPS_MEM:$MEMINFO_MEM))
+JVM_HEAP_RATIO=${JVM_HEAP_RATIO:-0.5}
+XMX=$(awk '{printf("%d",$1*$2/1024^2)}' <<<" ${MEM} ${JVM_HEAP_RATIO} ")
+
+# TODO handle cpu limits into -XX:ParallelGCThreads
+
+echo "-Xmx${XMX}m"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -28,6 +28,11 @@ touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_F
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;
 
+# Set default JVM arguments for Docker
+if [[ "${JAVA_OPTS}" != *"-Xmx"* ]]; then
+	export _JAVA_OPTIONS=$(/usr/local/bin/docker-jvm-opts.sh)
+fi
+
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   eval "exec java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war $JENKINS_OPTS \"\$@\""


### PR DESCRIPTION
If Xmx is not set the JVM will use by default 1/4th (in most cases) of the host memory
This can cause the Kernel to kill the container if the JVM memory grows over the cgroups limit
because the JVM is not aware of that limit and doesn't invoke the GC
Setting it by default to 0.5 times the memory limited by cgroups, customizable with JVM_HEAP_RATIO
