### PR TITLE
Install latest version of dependencies rather than the minimum version

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -104,15 +104,15 @@ function resolveDependencies() {
 			pluginInstalled="${pluginInstalled//[$'\r']}"
 			if ! [ -z "${pluginInstalled}" ]; then
 				versionInstalled=$(versionFromPlugin "${pluginInstalled}")
-				versionToInstall=$(versionFromPlugin "${d}")
-				if versionLT "${versionInstalled}" "${versionToInstall}"; then
-					echo "Upgrading bundled dependency $d ($versionToInstall > $versionInstalled)"
-					download "$plugin" "$versionToInstall" &
+				minVersion=$(versionFromPlugin "${d}")
+				if versionLT "${versionInstalled}" "${minVersion}"; then
+					echo "Upgrading bundled dependency $d ($minVersion > $versionInstalled)"
+					download "$plugin" "latest" &
 				else
-					echo "Skipping already bundled dependency $d ($versionToInstall <= $versionInstalled)"
+					echo "Skipping already bundled dependency $d ($minVersion <= $versionInstalled)"
 				fi
 			else
-				download "$plugin" "$(versionFromPlugin "${d}")" &
+				download "$plugin" "latest" &
 			fi
 		fi
 	done


### PR DESCRIPTION
install-plugins.sh currently installs the version of the plugin dependencies specified in the `MANIFEST.MF`. This behavior does not match the one of the Jenkins web interface which installs the latest version. This patch changes `install-plugins.sh` to work the same way as the Jenkins web interface.

Some tests breaks in my setup, but they also break when running them on the unmodified code. Might something wrong in my setup?

```
# bats tests
 ✓ build image
 ✓ versionLT
 ✓ build image
 ✓ clean test containers
 ✓ test multiple JENKINS_OPTS
 ✓ test jenkins arguments
 ✓ create test container
 ✓ test container is running
 ✗ Jenkins is initialized
   (from function `retry' in file tests/test_helpers.bash, line 41,
    in test file tests/tests.bats, line 43)
     `retry 30 5 test_url /api/json' failed
   Command "test_url /api/json" failed 30 times. Status: 1. Output: URL http://localhost:32779/api/json failed
   output:
 ✗ JAVA_OPTS are set
   (from function `assert' in file tests/test_helpers.bash, line 20,
    in test file tests/tests.bats, line 48)
     `assert 'default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;' \' failed
   curl: (7) Failed to connect to localhost port 32779: Connection refused
   expected: "default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;"
   actual:   ""
 ✓ plugins are installed with plugins.sh
 ✓ plugins are installed with install-plugins.sh
 ✓ plugins are installed with install-plugins.sh even when already exist
 ✓ clean test containers
 ✗ plugins are getting upgraded but not downgraded
   (from function `assert_success' in file tests/test_helper/bats-assert/src/assert.bash, line 114,
    in test file tests/tests.bats, line 113)
     `assert_success' failed

   -- command failed --
   status : 1
   output (2 lines):
     touch: cannot touch ‘/var/jenkins_home/copy_reference_file.log’: Permission denied
     Can not write to /var/jenkins_home/copy_reference_file.log. Wrong volume permissions?
   --

 ✓ clean work directory
 ✗ do not upgrade if plugin has been manually updated
   (from function `assert_success' in file tests/test_helper/bats-assert/src/assert.bash, line 114,
    in test file tests/tests.bats, line 144)
     `assert_success' failed

   -- command failed --
   status : 1
   output (2 lines):
     touch: cannot touch ‘/var/jenkins_home/copy_reference_file.log’: Permission denied
     Can not write to /var/jenkins_home/copy_reference_file.log. Wrong volume permissions?
   --

 ✓ clean work directory

18 tests, 4 failures
```

Note that the diff in github is screwed up (the highlighted lines are off by one), probably because of the carriage return character in `resolveDependencies`. You should really consider solving the replacing of the character in some other way (edit: see https://github.com/jenkinsci/docker/pull/329). To help see the changes in this screwed up diff they are explained below:
* Rename `versionToInstall` to `minVersion`.
* Pass `"latest"` rather than `$minVersion` to `download`.
* Removed trailing spaces (done by my editor)