### PR TITLE
[FIXED JENKINS-44733] - Fix #508 do not use latest alpine parent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8u121-jdk-alpine
 
 RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils
 


### PR DESCRIPTION
It breaks startup with UnsatisfiedLinkError
https://bugs.alpinelinux.org/issues/7372