### PR TITLE
Make jenkins version configurable via build-arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ RUN curl -fL https://github.com/krallin/tini/releases/download/v0.5.0/tini-stati
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 
-ENV JENKINS_VERSION 1.642.2
-ENV JENKINS_SHA e72e06e64d23eefb13090459f517b0697aad7be0
+ARG JENKINS_VERSION
+ENV JENKINS_VERSION ${JENKINS_VERSION:-1.642.2}
+ARG JENKINS_SHA
+ENV JENKINS_SHA ${JENKINS_SHA:-e72e06e64d23eefb13090459f517b0697aad7be0}
 
 
 # could use ADD but this one does not check Last-Modified header 


### PR DESCRIPTION
This PR allow defining the Jenkins version to be built via build-args. If no version is provided it defaults to the current LTS version.

*NOTE*: For the changes in this PR be effective Docker >= 1.9 is required.