### PR TITLE
Change filename for number of executors example

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ For more info check Docker docs section on [Managing data in containers](https:/
 
 You can specify and set the number of executors of your Jenkins master instance using a groovy script. By default its set to 2 executors, but you can extend the image and change it to your desired number of executors :
 
-`executors.groovy`
+`set-executors.groovy`
 ```
 import jenkins.model.*
 Jenkins.instance.setNumExecutors(5)
@@ -56,7 +56,7 @@ and `Dockerfile`
 
 ```
 FROM jenkins
-COPY executors.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
+COPY set-executors.groovy /usr/share/jenkins/ref/init.groovy.d/set-executors.groovy
 ```
 
 


### PR DESCRIPTION
When trying to run that script locally, it does not work (tested in `jenkins:2.32.2-alpine`). 
There is already a file named `executors.groovy` and so if you try to add the file, it won't actually override what is in the settings. When I changed the file name, it was able to work.

---

#### Reviewer notes:
I wasn't sure if this was an actual bug and thought it was just something that was a forethought. There might need to be additional documentation added about files that already exist to avoid collisions and the script runner not taking that file into account. 