### PR TITLE
use /etc/init.d/jenkins variant to provide multiple java options with quotes

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -29,16 +29,7 @@ find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
-  CMD=(java)
-  if [ ! -z "$JAVA_OPTS" ]; then
-    CMD+=("$JAVA_OPTS")
-  fi
-  CMD+=(-jar)
-  CMD+=(/usr/share/jenkins/jenkins.war)
-  if [ ! -z "$JENKINS_OPTS" ]; then
-    CMD+=("$JENKINS_OPTS")
-  fi
-  exec "${CMD[@]}" "$@"
+  exec /bin/bash -c "java $JAVA_OPTS -jar /usr/share/jenkins/jenkins.war $JENKINS_OPTS $@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for sample a `bash` shell to explore this image


### PR DESCRIPTION
To fix https://github.com/jenkinsci/docker/issues/193