### PR TITLE
Do not error if there are no 'resolved' flag files

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -81,4 +81,4 @@ do
 done
 
 # cleanup 'resolved' flag files
-rm *.resolved
+rm -f *.resolved


### PR DESCRIPTION
Plugins with no dependencies (like the `ansicolor` plugin) will not have created a `resolved` flag. 

`rm` will throw an error if the file does not exist. Set a `-f` flag to stop this.