### PR TITLE
Shell pedantry

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -12,15 +12,15 @@ FAILED="$REF_DIR/failed-plugins.txt"
 
 . /usr/local/bin/jenkins-support
 
-function getLockFile() {
-    echo -n "$REF_DIR/${1}.lock"
+getLockFile() {
+    printf '%s' "$REF_DIR/${1}.lock"
 }
 
-function getArchiveFilename() {
-    echo -n "$REF_DIR/${1}.jpi"
+getArchiveFilename() {
+    printf '%s' "$REF_DIR/${1}.jpi"
 }
 
-function download() {
+download() {
     local plugin originalPlugin version lock ignoreLockFile
     plugin="$1"
     version="${2:-latest}"
@@ -50,7 +50,7 @@ function download() {
     fi
 }
 
-function doDownload() {
+doDownload() {
     local plugin version url jpi
     plugin="$1"
     version="$2"
@@ -71,7 +71,7 @@ function doDownload() {
     return $?
 }
 
-function checkIntegrity() {
+checkIntegrity() {
     local plugin jpi
     plugin="$1"
     jpi="$(getArchiveFilename "$plugin")"
@@ -80,7 +80,7 @@ function checkIntegrity() {
     return $?
 }
 
-function resolveDependencies() {
+resolveDependencies() {
     local plugin jpi dependencies
     plugin="$1"
     jpi="$(getArchiveFilename "$plugin")"
@@ -94,7 +94,7 @@ function resolveDependencies() {
 
     echo " > $plugin depends on $dependencies"
 
-    IFS=',' read -a array <<< "$dependencies"
+    IFS=',' read -r -a array <<< "$dependencies"
 
     for d in "${array[@]}"
     do
@@ -121,7 +121,7 @@ function resolveDependencies() {
     wait
 }
 
-function bundledPlugins() {
+bundledPlugins() {
     local JENKINS_WAR=/usr/share/jenkins/jenkins.war
     if [ -f $JENKINS_WAR ]
     then
@@ -143,7 +143,7 @@ function bundledPlugins() {
     fi
 }
 
-function versionFromPlugin() {
+versionFromPlugin() {
     local plugin=$1
     if [[ $plugin =~ .*:.* ]]; then
         echo "${plugin##*:}"
@@ -153,7 +153,7 @@ function versionFromPlugin() {
 
 }
 
-function installedPlugins() {
+installedPlugins() {
     for f in "$REF_DIR"/*.jpi; do
         echo "$(basename "$f" | sed -e 's/\.jpi//'):$(get_plugin_version "$f")"
     done
@@ -170,10 +170,10 @@ main() {
         mkdir "$(getLockFile "${plugin%%:*}")"
     done
 
-    echo -e "\nAnalyzing war..."
+    printf '\n%s' "Analyzing war..."
     bundledPlugins="$(bundledPlugins)"
 
-    echo -e "\nDownloading plugins..."
+    printf '\n%s' "Downloading plugins..."
     for plugin in "$@"; do
         version=""
 
@@ -194,11 +194,11 @@ main() {
     installedPlugins
 
     if [[ -f $FAILED ]]; then
-        echo -e "\nSome plugins failed to download!\n$(<"$FAILED")" >&2
+        printf '\n%s' "Some plugins failed to download!" "$(<"$FAILED")" >&2
         exit 1
     fi
 
-    echo -e "\nCleaning up locks"
+    printf '\n%s' "Cleaning up locks"
     rm -r "$REF_DIR"/*.lock
 }
 

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,7 +3,7 @@
 : ${JENKINS_HOME:="/var/jenkins_home"}
 touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?" && exit 1)
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
-find /usr/share/jenkins/ref/ -type f -exec bash -c ". /usr/local/bin/jenkins-support; copy_reference_file '{}'" \;
+find /usr/share/jenkins/ref/ -type f -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,7 +1,7 @@
 #! /bin/bash -e
 
-: ${JENKINS_HOME:="/var/jenkins_home"}
-touch "${COPY_REFERENCE_FILE_LOG}" || (echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?" && exit 1)
+: "${JENKINS_HOME:="/var/jenkins_home"}"
+touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find /usr/share/jenkins/ref/ -type f -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +
 

--- a/plugins.sh
+++ b/plugins.sh
@@ -31,7 +31,7 @@ USAGE:
     exit 1
 else
     JENKINS_INPUT_JOB_LIST=$1
-    if [ ! -f $JENKINS_INPUT_JOB_LIST ]
+    if [ ! -f "$JENKINS_INPUT_JOB_LIST" ]
     then
         echo "ERROR File not found: $JENKINS_INPUT_JOB_LIST"
         exit 1
@@ -40,7 +40,7 @@ fi
 
 # the war includes a # of plugins, to make the build efficient filter out
 # the plugins so we dont install 2x - there about 17!
-if [ -d $JENKINS_HOME ]
+if [ -d "$JENKINS_HOME" ]
 then
     TEMP_ALREADY_INSTALLED=$JENKINS_HOME/preinstalled.plugins.$$.txt
 else
@@ -49,33 +49,31 @@ else
 fi
 
 JENKINS_PLUGINS_DIR=/var/jenkins_home/plugins
-if [ -d $JENKINS_PLUGINS_DIR ]
+if [ -d "$JENKINS_PLUGINS_DIR" ]
 then
     echo "Analyzing: $JENKINS_PLUGINS_DIR"
-    for i in `ls -pd1 $JENKINS_PLUGINS_DIR/*|egrep '\/$'`
-    do
-        JENKINS_PLUGIN=`basename $i`
-        JENKINS_PLUGIN_VER=`egrep -i Plugin-Version "$i/META-INF/MANIFEST.MF"|cut -d\: -f2|sed 's/ //'`
+    for i in "$JENKINS_PLUGINS_DIR"/*/; do
+        JENKINS_PLUGIN=$(basename "$i")
+        JENKINS_PLUGIN_VER=$(egrep -i Plugin-Version "$i/META-INF/MANIFEST.MF"|cut -d: -f2|sed 's/ //')
         echo "$JENKINS_PLUGIN:$JENKINS_PLUGIN_VER"
-    done > $TEMP_ALREADY_INSTALLED
+    done >"$TEMP_ALREADY_INSTALLED"
 else
     JENKINS_WAR=/usr/share/jenkins/jenkins.war
-    if [ -f $JENKINS_WAR ]
+    if [ -f "$JENKINS_WAR" ]
     then
         echo "Analyzing war: $JENKINS_WAR"
         TEMP_PLUGIN_DIR=/tmp/plugintemp.$$
-        for i in `jar tf $JENKINS_WAR | egrep '[^detached-]plugins.*\..pi' | sort`
-        do
-            rm -fr $TEMP_PLUGIN_DIR
-            mkdir -p $TEMP_PLUGIN_DIR
-            PLUGIN=`basename $i|cut -f1 -d'.'`
-            (cd $TEMP_PLUGIN_DIR;jar xf $JENKINS_WAR "$i";jar xvf $TEMP_PLUGIN_DIR/$i META-INF/MANIFEST.MF >/dev/null 2>&1)
-            VER=`egrep -i Plugin-Version "$TEMP_PLUGIN_DIR/META-INF/MANIFEST.MF"|cut -d\: -f2|sed 's/ //'`
+        while read -r i <&3; do
+            rm -fr "$TEMP_PLUGIN_DIR"
+            mkdir -p "$TEMP_PLUGIN_DIR"
+            PLUGIN=$(basename "$i"|cut -f1 -d'.')
+            (cd "$TEMP_PLUGIN_DIR" || exit; jar xf "$JENKINS_WAR" "$i"; jar xvf "$TEMP_PLUGIN_DIR/$i" META-INF/MANIFEST.MF >/dev/null 2>&1)
+            VER=$(egrep -i Plugin-Version "$TEMP_PLUGIN_DIR/META-INF/MANIFEST.MF"|cut -d: -f2|sed 's/ //')
             echo "$PLUGIN:$VER"
-        done > $TEMP_ALREADY_INSTALLED
-        rm -fr $TEMP_PLUGIN_DIR
+        done 3< <(jar tf "$JENKINS_WAR" | egrep '[^detached-]plugins.*\..pi' | sort) > "$TEMP_ALREADY_INSTALLED"
+        rm -fr "$TEMP_PLUGIN_DIR"
     else
-        rm -f $TEMP_ALREADY_INSTALLED
+        rm -f "$TEMP_ALREADY_INSTALLED"
         echo "ERROR file not found: $JENKINS_WAR"
         exit 1
     fi
@@ -84,30 +82,30 @@ fi
 REF=/usr/share/jenkins/ref/plugins
 mkdir -p $REF
 COUNT_PLUGINS_INSTALLED=0
-while read spec || [ -n "$spec" ]; do
+while read -r spec || [ -n "$spec" ]; do
 
     plugin=(${spec//:/ });
     [[ ${plugin[0]} =~ ^# ]] && continue
-    [[ ${plugin[0]} =~ ^\s*$ ]] && continue
+    [[ ${plugin[0]} =~ ^[[:space:]]*$ ]] && continue
     [[ -z ${plugin[1]} ]] && plugin[1]="latest"
 
     if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
       JENKINS_UC_DOWNLOAD=$JENKINS_UC/download
     fi
 
-    if ! grep -q "${plugin[0]}:${plugin[1]}" $TEMP_ALREADY_INSTALLED
+    if ! grep -q "${plugin[0]}:${plugin[1]}" "$TEMP_ALREADY_INSTALLED"
     then
         echo "Downloading ${plugin[0]}:${plugin[1]}"
-        curl --retry 3 --retry-delay 5 -sSL -f ${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi -o $REF/${plugin[0]}.jpi
-        unzip -qqt $REF/${plugin[0]}.jpi
-        COUNT_PLUGINS_INSTALLED=`expr $COUNT_PLUGINS_INSTALLED + 1`
+        curl --retry 3 --retry-delay 5 -sSL -f "${JENKINS_UC_DOWNLOAD}/plugins/${plugin[0]}/${plugin[1]}/${plugin[0]}.hpi" -o "$REF/${plugin[0]}.jpi"
+        unzip -qqt "$REF/${plugin[0]}.jpi"
+        (( COUNT_PLUGINS_INSTALLED += 1 ))
     else
         echo "  ... skipping already installed:  ${plugin[0]}:${plugin[1]}"
     fi
-done  < $JENKINS_INPUT_JOB_LIST
+done  < "$JENKINS_INPUT_JOB_LIST"
 
 echo "---------------------------------------------------"
-if [ $COUNT_PLUGINS_INSTALLED -gt 0 ]
+if (( "$COUNT_PLUGINS_INSTALLED" > 0 ))
 then
     echo "INFO: Successfully installed $COUNT_PLUGINS_INSTALLED plugins."
 
@@ -122,5 +120,5 @@ fi
 echo "---------------------------------------------------"
 
 #cleanup
-rm $TEMP_ALREADY_INSTALLED
+rm "$TEMP_ALREADY_INSTALLED"
 exit 0

--- a/weekly.sh
+++ b/weekly.sh
@@ -3,20 +3,20 @@
 set -e
 set -x
 
-JENKINS_VERSION=`curl -sq https://api.github.com/repos/jenkinsci/jenkins/tags | grep '"name":' | grep -o '[0-9]\.[0-9]*'  | uniq | sort --version-sort | tail -1`
-echo $JENKINS_VERSION
+JENKINS_VERSION=$(curl -sq https://api.github.com/repos/jenkinsci/jenkins/tags | grep '"name":' | grep -o '[0-9]\.[0-9]*'  | uniq | sort --version-sort | tail -1)
+echo "$JENKINS_VERSION"
 
-JENKINS_SHA=`curl http://repo.jenkins-ci.org/simple/releases/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war.sha1`
-echo $JENKINS_SHA
+JENKINS_SHA=$(curl "http://repo.jenkins-ci.org/simple/releases/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war.sha1")
+echo "$JENKINS_SHA"
 
-docker build --build-arg JENKINS_VERSION=$JENKINS_VERSION \
-             --build-arg JENKINS_SHA=$JENKINS_SHA \
+docker build --build-arg "JENKINS_VERSION=$JENKINS_VERSION" \
+             --build-arg "JENKINS_SHA=$JENKINS_SHA" \
              --no-cache --pull \
-             --tag jenkinsci/jenkins:$JENKINS_VERSION .
+             --tag "jenkinsci/jenkins:$JENKINS_VERSION" .
 
-docker tag -f jenkinsci/jenkins:$JENKINS_VERSION jenkinsci/jenkins:latest
+docker tag -f "jenkinsci/jenkins:$JENKINS_VERSION" jenkinsci/jenkins:latest
 
-docker push jenkinsci/jenkins:$JENKINS_VERSION
+docker push "jenkinsci/jenkins:$JENKINS_VERSION"
 docker push jenkinsci/jenkins:latest
 
 


### PR DESCRIPTION
This PR contains several individual commits, which are intended to be individually accepted, rejected, or pushed back on for modification. See links below with reasoning for each set of changes. Happy to amend to subpart out accepted or rejected components of the larger compliance-pass commit.

---

### Avoid shell injection vulnerability via malicious filenames
Also adds support for systems with non-GNU `find`. Previously discussed in #351.
### Avoid eval, shell-injection via JAVA_OPTS or JENKINS_OPTS
...see [BashFAQ #48](http://mywiki.wooledge.org/BashFAQ/048) for general discussion of why `eval` is best avoided.
### Full best-practices / shellcheck compliance pass
- Use modern `$()` syntax vs backticks [see [SC2006](https://github.com/koalaman/shellcheck/wiki/SC2006)]
- Always check for, and bail on, failures of `cd`. [see [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164)]
- Avoid `for foo in $(...)`, per [DontReadLinesWithFor](http://mywiki.wooledge.org/DontReadLinesWithFor)
- Avoid parsing `ls` to find subdirectories when `for d in "$dir"/*/` does the job; see also [ParsingLs](http://mywiki.wooledge.org/ParsingLs)
- `\s` is not specified in POSIX ERE (thus, not guaranteed to be available in bash-native regexes unless local platform's C library's regex implementation extends standard); use `[[:space:]]` instead. See [POSIX ERE specification](http://pubs.opengroup.org/onlinepubs/009696899/basedefs/xbd_chap09.html).
- Avoid unnecessary deviations from POSIX sh specification:
   - `echo -e` violates (not just extends) POSIX, and won't behave as desired on a bash compiled with `--enable-xpg-echo-default`; [POSIX specification](http://pubs.opengroup.org/onlinepubs/009604599/utilities/echo.html) suggests `printf` as replacement (see APPLICATION USAGE section thereof).
   - `function` keyword not specified in POSIX, provides no benefit over standard-compliant function declaration syntax, reducing reusability