### PR TITLE
Allow custom full plugin download URL

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -62,8 +62,9 @@ doDownload() {
         return 0
     fi
 
-    JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
-
+    if [ "$JENKINS_UC_DOWNLOAD" == "" ]; then
+        JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
+    fi
     url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"
 
     echo "Downloading plugin: $plugin from $url"

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -62,7 +62,7 @@ doDownload() {
         return 0
     fi
 
-    if [ "$JENKINS_UC_DOWNLOAD" == "" ]; then
+    if [ -z "$JENKINS_UC_DOWNLOAD" ]; then
         JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
     fi
     url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"


### PR DESCRIPTION
When using this image inside company firewalls and without connectivity to the outside world,
it is much better to download plugins from a custom URL.