### PR TITLE
Install plugins timeout fix

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -60,7 +60,7 @@ function doDownload() {
 	url="$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi"
 
 	echo "Downloading plugin: $plugin from $url"
-	curl -s -f -L "$url" -o "$hpi"
+        curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -s -f -L "$url" -o "$hpi"
 	return $?
 }
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -60,7 +60,7 @@ function doDownload() {
 	url="$JENKINS_UC/download/plugins/$plugin/$version/${plugin}.hpi"
 
 	echo "Downloading plugin: $plugin from $url"
-        curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -s -f -L "$url" -o "$hpi"
+	curl --connect-timeout 5 --max-time 10 --retry 5 --retry-delay 0 --retry-max-time 60 -s -f -L "$url" -o "$hpi"
 	return $?
 }
 


### PR DESCRIPTION
We found that there were random timeouts with pulling the plugins down. Fixed by adding timeouts and retry arguments to the curl call. 