### PR TITLE
Add package 'ttf-dejavu' to avoid NPE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM java:openjdk-8-jdk-alpine
 
-RUN apk --update add --no-cache curl zip bash && \
+RUN apk --update add --no-cache curl zip bash ttf-dejavu && \
     rm -rf /var/cache/apk/*
 
 ENV JENKINS_HOME /var/jenkins_home


### PR DESCRIPTION
java.lang.NullPointerException
	at sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
	at sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:219)
	at sun.awt.FontConfiguration.init(FontConfiguration.java:107)
	at sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:774)
	at sun.font.SunFontManager$2.run(SunFontManager.java:431)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.font.SunFontManager.<init>(SunFontManager.java:376)
	at sun.awt.FcFontManager.<init>(FcFontManager.java:35)
	at sun.awt.X11FontManager.<init>(X11FontManager.java:57)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at java.lang.Class.newInstance(Class.java:442)
	at sun.font.FontManagerFactory$1.run(FontManagerFactory.java:83)
	at java.security.AccessController.doPrivileged(Native Method)
	at sun.font.FontManagerFactory.getInstance(FontManagerFactory.java:74)
	at java.awt.Font.getFont2D(Font.java:491)
	at java.awt.Font.getFamily(Font.java:1220)
	at java.awt.Font.getFamily_NoClientCode(Font.java:1194)
	at java.awt.Font.getFamily(Font.java:1186)
	at java.awt.Font.toString(Font.java:1683)
	at hudson.util.ChartUtil.<clinit>(ChartUtil.java:255)
	at hudson.WebAppMain.contextInitialized(WebAppMain.java:184)