### PR TITLE
Update download script to add parallelism, correct locking, and specific version support.

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -62,7 +62,7 @@ function resolveDependencies() {
 	dependencies="$(unzip -p "$hpi" META-INF/MANIFEST.MF | sed -e 's###g' | tr '\n' '|' | sed -e 's#| ##g' | tr '|' '\n' | grep "^Plugin-Dependencies: " | sed -e 's#^Plugin-Dependencies: ##')"
 
 	if [[ ! $dependencies ]]; then
-		echo " > '$plugin' has no dependencies"
+		echo " > $plugin has no dependencies"
 		return
 	fi
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -19,7 +19,7 @@ function getHpiFilename() {
 function download() {
 	local plugin originalPlugin version lock ignoreLockFile
 	plugin="$1"
-	version="$2"
+	version="${2:-latest}"
 	ignoreLockFile="$3"
 	lock="$(getLockFile "$plugin")"
 
@@ -57,11 +57,7 @@ function doDownload() {
 		return 0
 	fi
 
-	if [[ $version ]]; then
-		url="$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi"
-	else
-		url="$JENKINS_UC/latest/${plugin}.hpi"
-	fi
+	url="$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi"
 
 	echo "Downloading plugin: $plugin from $url"
 	curl -s -f -L "$url" -o "$hpi"

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -42,6 +42,11 @@ function doDownload() {
 	version="$2"
 	hpi="$REF_DIR/${plugin}.hpi"
 
+	if [[ -f $hpi ]]; then
+		echo "Using provided plugin: $plugin"
+		return 0
+	fi
+
 	if [[ $version ]]; then
 		url="$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi"
 	else

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,84 +1,117 @@
-#! /bin/bash
+#!/bin/bash
 
 # Resolve dependencies and download plugins given on the command line
 #
 # FROM jenkins
 # RUN install-plugins.sh docker-slaves github-branch-source
 
-set -e
+REF_DIR=${REF:-/usr/share/jenkins/ref/plugins}
+FAILED="$REF_DIR/failed-plugins.txt"
 
-REF=${REF:-/usr/share/jenkins/ref/plugins}
-mkdir -p "$REF"
+function getLockFile() {
+	echo "$REF_DIR/${1}.lock"
+}
 
 function download() {
-	local plugin="$1"; shift
+	local plugin originalPlugin version lock ignoreLockFile
+	plugin="$1"
+	version="$2"
+	ignoreLockFile="$3"
+	lock="$(getLockFile "$plugin")"
 
-	if [[ ! -f "${plugin}.hpi" ]]; then
-
-		local url="${JENKINS_UC}/latest/${plugin}.hpi"
-		echo "download plugin : $plugin from $url"
-
-		if ! curl -s -f -L "$url" -o "${plugin}.hpi" 
-		then
+	if [[ $ignoreLockFile ]] || mkdir "$lock" &>/dev/null; then
+		if ! doDownload "$plugin" "$version"; then
 			# some plugin don't follow the rules about artifact ID
 			# typically: docker-plugin
-			plugin=${plugin}-plugin
-
-			local url="${JENKINS_UC}/latest/${plugin}.hpi"
-			echo "download plugin : $plugin from $url"
-			if ! curl -s -f -L "${url}" -o "${plugin}.hpi"
-			then
-				>&2 echo "failed to download plugin ${plugin}"
-				exit -1
+			originalPlugin="$plugin"
+			plugin="${plugin}-plugin"
+			if ! doDownload "$plugin" "$version"; then
+				echo "Failed to download plugin: $originalPlugin or $plugin" >&2
+				echo "${originalPlugin}" >> "$FAILED"
+				return 1
 			fi
 		fi
-	else
-		echo "$plugin is already downloaded."
-	fi	
 
-	if [[ ! -f ${plugin}.resolved ]]; then
 		resolveDependencies "$plugin"
 	fi
 }
 
+function doDownload() {
+	local plugin version url hpi
+	plugin="$1"
+	version="$2"
+	hpi="$REF_DIR/${plugin}.hpi"
+
+	if [[ $version ]]; then
+		url="$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi"
+	else
+		url="$JENKINS_UC/latest/${plugin}.hpi"
+	fi
+
+	echo "Downloading plugin: $plugin from $url"
+	curl -s -f -L "$url" -o "$hpi"
+	return $?
+}
+
 function resolveDependencies() {	
-	local plugin="$1"; shift
+	local plugin hpi dependencies
+	plugin="$1"
+	hpi="$REF_DIR/${plugin}.hpi"
 
-	local dependencies=`jrunscript -e '\
-	java.lang.System.out.println(\
-		new java.util.jar.JarFile("'${plugin}.hpi'")\
-			.getManifest()\
-			.getMainAttributes()\
-			.getValue("Plugin-Dependencies")\
-	);'`
+	# ^M below is a control character, inserted by typing ctrl+v ctrl+m
+	dependencies="$(unzip -p "$hpi" META-INF/MANIFEST.MF | sed -e 's###g' | tr '\n' '|' | sed -e 's#| ##g' | tr '|' '\n' | grep "^Plugin-Dependencies: " | sed -e 's#^Plugin-Dependencies: ##')"
 
-	if [[ "$dependencies" == "null" ]]; then
-		echo " > plugin has no dependencies"
+	if [[ ! $dependencies ]]; then
+		echo " > '$plugin' has no dependencies"
 		return
 	fi
 
-	echo " > depends on  ${dependencies}"
+	echo " > $plugin depends on $dependencies"
 
-	IFS=',' read -a array <<< "${dependencies}"
-    for d in "${array[@]}"
+	IFS=',' read -a array <<< "$dependencies"
+
+	for d in "${array[@]}"
 	do
-		local p=$(echo $d | cut -d':' -f1 -)
-		if [[ $d == *"resolution:=optional"* ]] 
-		then	
-			echo "skipping optional dependency $p"
+		plugin="$(cut -d':' -f1 - <<< "$d")"
+		if [[ $d == *"resolution:=optional"* ]]; then	
+			echo "Skipping optional dependency $plugin"
 		else
-			download "$p"
+			download "$plugin" &
 		fi
 	done
-	touch "${plugin}.resolved"
 }
 
-cd "$REF"
+main() {
+	local plugin version
 
-for plugin in "$@"
-do
-    download "$plugin"
-done
+	mkdir -p "$REF_DIR" || exit 1
 
-# cleanup 'resolved' flag files
-rm -f *.resolved
+	# Create lockfile manually before first run to make sure any explicit version set is used.
+	echo "Creating initial locks..."
+	for plugin in "$@"; do
+		mkdir "$(getLockFile "${plugin%%@*}")"
+	done
+
+	echo -e "\nDownloading plugins..."
+	for plugin in "$@"; do
+		version=""
+
+		if [[ $plugin =~ .*@.* ]]; then
+			version="${plugin##*@}"
+			plugin="${plugin%%@*}"
+		fi
+
+		download "$plugin" "$version" "true" &
+	done				  
+	wait
+
+	if [[ -f $FAILED ]]; then
+		echo -e "\nSome plugins failed to download!\n$(<"$FAILED")" >&2
+		exit 1
+	fi
+
+	echo -e "\nCleaning up locks..."
+	rm -rv "$REF_DIR"/*.lock
+}
+
+main "$@"

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -99,6 +99,7 @@ function resolveDependencies() {
 			download "$plugin" &
 		fi
 	done
+	wait
 }
 
 main() {


### PR DESCRIPTION
I took a crack at updating the download script to download plugins in parallel and also added a way to specify a specific version of a plugin with an optional `@version`.

**Assumptions from script retained:**

* `REF` and `JENKINS_UC` can be passed in from the environment.
* Failing to download a plugin returns a non-zero exit code from the script as a whole, failing the docker build.
* Plugin dependencies are only resolved once, and are resolved at the latest version of the plugin regardless of dependency metadata.
* Plugins all have `.hpi` as the extension.
* Plugin dependencies are resolved from each plugin's `META-INF/MANIFEST.MF`
* `-plugin` is appeded to any plugin names before plugin downloading is considered "failed".
* **EDIT:** Plugin `.hpi` files placed in `REF` directory cause a dependency of the same name to skip downloading, and their dependencies are then resolved.

**New Features:**

* Increased performance using parallelism and `unzip -p` instead of `jrunscript`.
* Specifying a plugin as `install-plugins.sh plugin:version` will pull the plugin from `$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi` instead of `$JENKINS_UC/latest/${plugin}.hpi`
* Uses simple directory-based atomic locking to avoid race conditions.
* **EDIT:** Uses `zip -T` to check the integrity of each downloaded `.hpi` to make sure jenkins can unzip it.

Two things to note:

1. MANIFEST.MF files have a ^M in them, and long manifest entries are truncated and continued on the next line if too long.  Ugly sed -> tr -> sed -> tr piping is used to remove the ^M and concatenate lines so no plugin dependencies are missed. Although ugly, this still seems preferable to `jrunscript`.
2. Because backgrounding is used to resolve dependencies in parallel, all dependencies must finish downloading before the script realizes that there are failures (i.e. it can't exit prematurely).  Since backgrounding is such a huge performance gain for the happy path, this seems to be acceptable.