### PR TITLE
Add install-plugins.sh for Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,3 +62,4 @@ ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle
 COPY plugins.sh /usr/local/bin/plugins.sh
+COPY install-plugins.sh /usr/local/bin/install-plugins.sh

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,0 +1,84 @@
+#! /bin/bash
+
+# Resolve dependencies and download plugins given on the command line
+#
+# FROM jenkins
+# RUN install-plugins.sh docker-slaves github-branch-source
+
+set -e
+
+REF=${REF:-/usr/share/jenkins/ref/plugins}
+mkdir -p "$REF"
+
+function download() {
+	local plugin="$1"; shift
+
+	if [[ ! -f "${plugin}.hpi" ]]; then
+
+		local url="${JENKINS_UC}/latest/${plugin}.hpi"
+		echo "download plugin : $plugin from $url"
+
+		if ! curl -s -f -L "$url" -o "${plugin}.hpi" 
+		then
+			# some plugin don't follow the rules about artifact ID
+			# typically: docker-plugin
+			plugin=${plugin}-plugin
+
+			local url="${JENKINS_UC}/latest/${plugin}.hpi"
+			echo "download plugin : $plugin from $url"
+			if ! curl -s -f -L "${url}" -o "${plugin}.hpi"
+			then
+				>&2 echo "failed to download plugin ${plugin}"
+				exit -1
+			fi
+		fi
+	else
+		echo "$plugin is already downloaded."
+	fi	
+
+	if [[ ! -f ${plugin}.resolved ]]; then
+		resolveDependencies "$plugin"
+	fi
+}
+
+function resolveDependencies() {	
+	local plugin="$1"; shift
+
+	local dependencies=`jrunscript -e '\
+	java.lang.System.out.println(\
+		new java.util.jar.JarFile("'${plugin}.hpi'")\
+			.getManifest()\
+			.getMainAttributes()\
+			.getValue("Plugin-Dependencies")\
+	);'`
+
+	if [[ "$dependencies" == "null" ]]; then
+		echo " > plugin has no dependencies"
+		return
+	fi
+
+	echo " > depends on  ${dependencies}"
+
+	IFS=',' read -a array <<< "${dependencies}"
+    for d in "${array[@]}"
+	do
+		local p=$(echo $d | cut -d':' -f1 -)
+		if [[ $d == *"resolution:=optional"* ]] 
+		then	
+			echo "skipping optional dependency $p"
+		else
+			download "$p"
+		fi
+	done
+	touch "${plugin}.resolved"
+}
+
+cd "$REF"
+
+for plugin in "$@"
+do
+    download "$plugin"
+done
+
+# cleanup 'resolved' flag files
+rm *.resolved


### PR DESCRIPTION
When trying to build the [Jenkins BlueOcean Docker image](https://github.com/jenkinsci/blueocean-plugin/blob/master/Dockerfile) with the Alpine-based Jenkins base-image instead, I noticed it is missing the `install-plugins.sh` script.

This adds back that feature!

And Alpine-based BlueOcean builds work for me now, with these changes in place.