### PR TITLE
if a config file has .override appended to its name, it will override…

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,23 +3,24 @@
 set -e
 
 # Copy files from /usr/share/jenkins/ref into /var/jenkins_home
-# So the initial JENKINS-HOME is set with expected content. 
-# Don't override, as this is just a reference setup, and use from UI 
+# So the initial JENKINS-HOME is set with expected content.
+# Don't override, as this is just a reference setup, and use from UI
 # can then change this, upgrade plugins, etc.
 copy_reference_file() {
 	f="${1%/}"
+	b="${f%.override}"
 	echo "$f" >> "$COPY_REFERENCE_FILE_LOG"
-    rel="${f:23}"
-    dir="$(dirname ${f})"
-    echo " $f -> $rel" >> "$COPY_REFERENCE_FILE_LOG"
-	if [[ ! -e /var/jenkins_home/${rel} ]] 
+	rel="${b:23}"
+	dir="$(dirname ${b})"
+	echo " $f -> $rel" >> "$COPY_REFERENCE_FILE_LOG"
+	if [[ ! -e /var/jenkins_home/${rel} || $f = *.override ]]
 	then
 		echo "copy $rel to JENKINS_HOME" >> "$COPY_REFERENCE_FILE_LOG"
 		mkdir -p "/var/jenkins_home/${dir:23}"
-		cp -r "/usr/share/jenkins/ref/${rel}" "/var/jenkins_home/${rel}";
+		cp -r "${f}" "/var/jenkins_home/${rel}";
 		# pin plugins on initial copy
 		[[ ${rel} == plugins/*.jpi ]] && touch "/var/jenkins_home/${rel}.pinned"
-	fi; 
+	fi;
 }
 export -f copy_reference_file
 touch "${COPY_REFERENCE_FILE_LOG}" || echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"
@@ -33,4 +34,3 @@ fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image
 exec "$@"
-


### PR DESCRIPTION
… and overwrite any existing config file.

e.g adding /usr/share/jenkins/ref/config.xml.override to a container will make sure Jenkins will always run start the with provided config.xml. 
