### PR TITLE
Fix weekly version regular expression

### DIFF
--- a/weekly.sh
+++ b/weekly.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-JENKINS_VERSION=$(curl -sq https://api.github.com/repos/jenkinsci/jenkins/tags | grep '"name":' | grep -E -o '\d+(\.\d+)+'  | uniq | sort --version-sort | tail -1)
+JENKINS_VERSION=$(curl -sq https://api.github.com/repos/jenkinsci/jenkins/tags | grep '"name":' | egrep -o '[0-9]+(\.[0-9]+)+'  | uniq | sort --version-sort | tail -1)
 echo "$JENKINS_VERSION"
 
 JENKINS_SHA=$(curl "http://repo.jenkins-ci.org/simple/releases/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war.sha1")

--- a/weekly.sh
+++ b/weekly.sh
@@ -3,7 +3,7 @@
 set -e
 set -x
 
-JENKINS_VERSION=$(curl -sq https://api.github.com/repos/jenkinsci/jenkins/tags | grep '"name":' | egrep -o '[0-9]+(\.[0-9]+)+'  | uniq | sort --version-sort | tail -1)
+JENKINS_VERSION=$(curl -sq https://api.github.com/repos/jenkinsci/jenkins/tags | grep '"name":' | egrep -o '[0-9]+(\.[0-9]+)+' | sort --version-sort | uniq | tail -1)
 echo "$JENKINS_VERSION"
 
 JENKINS_SHA=$(curl "http://repo.jenkins-ci.org/simple/releases/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war.sha1")


### PR DESCRIPTION
`grep -P` supports the `\d` character class but `grep -E` does not. `grep -E` only supports `[[:digit:]]`. I used `[0-9]` because it's shorter. I also switched to using `egrep`, keeping in line with [other scripts in the repo](https://github.com/jenkinsci/docker/blob/3eec42c/plugins.sh#L57).

Additionally, I moved sorting to happen before running `uniq`, as `uniq` only looks at the immediately preceding line for deduplication.