### PR TITLE
Reference #206 - Added example to get a list of plugins in the required format

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,22 @@ COPY plugins.txt /usr/share/jenkins/plugins.txt
 RUN /usr/local/bin/plugins.sh /usr/share/jenkins/plugins.txt
 ```
 
+Here is an example to get the list of plugins from an existing server you can use the following curl command:
+
+```
+JENKINS_HOST=myhost.com:port
+curl -sSL "http://$JENKINS_HOST/pluginManager/api/xml?depth=1&xpath=/*/*/shortName|/*/*/version&wrapper=plugins" | perl -pe 's/.*?<shortName>([\w-]+).*?<version>([^<]+)()(<\/\w+>)+/\1 \2\n/g'|sed 's/ /:/'
+```
+
+Example Output:
+
+```
+cucumber-testresult-plugin:0.8.2
+pam-auth:1.1
+matrix-project:1.4.1
+script-security:1.13
+...
+```
 
 # Upgrading
 


### PR DESCRIPTION
Updated the README.md to give instructions to extract a list of plugins from an existing server to create the list in the format required to create a plugin.txt file.
