### PR TITLE
Add mercurial like git to supported SCM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8u121-jdk-alpine
 
-RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils
+RUN apk add --no-cache git mercurial openssh-client curl unzip bash ttf-dejavu coreutils
 
 ARG user=jenkins
 ARG group=jenkins


### PR DESCRIPTION
This avoids errors like this:
  Checking out hg http://mercurial/Project/ default to read Jenkinsfile
  $ hg clone --rev default --noupdate http://mercurial/Project/ /var/jenkins_home/jobs/Project/workspace@script/source
  ERROR: Failed to clone http://mercurial/Project/ because hg could not be found; check that you've properly configured your Mercurial installation