### PR TITLE
dependencies always resolved as latest

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -102,19 +102,20 @@ function resolveDependencies() {
         if [[ $d == *"resolution:=optional"* ]]; then
             echo "Skipping optional dependency $plugin"
         else
-            local pluginInstalled
+            local pluginInstalled version
+            version=$(versionFromPlugin "${d}")
             if pluginInstalled="$(echo "${bundledPlugins}" | grep "^${plugin}:")"; then
                 pluginInstalled="${pluginInstalled//[$'\r']}"
                 local versionInstalled; versionInstalled=$(versionFromPlugin "${pluginInstalled}")
                 local minVersion; minVersion=$(versionFromPlugin "${d}")
                 if versionLT "${versionInstalled}" "${minVersion}"; then
                     echo "Upgrading bundled dependency $d ($minVersion > $versionInstalled)"
-                    download "$plugin" &
+                    download "$plugin" "$version" &
                 else
                     echo "Skipping already bundled dependency $d ($minVersion <= $versionInstalled)"
                 fi
             else
-                download "$plugin" &
+                download "$plugin" "$version" &
             fi
         fi
     done


### PR DESCRIPTION
It seems dependencies are always resolved as latest.
E.g. git:2.4.0 depends (amongst others) on matrix-project:1.4
This is also echoed when running the script with arg `git:2.4.0`

However, when it comes to the actual download of the dependency, it always takes the latest version as the `download` function is only called with one argument, which is the plugin name - so the `download` function falls back to `latest`.

One could argue that plugins should be compatible, so using a newer version should be safe. However that is only true for the API the plugin provides, but not for the API it uses itself.

This means, even though the latest version of `matrix-project`, say 1.6 is compatible, hence will not break the older `git` plugin 2.4.0 that uses it: the latest version of `matrix-project` in turn might internally rely on a newer Jenkins API.

Probably in my Docker file I've set `git` explicitly to version 2.4.0, because I know this is compatible with the Jenkins image I'm inheriting in my Dockerfile!
If suddenly the newest version of the `matrix-project` dependency is fetched, say 1.6, this might not be compatible with the Jenkins version I'm using...