### PR TITLE
Add plugins.txt file compability for install-plugins.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ FROM jenkins
 RUN /usr/local/bin/install-plugins.sh docker-slaves github-branch-source:1.8
 ```
 
+Furthermore it is possible to pass a file that contains this set of plugins (with or without line breaks).
+
+```
+FROM jenkins
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh </usr/share/jenkins/ref/plugins.txt
+```
+
 When jenkins container starts, it will check `JENKINS_HOME` has this reference content, and copy them
 there if required. It will not override such files, so if you upgraded some plugins from UI they won't
 be reverted on next start.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Furthermore it is possible to pass a file that contains this set of plugins (wit
 ```
 FROM jenkins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh </usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
 ```
 
 When jenkins container starts, it will check `JENKINS_HOME` has this reference content, and copy them

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -160,13 +160,22 @@ installedPlugins() {
 }
 
 main() {
-    local plugin version
+    local plugin plugins version
 
     mkdir -p "$REF_DIR" || exit 1
 
+    # Read plugins from stdin or from the command line arguments
+    if [[ ($# -eq 0) ]]; then
+        while read line; do
+            plugins="${plugins:=} ${line}"
+        done
+    else
+        plugins="$@"
+    fi
+
     # Create lockfile manually before first run to make sure any explicit version set is used.
     echo "Creating initial locks..."
-    for plugin in "$@"; do
+    for plugin in $plugins; do
         mkdir "$(getLockFile "${plugin%%:*}")"
     done
 
@@ -174,7 +183,7 @@ main() {
     bundledPlugins="$(bundledPlugins)"
 
     echo "Downloading plugins..."
-    for plugin in "$@"; do
+    for plugin in $plugins; do
         version=""
 
         if [[ $plugin =~ .*:.* ]]; then

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -48,6 +48,31 @@ load test_helpers
   assert_line 'mailer.jpi.pinned'
 }
 
+@test "plugins are installed with install-plugins.sh from a plugins file" {
+  run docker build -t $SUT_IMAGE-install-plugins-pluginsfile $BATS_TEST_DIRNAME/install-plugins/pluginsfile
+  assert_success
+  refute_line --partial 'Skipping already bundled dependency'
+  # replace DOS line endings \r\n
+  run bash -c "docker run --rm $SUT_IMAGE-install-plugins ls --color=never -1 /var/jenkins_home/plugins | tr -d '\r'"
+  assert_success
+  assert_line 'maven-plugin.jpi'
+  assert_line 'maven-plugin.jpi.pinned'
+  assert_line 'ant.jpi'
+  assert_line 'ant.jpi.pinned'
+  assert_line 'credentials.jpi'
+  assert_line 'credentials.jpi.pinned'
+  assert_line 'mesos.jpi'
+  assert_line 'mesos.jpi.pinned'
+  # optional dependencies
+  refute_line 'metrics.jpi'
+  refute_line 'metrics.jpi.pinned'
+  # plugins bundled but under detached-plugins, so need to be installed
+  assert_line 'javadoc.jpi'
+  assert_line 'javadoc.jpi.pinned'
+  assert_line 'mailer.jpi'
+  assert_line 'mailer.jpi.pinned'
+}
+
 @test "plugins are installed with install-plugins.sh even when already exist" {
   run docker build -t $SUT_IMAGE-install-plugins-update --no-cache $BATS_TEST_DIRNAME/install-plugins/update
   assert_success

--- a/tests/install-plugins/pluginsfile/Dockerfile
+++ b/tests/install-plugins/pluginsfile/Dockerfile
@@ -1,0 +1,4 @@
+FROM bats-jenkins
+
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt

--- a/tests/install-plugins/pluginsfile/plugins.txt
+++ b/tests/install-plugins/pluginsfile/plugins.txt
@@ -1,0 +1,3 @@
+ant:1.3
+maven-plugin:2.7.1
+mesos:0.13.0


### PR DESCRIPTION
The new install-plugins.sh script removed the possibility to pass a file
containing a list of plugins that was given with the 'old' plugins.sh
script, although this functionality can be provided with only a few
lines more.

Now, when the install-plugins.sh script is called with only a single
argument that matches an existing file on the file system, it is assumed
that this file contains the list of plugins that should be installed,
newlines are replaced by spaces and this manipulated content is used as
the plugins list for further processing.

Closes #348.
