### PR TITLE
reference #207 - Filter out plugins already installed

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -10,6 +10,7 @@
 # Note: Plugins already installed are skipped
 #
 
+set -e
 
 REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
@@ -32,8 +33,7 @@ while read spec || [ -n "$spec" ]; do
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
 
-    egrep "${plugin[0]}:${plugin[1]}" $TEMP_ALREADY_INSTALLED >/dev/null 2>&1
-    if [ $? -ne 0 ]
+    if ! grep -q "${plugin[0]}:${plugin[1]}" $TEMP_ALREADY_INSTALLED 
     then
     	echo "Downloading ${plugin[0]}:${plugin[1]}"
         curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi

--- a/plugins.sh
+++ b/plugins.sh
@@ -7,22 +7,43 @@
 # COPY plugins.txt /plugins.txt
 # RUN /usr/local/bin/plugins.sh /plugins.txt
 #
+# Note: Plugins already installed are skipped
+#
 
-set -e
 
 REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
+
+TEMP_ALREADY_INSTALLED=/var/jenkins_home/preinstalled.plugins.txt
+for i in `ls -pd1 /var/jenkins_home/plugins/*|egrep '\/$'`
+do 
+	PLUGIN=`basename $i`
+	VER=`egrep -i Plugin-Version "$i/META-INF/MANIFEST.MF"|cut -d\: -f2|sed 's/ //'`
+	echo "$PLUGIN:$VER"
+done > $TEMP_ALREADY_INSTALLED
 
 while read spec || [ -n "$spec" ]; do
     plugin=(${spec//:/ });
     [[ ${plugin[0]} =~ ^# ]] && continue
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
-    echo "Downloading ${plugin[0]}:${plugin[1]}"
 
     if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
-    curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
-    unzip -qqt $REF/${plugin[0]}.jpi
+
+    egrep "${plugin[0]}:${plugin[1]}" $TEMP_ALREADY_INSTALLED >/dev/null 2>&1
+    if [ $? -ne 0 ]
+    then
+    	echo "Downloading ${plugin[0]}:${plugin[1]}"
+        curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
+        unzip -qqt $REF/${plugin[0]}.jpi
+    else
+    	echo "  ... skipping already installed:  ${plugin[0]}:${plugin[1]}"
+    fi
 done  < $1
+
+#cleanup
+rm $TEMP_ALREADY_INSTALLED
+
+exit 0


### PR DESCRIPTION
Example output:

➜  jenkinsci_docker git:(filterPlugins) ✗ docker exec -t angry_kilby bash  /tmp/plugins.sh /tmp/plugins.txt
  ... skipping already installed:  ant:1.2
  ... skipping already installed:  antisamy-markup-formatter:1.1
  ... skipping already installed:  credentials:1.18
Downloading cucumber-testresult-plugin:0.8.2
  ... skipping already installed:  cvs:2.11
  ... skipping already installed:  external-monitor-job:1.4
Downloading git-client:1.19.0
Downloading git:2.4.0
  ... skipping already installed:  javadoc:1.1
  ... skipping already installed:  junit:1.2-beta-4
  ... skipping already installed:  ldap:1.11
  ... skipping already installed:  mailer:1.11
  ... skipping already installed:  matrix-auth:1.1
  ... skipping already installed:  matrix-project:1.4.1
  ... skipping already installed:  maven-plugin:2.7.1
  ... skipping already installed:  maven-plugin:2.7.1
  ... skipping already installed:  pam-auth:1.1
Downloading scm-api:1.0
  ... skipping already installed:  script-security:1.13
  ... skipping already installed:  ssh-credentials:1.10
  ... skipping already installed:  ssh-slaves:1.9
  ... skipping already installed:  subversion:1.54
  ... skipping already installed:  translation:1.10
  ... skipping already installed:  windows-slaves:1.0
➜  jenkinsci_docker git:(filterPlugins) ✗