### PR TITLE
Fix broken example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Furthermore it is possible to pass a file that contains this set of plugins (wit
 ```
 FROM jenkins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+RUN /usr/local/bin/install-plugins.sh $(cat /usr/share/jenkins/ref/plugins.txt)
 ```
 
 When jenkins container starts, it will check `JENKINS_HOME` has this reference content, and copy them


### PR DESCRIPTION
Currently running the example will cause the following error to be thrown.
```
Creating initial locks...
Analyzing war...
Downloading plugins...

WAR bundled plugins:


Installed plugins:
*:
Cleaning up locks
rm: cannot remove ‘/usr/share/jenkins/ref/plugins/*.lock’: No such file or directory
The command '/bin/sh -c /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt' returned a non-zero code: 1
```
This is because the script does not support reading from stdin via read like the plugins.sh script.