### PR TITLE
Added support for directory names containing spaces

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -10,7 +10,7 @@ copy_reference_file() {
 	f="${1%/}"
 	echo "$f" >> "$COPY_REFERENCE_FILE_LOG"
     rel="${f:23}"
-    dir="$(dirname ${f})"
+    dir="${f%/*}"
     echo " $f -> $rel" >> "$COPY_REFERENCE_FILE_LOG"
 	if [[ ! -e /var/jenkins_home/${rel} ]] 
 	then


### PR DESCRIPTION
Placing a directory containing spaces, for example jobs/job name here/config.xml, into .../jenkins/refs fails to copy due to dirname splitting the reference into multiple whitespace delimited directories.

Since it's already established that the argument is a file, it's sufficient to simply strip everything after the last slash in the reference instead of using dirname.