### PR TITLE
Breakup USER and comment to two lines.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,8 @@ FROM jenkins
 # if we want to install via apt
 USER root
 RUN apt-get update && apt-get install -y ruby make more-thing-here
-USER jenkins # drop back to the regular jenkins user - good practice
+# drop back to the regular jenkins user - good practice
+USER jenkins
 ```
 
 In such a derived image, you can customize your jenkins instance with hook scripts or additional plugins.


### PR DESCRIPTION
Dockerfile USER command doesn't allow comment on same line this causes
errors in local testing.

Update the readme to reflect a working Dockerfile.

Tested with:
docker 1.13.1, build 092cba3
docker-compose 1.10.0, build 4bd6f1a
