### PR TITLE
Remove zip dependency and replace with unzip equivalent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk
 
-RUN apt-get update && apt-get install -y git curl zip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
 ENV JENKINS_HOME /var/jenkins_home
 ENV JENKINS_SLAVE_AGENT_PORT 50000

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -76,7 +76,7 @@ function checkIntegrity() {
     plugin="$1"
     jpi="$(getArchiveFilename "$plugin")"
 
-    zip -T "$jpi" >/dev/null
+    unzip -t -qq "$jpi" >/dev/null
     return $?
 }
 


### PR DESCRIPTION
The zip dependency seems unnecessary for just checksum validation as unzip offers this integrity check. 

Updated to remove the dependency. 