### PR TITLE
Update the Dockerfile: vim added

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM java:8-jdk
 
 RUN apt-get update && apt-get install -y git curl zip && rm -rf /var/lib/apt/lists/*
-
+RUN apt-get update -y
+RUN apt-get install -y vim
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_SLAVE_AGENT_PORT 50000
 


### PR DESCRIPTION
**Why this pull request?**

`Vim` is not installed by default, and we need vim/nano/vi to read the secret password in the container to start Jenkins. 

**How to fix it?** 

To fix that, we just need to add the two following lines:

```Bash
RUN apt-get update -y
RUN apt-get install -y vim
```