### PR TITLE
Use official OpenJDK 8 as base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM frolvlad/alpine-oraclejdk8:cleaned
+FROM java:openjdk-8-jdk-alpine
 
 RUN apk --update add --no-cache curl zip bash && \
     rm -rf /var/cache/apk/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
-FROM java:8-jdk
+FROM frolvlad/alpine-oraclejdk8:cleaned
 
-RUN apt-get update && apt-get install -y wget git curl zip && rm -rf /var/lib/apt/lists/*
+RUN apk --update add --no-cache curl zip bash && \
+    rm -rf /var/cache/apk/*
 
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_SLAVE_AGENT_PORT 50000
 
 ARG user=jenkins
-ARG group=jenkins
 ARG uid=1000
-ARG gid=1000
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container, 
 # ensure you use the same uid
-RUN groupadd -g ${gid} ${group} \
-    && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+RUN adduser -h "$JENKINS_HOME" -u ${uid} -s /bin/bash -D ${user}
 
 # Jenkins home directory is a volume, so configuration and build history 
 # can be persisted and survive image upgrades
@@ -29,7 +27,7 @@ ENV TINI_SHA 066ad710107dc7ee05d3aa6e4974f01dc98f3888
 
 # Use tini as subreaper in Docker container to adopt zombie processes 
 RUN curl -fsSL https://github.com/krallin/tini/releases/download/v0.5.0/tini-static -o /bin/tini && chmod +x /bin/tini \
-  && echo "$TINI_SHA /bin/tini" | sha1sum -c -
+  && echo "$TINI_SHA  /bin/tini" | sha1sum -wc -
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 
@@ -42,7 +40,7 @@ ENV JENKINS_SHA ${JENKINS_SHA:-3cb37dde64b1aca9952c7a4f98f3c0b71d02cd8b}
 # could use ADD but this one does not check Last-Modified header 
 # see https://github.com/docker/docker/issues/8331
 RUN curl -fsSL http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war -o /usr/share/jenkins/jenkins.war \
-  && echo "$JENKINS_SHA /usr/share/jenkins/jenkins.war" | sha1sum -c -
+  && echo "$JENKINS_SHA  /usr/share/jenkins/jenkins.war" | sha1sum -wc -
 
 ENV JENKINS_UC https://updates.jenkins-ci.org
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref


### PR DESCRIPTION
This is based on OpenJDK 8.
The resulting image size is 111.9 MB

To pull it via docker:
docker pull quay.io/elifarley/alpine-jenkins:alpine-openjdk8

Or you can visit https://quay.io/repository/elifarley/alpine-jenkins?tab=tags

This PR should be merged to an alternate branch like **alpine-openjdk-8**.

Fixes #239
