### PR TITLE
copy symlinked reference files

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -3,7 +3,7 @@
 : "${JENKINS_HOME:="/var/jenkins_home"}"
 touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
-find /usr/share/jenkins/ref/ -type f -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +
+find /usr/share/jenkins/ref/ -type f -or -type l -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then


### PR DESCRIPTION
I noticed my mounted `init.groovy.d` files not being copied over on a fresh boot. After digging into this, I found the `find -type f` line, which prevents copying symlinked files.

Using Kubernetes, when using something like a ConfigMap, files are actually symlinked into place, which makes them not work as expected.

This PR fixes that.