### PR TITLE
Upgrade Tini to 0.13.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,11 +25,11 @@ VOLUME /var/jenkins_home
 # or config file with your custom jenkins Docker image.
 RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
 
-ENV TINI_VERSION 0.9.0
-ENV TINI_SHA fa23d1e20732501c3bb8eeeca423c89ac80ed452
+ENV TINI_VERSION 0.13.1
+ENV TINI_SHA 0f78709a0e3c80e7c9119fdc32c2bc0f4cfc4cab
 
 # Use tini as subreaper in Docker container to adopt zombie processes 
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static -o /bin/tini && chmod +x /bin/tini \
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/v${TINI_VERSION}/tini-static-amd64 -o /bin/tini && chmod +x /bin/tini \
   && echo "$TINI_SHA  /bin/tini" | sha1sum -c -
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy


### PR DESCRIPTION
This upgrades Tini to 0.13.1 in order to fix a compatibility issue with
https://github.com/joyent/sdc-docker (see:
https://github.com/joyent/sdc-docker/issues/91). The fix itself was
provided by @geek of Joyent.

I've also made the Tini architecture more explicit (since Tini now also
supports ARM), so in case you decide to support additional architectures
in the future, the fix should be more obvious.

There isn't much functional difference between 0.9.0 (which you were
using) and 0.13.1, but here are a few notable changes you might care
about to some extent:

- Tini now supports a `-l` flag to show its license. This was useful
  from a compliance perspective for some users (so considering you're
  shipping Tini that might indirectly be useful to you!).
- Tini now supports a `--version` argument to show its version. This is
  here mostly because it's a little more intuitive than what was there
  before (you'd have to use `-h` to see the version).
- Tini now supports a `TINI_VERBOSITY` environment variable (should be
  an int), which can be convenient for debugging when Tini is used as an
  `ENTRYPOINT` (avoids the need to alter the entrypoint to configure
  it).
- Tini now uses more specific exit codes when it fails to fork (e.g.
  because the binary you're looking for doesn't exist, etc.).

Thanks for using Tini in this image!

---

fyi, @geek