### PR TITLE
Add ssl to war download url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.19.1}
 ARG JENKINS_SHA=dc28b91e553c1cd42cc30bd75d0f651671e6de0b
 
 # Can be used to customize where jenkins.war get downloaded from
-ARG JENKINS_URL=http://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum 
 # see https://github.com/docker/docker/issues/8331


### PR DESCRIPTION
My main reason for switching is to get past my work ISP throttling.  When I try to build test these locally for pull requests to official-images, my ISP (or someone in between) decides to do some extreme throttling causing a timeout on the download.  This does not happen when downloading over `https`.  `repo.jenkins-ci.org` redirects to `https`, but not when accessing a specific artifact.

The secondary and probably more important reason is to verify that the file is coming from the proper authority `repo.jenkins-ci.org`.  Yes, we have the `SHA1`, but `https` provides an extra layer of trust.