### PR TITLE
adding retry to plugins.sh for curl

### DIFF
--- a/plugins.sh
+++ b/plugins.sh
@@ -23,6 +23,6 @@ while read spec || [ -n "$spec" ]; do
     if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
-    curl -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
+    curl --retry 3 --retry-delay 5 -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
     unzip -qqt $REF/${plugin[0]}.jpi
 done  < $1


### PR DESCRIPTION
There are occasions when pulling plugins from Jenkins results in a 404. I've added a curl retry and curl retry delay to re-attempt downloading the plugins so builds do not automatically fail on a temporary issue.