### PR TITLE
Make options for curl from plugins.sh configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,4 +61,6 @@ COPY jenkins.sh /usr/local/bin/jenkins.sh
 ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle
+ARG CURL_OPTS
+ARG CURL_ENABLE_OUTPUT
 COPY plugins.sh /usr/local/bin/plugins.sh

--- a/plugins.sh
+++ b/plugins.sh
@@ -20,9 +20,13 @@ while read spec || [ -n "$spec" ]; do
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
     echo "Downloading ${plugin[0]}:${plugin[1]}"
 
+    if [ -z "${CURL_ENABLE_OUTPUT}" ]; then
+        CURL_OPTS="${CURL_OPTS} -s"
+    fi
+
     if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
-    curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
+    curl -SL "${CURL_OPTS}" -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
     unzip -qqt $REF/${plugin[0]}.jpi
 done  < $1


### PR DESCRIPTION
The plugins.sh script works great except when it doesn't
(and you have build failures that require debugging networking)

This commit adds two build time environment variables:
  * CURL_OPTS - allows you to set arbitary options to curl (like
    if you need to add retries and timeouts)
  * CURL_ENABLE_OUTPUT - removes -s flag so that you can view
   download stats at build time. This is added seperately from
   CURL_OPTS to retain backwards compatibility.