### PR TITLE
Multiple enhancement in `Dockerfile` and `jenkins.sh` (jessie)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,41 @@
 FROM java:8-jdk
 
-RUN apt-get update && apt-get install -y git curl zip && rm -rf /var/lib/apt/lists/*
-
-ENV JENKINS_HOME /var/jenkins_home
-ENV JENKINS_REF /usr/share/jenkins/ref
+ENV JENKINS_UC "https://updates.jenkins.io"
+ENV JENKINS_HOME "/var/jenkins_home"
+ENV JENKINS_REF "/usr/share/jenkins/ref"
 ENV JENKINS_SLAVE_AGENT_PORT 50000
+ENV COPY_REFERENCE_FILE_LOG "$JENKINS_HOME/copy_reference_file.log"
+
+ARG JENKINS_VERSION
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.8}
+ARG JENKINS_SHA
+ENV JENKINS_SHA ${JENKINS_SHA:-fda2f13e16b81e1d295696eaf838d60f54f9395c}
+ARG TINI_SHA
+ENV TINI_SHA ${TINI_SHA:-fa23d1e20732501c3bb8eeeca423c89ac80ed452}
 
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
 
-# Jenkins is run with user `jenkins`, uid = 1000
-# If you bind mount a volume from the host or a data container, 
-# ensure you use the same uid
+# $JENKINS_HOME is a volume, so configuration and build history 
+# can be persisted and survive image upgrades
+VOLUME $JENKINS_HOME
+
+RUN apt-get update \
+    && apt-get install -y git curl zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Jenkins is started by $user:$group with $uid:$gid which defaults 
+# respectively to 'jenkins:jenkins' and '1000:1000' (see above)
+# If you bind mount a volume from the host or a data container, ensure 
+# you use the same uid
 RUN groupadd -g ${gid} ${group} \
     && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
 
-# Jenkins home directory is a volume, so configuration and build history 
-# can be persisted and survive image upgrades
-VOLUME /var/jenkins_home
-
-# `/usr/share/jenkins/ref/` contains all reference configuration we want 
+# $JENKINS_REF contains all reference configuration we want 
 # to set on a fresh new installation. Use it to bundle additional plugins 
-# or config file with your custom jenkins Docker image.
+# or config file with your custom derived jenkins Dockerfile
 RUN mkdir -p ${JENKINS_REF}/init.groovy.d
 COPY init.groovy ${JENKINS_REF}/init.groovy.d/tcp-slave-agent-port.groovy
 
@@ -39,14 +51,12 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-1.651.3}
 ARG JENKINS_SHA
 ENV JENKINS_SHA ${JENKINS_SHA:-564e49fbd180d077a22a8c7bb5b8d4d58d2a18ce}
 
-
 # could use ADD but this one does not check Last-Modified header 
 # see https://github.com/docker/docker/issues/8331
 RUN curl -fsSL http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war -o /usr/share/jenkins/jenkins.war \
-  && echo "$JENKINS_SHA  /usr/share/jenkins/jenkins.war" | sha1sum -c -
+    && echo "$JENKINS_SHA  /usr/share/jenkins/jenkins.war" | sha1sum -c -
 
-ENV JENKINS_UC https://updates.jenkins.io
-RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref
+RUN chown -R ${user} "$JENKINS_HOME" "$JENKINS_REF"
 
 # for main web interface:
 EXPOSE 8080
@@ -54,13 +64,11 @@ EXPOSE 8080
 # will be used by attached slave agents:
 EXPOSE ${JENKINS_SLAVE_AGENT_PORT}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
-
-COPY jenkins.sh /usr/local/bin/jenkins.sh
-ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle
 COPY plugins.sh /usr/local/bin/plugins.sh
 COPY install-plugins.sh /usr/local/bin/install-plugins.sh
+
+COPY jenkins.sh /usr/local/bin/jenkins.sh
+ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM java:8-jdk
 RUN apt-get update && apt-get install -y git curl zip && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_HOME /var/jenkins_home
+ENV JENKINS_REF /usr/share/jenkins/ref
 ENV JENKINS_SLAVE_AGENT_PORT 50000
 
 ARG user=jenkins
@@ -23,7 +24,8 @@ VOLUME /var/jenkins_home
 # `/usr/share/jenkins/ref/` contains all reference configuration we want 
 # to set on a fresh new installation. Use it to bundle additional plugins 
 # or config file with your custom jenkins Docker image.
-RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
+RUN mkdir -p ${JENKINS_REF}/init.groovy.d
+COPY init.groovy ${JENKINS_REF}/init.groovy.d/tcp-slave-agent-port.groovy
 
 ENV TINI_VERSION 0.9.0
 ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
@@ -31,8 +33,6 @@ ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
 # Use tini as subreaper in Docker container to adopt zombie processes 
 RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && chmod +x /bin/tini \
   && echo "$TINI_SHA  /bin/tini" | sha1sum -c -
-
-COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 
 ARG JENKINS_VERSION
 ENV JENKINS_VERSION ${JENKINS_VERSION:-1.651.3}

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,17 +43,13 @@ ENV TINI_VERSION 0.9.0
 ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
 
 # Use tini as subreaper in Docker container to adopt zombie processes 
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && chmod +x /bin/tini \
-  && echo "$TINI_SHA  /bin/tini" | sha1sum -c -
-
-ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-1.651.3}
-ARG JENKINS_SHA
-ENV JENKINS_SHA ${JENKINS_SHA:-564e49fbd180d077a22a8c7bb5b8d4d58d2a18ce}
+RUN curl -fsSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static" -o /bin/tini \
+    && chmod +x /bin/tini \
+    && echo "$TINI_SHA  /bin/tini" | sha1sum -c -
 
 # could use ADD but this one does not check Last-Modified header 
 # see https://github.com/docker/docker/issues/8331
-RUN curl -fsSL http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war -o /usr/share/jenkins/jenkins.war \
+RUN curl -fsSL "http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war" -o /usr/share/jenkins/jenkins.war \
     && echo "$JENKINS_SHA  /usr/share/jenkins/jenkins.war" | sha1sum -c -
 
 RUN chown -R ${user} "$JENKINS_HOME" "$JENKINS_REF"
@@ -72,3 +68,4 @@ COPY install-plugins.sh /usr/local/bin/install-plugins.sh
 
 COPY jenkins.sh /usr/local/bin/jenkins.sh
 ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,12 +55,11 @@ RUN curl -fsSL "http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-wa
 # fix perms
 RUN chown -R ${user}:${group} "$JENKINS_HOME" "$JENKINS_REF"
 
-# for main web interface:
+# expose webui and slave ports
 EXPOSE 8080
-
-# will be used by attached slave agents:
 EXPOSE ${JENKINS_SLAVE_AGENT_PORT}
 
+# switch to non-root
 USER ${user}
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref
 EXPOSE 8080
 
 # will be used by attached slave agents:
-EXPOSE 50000
+EXPOSE ${JENKINS_SLAVE_AGENT_PORT}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,10 @@ ENV JENKINS_REF "/usr/share/jenkins/ref"
 ENV JENKINS_SLAVE_AGENT_PORT 50000
 ENV COPY_REFERENCE_FILE_LOG "$JENKINS_HOME/copy_reference_file.log"
 
-ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.8}
-ARG JENKINS_SHA
-ENV JENKINS_SHA ${JENKINS_SHA:-fda2f13e16b81e1d295696eaf838d60f54f9395c}
-ARG TINI_SHA
-ENV TINI_SHA ${TINI_SHA:-fa23d1e20732501c3bb8eeeca423c89ac80ed452}
+ARG JENKINS_VERSION=1.651.3
+ARG JENKINS_SHA=564e49fbd180d077a22a8c7bb5b8d4d58d2a18ce
+ARG TINI_VERSION=0.9.0
+ARG TINI_SHA=fa23d1e20732501c3bb8eeeca423c89ac80ed452
 
 ARG user=jenkins
 ARG group=jenkins
@@ -33,9 +31,6 @@ RUN groupadd -g ${gid} ${group} \
 # to set on a fresh new installation. Use it to bundle additional plugins 
 # or config file with your custom derived jenkins Dockerfile
 RUN mkdir -p ${JENKINS_REF}
-
-ENV TINI_VERSION 0.9.0
-ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
 
 # Use tini as subreaper in Docker container to adopt zombie processes 
 RUN curl -fsSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static" -o /bin/tini \

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,8 @@ RUN curl -fsSL "https://github.com/krallin/tini/releases/download/v${TINI_VERSIO
 RUN curl -fsSL "http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war" -o /usr/share/jenkins/jenkins.war \
     && echo "$JENKINS_SHA  /usr/share/jenkins/jenkins.war" | sha1sum -c -
 
-RUN chown -R ${user} "$JENKINS_HOME" "$JENKINS_REF"
+# fix perms
+RUN chown -R ${user}:${group} "$JENKINS_HOME" "$JENKINS_REF"
 
 # for main web interface:
 EXPOSE 8080

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,7 @@ RUN groupadd -g ${gid} ${group} \
 # $JENKINS_REF contains all reference configuration we want 
 # to set on a fresh new installation. Use it to bundle additional plugins 
 # or config file with your custom derived jenkins Dockerfile
-RUN mkdir -p ${JENKINS_REF}/init.groovy.d
-COPY init.groovy ${JENKINS_REF}/init.groovy.d/tcp-slave-agent-port.groovy
+RUN mkdir -p ${JENKINS_REF}
 
 ENV TINI_VERSION 0.9.0
 ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
@@ -62,6 +61,12 @@ EXPOSE ${JENKINS_SLAVE_AGENT_PORT}
 # switch to non-root
 USER ${user}
 
+# Minimal configuration setup:
+# Groovy script to set the slave agent port to $JENKINS_SLAVE_AGENT_PORT
+RUN mkdir -p ${JENKINS_REF}/init.groovy.d
+COPY init.groovy ${JENKINS_REF}/init.groovy.d/tcp-slave-agent-port.groovy
+
+# Include script helpers to install plugins:
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle
 COPY plugins.sh /usr/local/bin/plugins.sh
 COPY install-plugins.sh /usr/local/bin/install-plugins.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,6 @@ ARG group=jenkins
 ARG uid=1000
 ARG gid=1000
 
-# $JENKINS_HOME is a volume, so configuration and build history 
-# can be persisted and survive image upgrades
-VOLUME $JENKINS_HOME
-
 RUN apt-get update \
     && apt-get install -y git curl zip \
     && rm -rf /var/lib/apt/lists/*
@@ -53,6 +49,10 @@ RUN curl -fsSL "http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-wa
 
 # fix perms
 RUN chown -R ${user}:${group} "$JENKINS_HOME" "$JENKINS_REF"
+
+# $JENKINS_HOME is a volume, so configuration and build history 
+# can be persisted and survive image upgrades
+VOLUME $JENKINS_HOME
 
 # expose webui and slave ports
 EXPOSE 8080

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,31 +2,40 @@
 
 set -e
 
-# Copy files from /usr/share/jenkins/ref into $JENKINS_HOME
+# Copy files from $JENKINS_REF into $JENKINS_HOME
 # So the initial JENKINS-HOME is set with expected content.
 # Don't override, as this is just a reference setup, and use from UI
 # can then change this, upgrade plugins, etc.
 copy_reference_file() {
-	f="${1%/}"
-	b="${f%.override}"
-	echo "$f" >> "$COPY_REFERENCE_FILE_LOG"
-	rel="${b:23}"
-	dir=$(dirname "${b}")
-	echo " $f -> $rel" >> "$COPY_REFERENCE_FILE_LOG"
-	if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]
-	then
-		echo "copy $rel to JENKINS_HOME" >> "$COPY_REFERENCE_FILE_LOG"
-		mkdir -p "$JENKINS_HOME/${dir:23}"
-		cp -r "${f}" "$JENKINS_HOME/${rel}";
-		# pin plugins on initial copy
-		[[ ${rel} == plugins/*.jpi ]] && touch "$JENKINS_HOME/${rel}.pinned"
-	fi;
+  {
+    src="${1%.override}"
+    rel="${src#"$JENKINS_REF/"}"
+    dst="$JENKINS_HOME/${rel}"
+
+    if [[ ! -e "${dst}" || "$1" != "$src" ]]
+    then
+      echo -n "copy: "
+      mkdir -p "$(dirname $dst)"
+      cp -rv "${src}" "${dst}"
+
+      # pin plugins on initial copy
+      [[ "${rel}" == plugins/*.jpi ]] && touch "${dst}.pinned"
+    else
+      echo "skip: ‘${src}’"
+    fi;
+    echo
+  } >> "$COPY_REFERENCE_FILE_LOG"
 }
-: ${JENKINS_HOME:="/var/jenkins_home"}
-export -f copy_reference_file
+
+# Init
+: ${JENKINS_REF:="/usr/share/jenkins/ref"} ${JENKINS_HOME:="/var/jenkins_home"}
+export JENKINS_REF="${JENKINS_REF%/}" JENKINS_HOME="${JENKINS_HOME%/}"
+export -f copy_reference_file 
 touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?" && exit 1)
+
+# Copy
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
-find /usr/share/jenkins/ref/ -type f -exec bash -c "copy_reference_file '{}'" \;
+find "$JENKINS_REF" -type f -exec bash -c "copy_reference_file '{}'" \;
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then


### PR DESCRIPTION
Improvements:
- [x] Improve code readability in `copy_reference_file` function
- [x] Improve code genericity in `copy_reference_file` function (dynamically extract string subsets)
- [x] Improve log output format : oneliner status + use `copy:` and `skip:` prefixes
- [x] Improve Dockerfile readability
- [x] Various minor Dockerfiles fixes (use group in chmod, protect vars with double quotes,...)

Upgrades:
- [x] Jenkins 2.8
- [x] tini 0.9.0
