### PR TITLE
Use openjdk:8-jdk-alpine as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8u121-jdk-alpine
+FROM openjdk:8-jdk-alpine
 
 RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils
 


### PR DESCRIPTION
This is consistent with master, which uses openjdk:8-jdk. By fixing
the version to openjdk:8u121-jdk-alpine, we weren't getting built with
the latest patch version of openjdk (8u121 vs 8u131 at time of
writing), nor the latest version of Alpine (3.5.2 vs 3.6.2).