### PR TITLE
Upgrade plugins if needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,12 @@ All the data needed is in the /var/jenkins_home directory - so depending on how 
 
 As always - please ensure that you know how to drive docker - especially volume handling!
 
+## Upgrading plugins
+
+By default, plugins will be upgraded if they haven't been upgraded manually and if the version from the docker image is newer than the version in the container. Versions installed by the docker image are tracked through a marker file.
+
+The default behaviour when upgrading from a docker image that didn't write marker files is to leave existing plugins in place. If you want to upgrade existing plugins without marker you may run the docker image with `-e TRY_UPGRADE_IF_NO_MARKER=true`. Then plugins will be upgraded if the version provided by the docker image is newer.
+
 # Building
 
 Build with the usual

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,6 +2,19 @@
 
 set -e
 
+# compare if version1 < version2
+versionLT() {
+	[ "$1" = "$2" ] && return 1 || [  "$1" = "`echo -e "$1\n$2" | sort -V | head -n1`" ]
+}
+
+# returns a plugin version from a plugin archive
+get_plugin_version() {
+	local archive; archive=$1
+	local version; version=$(unzip -p $archive META-INF/MANIFEST.MF | grep "^Plugin-Version: " | sed -e 's#^Plugin-Version: ##')
+	version=${version%%[[:space:]]}
+	echo $version
+}
+
 # Copy files from /usr/share/jenkins/ref into $JENKINS_HOME
 # So the initial JENKINS-HOME is set with expected content.
 # Don't override, as this is just a reference setup, and use from UI
@@ -9,20 +22,94 @@ set -e
 copy_reference_file() {
 	f="${1%/}"
 	b="${f%.override}"
-	echo "$f" >> "$COPY_REFERENCE_FILE_LOG"
 	rel="${b:23}"
+	version_marker="${rel}.version_from_image"
 	dir=$(dirname "${b}")
-	echo " $f -> $rel" >> "$COPY_REFERENCE_FILE_LOG"
-	if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]
-	then
-		echo "copy $rel to JENKINS_HOME" >> "$COPY_REFERENCE_FILE_LOG"
-		mkdir -p "$JENKINS_HOME/${dir:23}"
-		cp -r "${f}" "$JENKINS_HOME/${rel}";
-		# pin plugins on initial copy
-		[[ ${rel} == plugins/*.jpi ]] && touch "$JENKINS_HOME/${rel}.pinned"
-	fi;
+	local action;
+	local reason;
+	local container_version;
+	local image_version;
+	local marker_version;
+	local log; log=false
+	if [[ ${rel} == plugins/*.jpi ]]; then
+	    container_version=$(get_plugin_version $JENKINS_HOME/${rel})
+        image_version=$(get_plugin_version ${f})
+	    if [[ -e $JENKINS_HOME/${version_marker} ]]; then
+            marker_version=$(cat $JENKINS_HOME/${version_marker})
+            if versionLT $marker_version $container_version; then
+                action="SKIPPED"
+                reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version)"
+                log=true
+            else
+                if [[ "$image_version" == "$container_version" ]]; then
+                    action="SKIPPED"
+                    reason="Version from image is the same as the installed version $image_version"
+                else
+                    if versionLT $image_version $container_version; then
+                        action="SKIPPED"
+                        log=true
+                        reason="Image version ($image_version) is older than installed version ($container_version)"
+                    else
+                        action="UPGRADED"
+                        log=true
+                        reason="Image version ($image_version) is newer than installed version ($container_version)"
+                    fi
+                fi
+            fi
+        else
+            if [[ -n "$TRY_UPGRADE_IF_NO_MARKER" ]]; then
+                if [[ "$image_version" == "$container_version" ]]; then
+                    action="SKIPPED"
+                    reason="Version from image is the same as the installed version $image_version (no marker found)"
+                    # Add marker for next time
+                    echo $image_version > $JENKINS_HOME/${version_marker}
+                else
+                    if versionLT $image_version $container_version; then
+                        action="SKIPPED"
+                        log=true
+                        reason="Image version ($image_version) is older than installed version ($container_version) (no marker found)"
+                    else
+                        action="UPGRADED"
+                        log=true
+                        reason="Image version ($image_version) is newer than installed version ($container_version) (no marker found)"
+                    fi
+                fi
+            fi
+		fi
+        if [[ ! -e $JENKINS_HOME/${rel} || "$action" == "UPGRADED" || $f = *.override ]]; then
+            action=${action:-"INSTALLED"}
+            log=true
+            mkdir -p "$JENKINS_HOME/${dir:23}"
+            cp -r "${f}" "$JENKINS_HOME/${rel}";
+		    # pin plugins on initial copy
+		    touch "$JENKINS_HOME/${rel}.pinned"
+            echo $image_version > $JENKINS_HOME/${version_marker}
+            reason=${reason:-$image_version}
+        else
+            action=${action:-"SKIPPED"}
+	    fi
+    else
+        if [[ ! -e $JENKINS_HOME/${rel} || $f = *.override ]]
+        then
+            action="INSTALLED"
+            log=true
+            mkdir -p "$JENKINS_HOME/${dir:23}"
+            cp -r "${f}" "$JENKINS_HOME/${rel}";
+        else
+            action="SKIPPED"
+        fi
+	fi
+	if [[ -n "$VERBOSE" || "$log" == "true" ]]; then
+        if [ -z "$reason" ]; then
+            echo "$action $rel" >> "$COPY_REFERENCE_FILE_LOG"
+        else
+            echo "$action $rel : $reason" >> "$COPY_REFERENCE_FILE_LOG"
+        fi
+	fi
 }
 : ${JENKINS_HOME:="/var/jenkins_home"}
+export -f versionLT
+export -f get_plugin_version
 export -f copy_reference_file
 touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?" && exit 1)
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -3,6 +3,7 @@
 # check dependencies
 (
     type docker &>/dev/null || ( echo "docker is not available"; exit 1 )
+    type unzip &>/dev/null || ( echo "unzip is not available"; exit 1 )
     type curl &>/dev/null || ( echo "curl is not available"; exit 1 )
 )>&2
 

--- a/tests/upgrade-plugins/Dockerfile
+++ b/tests/upgrade-plugins/Dockerfile
@@ -1,0 +1,3 @@
+FROM bats-jenkins
+
+RUN /usr/local/bin/install-plugins.sh maven-plugin:2.13 ant:1.2


### PR DESCRIPTION
Each plugin installed through the docker image is now tracked using a
marker file containing the version that was installed through the image.

If later, the container is started from a docker image containing newer
plugins, existing plugins will be upgraded if they haven't been upgraded
in the mean time and if the new docker image provides a new version of
them.