### PR TITLE
Miscellaneous install-plugins.sh fixes

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,5 +1,15 @@
 #! /bin/bash
 
+# Resolve dependencies and download plugins given on the command line
+#
+# FROM jenkins
+# RUN install-plugins.sh docker-slaves github-branch-source
+
+set -e
+
+REF=/usr/share/jenkins/ref/plugins
+mkdir -p "$REF"
+
 function download() {
 	local plugin=$1; shift
 
@@ -61,6 +71,8 @@ function resolveDependencies() {
 	done
 	touch ${plugin}.resolved
 }
+
+cd "$REF"
 
 for plugin in "$@"
 do

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -25,7 +25,7 @@ function download() {
 	fi	
 
 	if [[ ! -f ${plugin}.resolved ]]; then
-		resolveDependencies $1
+		resolveDependencies $plugin
 	fi
 }
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -11,19 +11,19 @@ REF=/usr/share/jenkins/ref/plugins
 mkdir -p "$REF"
 
 function download() {
-	local plugin=$1; shift
+	local plugin="$1"; shift
 
-	if [[ ! -f ${plugin}.hpi ]]; then
+	if [[ ! -f "${plugin}.hpi" ]]; then
 
-		url=${JENKINS_UC}/latest/${plugin}.hpi
+		url="${JENKINS_UC}/latest/${plugin}.hpi"
 		echo "download plugin : $plugin from $url"
 
-		curl -s -f -L $url -o ${plugin}.hpi
+		curl -s -f -L "$url" -o "${plugin}.hpi"
 		if [[ $? -ne 0 ]]
 		then
 			# some plugin don't follow the rules about artifact ID
 			# typically: docker-plugin
-			curl -s -f -L $url -o ${plugin}-plugin.hpi
+			curl -s -f -L "$url" -o "${plugin}-plugin.hpi"
 			if [[ $? -ne 0 ]]
 			then
 				>&2 echo "failed to download plugin ${plugin}"
@@ -35,12 +35,12 @@ function download() {
 	fi	
 
 	if [[ ! -f ${plugin}.resolved ]]; then
-		resolveDependencies $plugin
+		resolveDependencies "$plugin"
 	fi
 }
 
 function resolveDependencies() {	
-	local plugin=$1; shift
+	local plugin="$1"; shift
 
 	dependencies=`jrunscript -e '\
 	java.lang.System.out.println(\
@@ -66,17 +66,17 @@ function resolveDependencies() {
 		then	
 			echo "skipping optional dependency $plugin"
 		else
-    		download $plugin
+			download "$plugin"
 		fi
 	done
-	touch ${plugin}.resolved
+	touch "${plugin}.resolved"
 }
 
 cd "$REF"
 
 for plugin in "$@"
 do
-    download $plugin
+    download "$plugin"
 done
 
 # cleanup 'resolved' flag files


### PR DESCRIPTION
### Summary
Includes fixes that ensure that the script is working in the correct directory (I just copied this over from `plugins.sh`) and that dependencies actually get resolved.

### Output with current `master`
    Building jenkins
    Step 1 : FROM jenkinsci/jenkins:2.7
     ---> 2a700527ed23
    Step 2 : RUN install-plugins.sh ldap
     ---> Running in 95241665f5ee
    rm: cannot remove ‘*.resolved’: No such file or directory
    ERROR: Service 'jenkins' failed to build: The command '/bin/sh -c install-plugins.sh ldap' returned a non-zero code: 1

Even with setting the `WORKDIR` (to avoid permission errors in curl) this fails in the same manner, as the function is called with an empty `$1` argument.

### Expected result
I would expect this to work like documented and install the plugins.

### docker version
    Client:
     Version:      1.11.1
     API version:  1.23
     Go version:   go1.6.2
     Git commit:   5604cbe
     Built:        Mon May  2 00:06:51 2016
     OS/Arch:      linux/amd64
    
    Server:
     Version:      1.11.1
     API version:  1.23
     Go version:   go1.6.2
     Git commit:   5604cbe
     Built:        Mon May  2 00:06:51 2016
     OS/Arch:      linux/amd64

*PS:* I just noticed, I haven't tested the actual installation yet.