### PR TITLE
Use SHA-256 instead of SHA-1 to verify the jenkins.war file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ ARG JENKINS_VERSION
 ENV JENKINS_VERSION ${JENKINS_VERSION:-2.32.3}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=a25b9a314ca9e76f9673da7309e1882e32674223
+ARG JENKINS_SHA=3eb599dd78ecf00e5f177ec5c4b1ba4274be4e5f63236da6ac92401a66fa91e8
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
@@ -47,7 +47,7 @@ ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-w
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum 
 # see https://github.com/docker/docker/issues/8331
 RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
-  && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha1sum -c -
+  && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
 
 ENV JENKINS_UC https://updates.jenkins.io
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref


### PR DESCRIPTION
Jenkins publishes the sha256sum of jenkins.war [here](http://mirrors.jenkins.io/war-stable/2.32.3/jenkins.war.sha256). They don't seem to publish a sha1sum.

Also, [this](https://en.wikipedia.org/wiki/SHA-1#SHAttered_-_First_public_collision).

I tested building this image using cached steps, then also tested building from scratch. I ran the BATS tests too and everything is passing.

```
Removing intermediate container 84e2e3652e57
Step 17/31 : ENV JENKINS_VERSION ${JENKINS_VERSION:-2.32.3}
 ---> Running in 5b2693641b9c
 ---> 3c688307fb75
Removing intermediate container 5b2693641b9c
Step 18/31 : ARG JENKINS_SHA=3eb599dd78ecf00e5f177ec5c4b1ba4274be4e5f63236da6ac92401a66fa91e8
 ---> Running in a342195fd73f
 ---> 9ddfcf1fd4d4
Removing intermediate container a342195fd73f
Step 19/31 : ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 ---> Running in f6ea69762dd7
 ---> 41883c886efd
Removing intermediate container f6ea69762dd7
Step 20/31 : RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war   && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
 ---> Running in ca0d1133c6ab
/usr/share/jenkins/jenkins.war: OK
 ---> 4b2243c77881
```

```
$ bats/bin/bats tests
 ✓ build image
 ✓ versionLT
 ✓ build image
 ✓ plugins are installed with plugins.sh
 ✓ plugins are installed with install-plugins.sh
 ✓ plugins are installed with install-plugins.sh even when already exist
 ✓ plugins are getting upgraded but not downgraded
 ✓ clean work directory
 ✓ do not upgrade if plugin has been manually updated
 ✓ clean work directory
 ✓ build image
 ✓ clean test containers
 ✓ test multiple JENKINS_OPTS
 ✓ test jenkins arguments
 ✓ create test container
 ✓ test container is running
 ✓ Jenkins is initialized
 ✓ JAVA_OPTS are set
 ✓ clean test containers

19 tests, 0 failures
```