### PR TITLE
Use previous version of shellcheck docker image

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,8 @@ node('docker') {
     if (!infra.isTrusted()) {
 
         stage('shellcheck') {
-            docker.image('koalaman/shellcheck').inside() {
+            // newer versions of the image don't have cat installed and docker pipeline fails
+            docker.image('koalaman/shellcheck:v0.4.6').inside() {
                 // run shellcheck ignoring error SC1091
                 // Not following: /usr/local/bin/jenkins-support was not specified as input
                 sh "shellcheck -e SC1091 *.sh"


### PR DESCRIPTION
newer versions of the image don't have cat installed and docker pipeline fails