### PR TITLE
reference #207 - Filter out plugins already installed

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -7,22 +7,118 @@
 # COPY plugins.txt /plugins.txt
 # RUN /usr/local/bin/plugins.sh /plugins.txt
 #
+# Note: Plugins already installed are skipped
+#
 
 set -e
 
+if [ -z "$1" ]
+then
+	echo "
+USAGE: 
+  Parse a support-core plugin -style txt file as specification for jenkins plugins to be installed
+  in the reference directory, so user can define a derived Docker image with just :
+ 
+  FROM jenkins
+  COPY plugins.txt /plugins.txt
+  RUN /usr/local/bin/plugins.sh /plugins.txt
+ 
+  Note: Plugins already installed are skipped
+ 
+"
+	exit 1
+else
+	JENKINS_INPUT_JOB_LIST=$1
+	if [ ! -f $JENKINS_INPUT_JOB_LIST ]
+	then
+		echo "ERROR File not found: $JENKINS_INPUT_JOB_LIST"
+		exit 1
+	fi
+fi
+
+# the war includes a # of plugins, to make the build efficient filter out 
+# the plugins so we dont install 2x - there about 17!
+if [ -d $JENKINS_HOME ]
+then
+	TEMP_ALREADY_INSTALLED=$JENKINS_HOME/preinstalled.plugins.$$.txt
+else
+	echo "ERROR $JENKINS_HOME not found"
+	exit 1
+fi
+
+JENKINS_PLUGINS_DIR=/var/jenkins_home/plugins
+if [ -d $JENKINS_PLUGINS_DIR ]
+then
+	echo "Analyzing: $JENKINS_PLUGINS_DIR"
+	for i in `ls -pd1 $JENKINS_PLUGINS_DIR/*|egrep '\/$'`
+	do
+		JENKINS_PLUGIN=`basename $i`
+		JENKINS_PLUGIN_VER=`egrep -i Plugin-Version "$i/META-INF/MANIFEST.MF"|cut -d\: -f2|sed 's/ //'`
+		echo "$JENKINS_PLUGIN:$JENKINS_PLUGIN_VER"
+	done > $TEMP_ALREADY_INSTALLED
+else
+	JENKINS_WAR=/usr/share/jenkins/jenkins.war
+	if [ -f $JENKINS_WAR ]
+	then
+		echo "Analyzing war: $JENKINS_WAR"
+		TEMP_PLUGIN_DIR=/tmp/plugintemp.$$
+		for i in `jar tf $JENKINS_WAR|egrep 'plugins'|egrep -v '\/$'|sort`
+		do 
+			rm -fr $TEMP_PLUGIN_DIR
+			mkdir -p $TEMP_PLUGIN_DIR
+			PLUGIN=`basename $i|cut -f1 -d'.'`
+			(cd $TEMP_PLUGIN_DIR;jar xf $JENKINS_WAR "$i";jar xvf $TEMP_PLUGIN_DIR/$i META-INF/MANIFEST.MF >/dev/null 2>&1)
+			VER=`egrep -i Plugin-Version "$TEMP_PLUGIN_DIR/META-INF/MANIFEST.MF"|cut -d\: -f2|sed 's/ //'`
+			echo "$PLUGIN:$VER"
+		done > $TEMP_ALREADY_INSTALLED
+		rm -fr $TEMP_PLUGIN_DIR
+	else
+		rm -f $TEMP_ALREADY_INSTALLED	
+		echo "ERROR file not found: $JENKINS_WAR"
+		exit 1
+	fi
+fi
+
 REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
-
+COUNT_PLUGINS_INSTALLED=0
 while read spec || [ -n "$spec" ]; do
+
     plugin=(${spec//:/ });
     [[ ${plugin[0]} =~ ^# ]] && continue
     [[ ${plugin[0]} =~ ^\s*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
-    echo "Downloading ${plugin[0]}:${plugin[1]}"
 
     if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
-    curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
-    unzip -qqt $REF/${plugin[0]}.jpi
-done  < $1
+
+    if ! grep -q "${plugin[0]}:${plugin[1]}" $TEMP_ALREADY_INSTALLED 
+    then
+    	echo "Downloading ${plugin[0]}:${plugin[1]}"
+        curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
+        unzip -qqt $REF/${plugin[0]}.jpi
+	COUNT_PLUGINS_INSTALLED=`expr $COUNT_PLUGINS_INSTALLED + 1`
+    else
+    	echo "  ... skipping already installed:  ${plugin[0]}:${plugin[1]}"
+    fi
+done  < $JENKINS_INPUT_JOB_LIST
+
+echo "---------------------------------------------------"
+if [ $COUNT_PLUGINS_INSTALLED -gt 0 ]
+then
+	echo "INFO: Successfully installed $COUNT_PLUGINS_INSTALLED plugins."
+
+	if [ -d $JENKINS_PLUGINS_DIR ]
+	then
+		echo "INFO: Please restart the container for changes to take effect!"
+	fi
+else
+	echo "INFO: No changes, all plugins previously installed."
+
+fi
+echo "---------------------------------------------------"
+
+#cleanup
+rm $TEMP_ALREADY_INSTALLED
+exit 0


### PR DESCRIPTION
I updated the script to be based on jenkins.war.  I crated a local image, then created a test Dockerfile based on the image.

Please review the approach, sample output from the test run:

Removing intermediate container 7f545b034f1a
Step 7 : RUN /usr/local/bin/plugins.sh /usr/share/jenkins/ref/plugins.txt
 ---> Running in f1606faa6f4a
  ... skipping already installed:  ant:1.2
  ... skipping already installed:  antisamy-markup-formatter:1.1
  ... skipping already installed:  credentials:1.18
Downloading cucumber-testresult-plugin:0.8.2
  ... skipping already installed:  cvs:2.11
  ... skipping already installed:  external-monitor-job:1.4
Downloading git:2.4.0
Downloading git-client:1.19.0
  ... skipping already installed:  javadoc:1.1
  ... skipping already installed:  junit:1.2-beta-4
  ... skipping already installed:  ldap:1.11
  ... skipping already installed:  mailer:1.11
  ... skipping already installed:  matrix-auth:1.1
  ... skipping already installed:  matrix-project:1.4.1
  ... skipping already installed:  maven-plugin:2.7.1
  ... skipping already installed:  pam-auth:1.1
Downloading scm-api:1.0
  ... skipping already installed:  script-security:1.13
  ... skipping already installed:  ssh-credentials:1.10
  ... skipping already installed:  ssh-slaves:1.9
  ... skipping already installed:  subversion:1.54
  ... skipping already installed:  translation:1.10
  ... skipping already installed:  windows-slaves:1.0
 ---> 8da9a950147d
Removing intermediate container f1606faa6f4a
Step 8 : ADD jobs /var/jenkins_home/jobs