### PR TITLE
split out the JENKINS_HOME directory from the jenkins user directory.…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,9 @@ ARG gid=1000
 # If you bind mount a volume from the host or a data container, 
 # ensure you use the same uid
 RUN groupadd -g ${gid} ${group} \
-    && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+    && useradd -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+
+RUN mkdir $JENKINS_HOME && chown -R ${user} "$JENKINS_HOME"
 
 # Jenkins home directory is a volume, so configuration and build history 
 # can be persisted and survive image upgrades
@@ -45,7 +47,7 @@ RUN curl -fsSL http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war
   && echo "$JENKINS_SHA  /usr/share/jenkins/jenkins.war" | sha1sum -c -
 
 ENV JENKINS_UC https://updates.jenkins.io
-RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref
+RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref 
 
 # for main web interface:
 EXPOSE 8080

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -24,6 +24,8 @@ copy_reference_file() {
 }
 : ${JENKINS_HOME:="/var/jenkins_home"}
 export -f copy_reference_file
+ls -al ${JENKINS_HOME}
+ls -al ~/
 touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?" && exit 1)
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;


### PR DESCRIPTION
… This is to allow consumers of the docker image to use it as a base that can have other tools installed that make use of the home directory

Following on from the issue that I raised: https://github.com/jenkinsci/docker/issues/271 I have made a change that I think successfully splits out the configuration directory (JENKINS_HOME) from the jenkins users' home directory.

in order to try this out, build the jenkins image like this from the root of the repo:

docker build -t jenkins.edsykes.com .

then run a build using the jenkins image as a base using this as the Dockerfile:

FROM jenkins.edsykes.com
USER jenkins
RUN wget -qO- https://raw.githubusercontent.com/creationix/nvm/v0.31.1/install.sh | bash

Now you have an image that has nvm installed in the image, which can then be called during a jenkins job by using 'nvm' at the command line.
# 

Note this didn't work before, the installation of nvm would be lost, since it ends up in ~/.nvm which was effectively mapped to the JENKINS_HOME on a volume. 
