### PR TITLE
Issue #538 - Add support of downloading plugins from the Experimental UC

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
 
 ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref
 
 # for main web interface:

--- a/README.md
+++ b/README.md
@@ -151,17 +151,47 @@ COPY custom.groovy /usr/share/jenkins/ref/init.groovy.d/custom.groovy
 ## Preinstalling plugins
 
 You can rely on the `install-plugins.sh` script to pass a set of plugins to download with their dependencies.
-Use plugin artifact ID, whithout `-plugin` extension, and append the version if needed separated by `:`.
+This script will perform downloads from update centers, an internet access is required for the default update centers.
+
+### Setting update centers
+
+During the download, the script will use update centers defined by the following environment variables:
+
+* `JENKINS_UC` - Main update center. 
+  This update center may offer plugin versions depending on the Jenkins LTS Core versions.
+  Default value: https://updates.jenkins.io
+* `JENKINS_UC_EXPERIMENTAL` - [Experimental Update Center](https://jenkins.io/blog/2013/09/23/experimental-plugins-update-center/).
+  This center offers Alpha and Beta versions of plugins.
+  Default value: https://updates.jenkins.io/experimental
+  
+It is possible to override the environment variables in images.
+
+:exclamation: Note that changing this variables **will not** change the Update Center being used by Jenkins runtime.
+
+### Plugin version format
+
+Use plugin artifact ID, without `-plugin` extension, and append the version if needed separated by `:`.
 Dependencies that are already included in the Jenkins war will only be downloaded if their required version is newer than the one included.
 
-```
+There are also custom version specifiers:
+
+* `latest` - download the latest version from the main update center.
+  For Jenkins LTS images 
+  (example: `git:latest`)
+* `experimental` - download the latest version from the experimental update center defined by the `JENKINS_UC_EXPERIMENTAL` environment variable (example: `filesystem_scm:experimental`)
+
+### Script usage
+
+You can run the script manually in Dockerfile:
+
+```Dockerfile
 FROM jenkins
 RUN /usr/local/bin/install-plugins.sh docker-slaves github-branch-source:1.8
 ```
 
 Furthermore it is possible to pass a file that contains this set of plugins (with or without line breaks).
 
-```
+```Dockerfile
 FROM jenkins
 COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
 RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -66,6 +66,9 @@ doDownload() {
         # If version-specific Update Center is available, which is the case for LTS versions,
         # use it to resolve latest versions.
         url="$JENKINS_UC_LATEST/latest/${plugin}.hpi"
+    elif [[ "$version" == "experimental" && -n "$JENKINS_UC_EXPERIMENTAL" ]]; then
+        # Download from the experimental update center
+        url="$JENKINS_UC_EXPERIMENTAL/latest/${plugin}.hpi"
     else
         JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
         url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"

--- a/tests/install-plugins/pluginsfile/plugins.txt
+++ b/tests/install-plugins/pluginsfile/plugins.txt
@@ -1,3 +1,5 @@
 ant:1.3
 maven-plugin:2.7.1
 mesos:0.13.0
+git:latest
+filesystem_scm:experimental


### PR DESCRIPTION
In my demo Docker image I sometimes need to install plugins from the Experimental update center. If I just specify it as `JENKINS_UC`, improper download link format will be generated for the latest paths (e.g. `filesystem_scm:latest` in plugins.txt). Effectively it leads to the download of the latest version from the main update center.

I propose to add the `JENKINS_UC_EXPERIMENTAL` and to extend parsing of plugins.txt (e.g. `filesystem_scm:experimental`). It will allow downloading only particular plugins from the experimental update center without impacting transient dependencies download

- [x] Add `JENKINS_UC_EXPERIMENTAL`
- [x] Document the new option and the update center usage specifics in README

Closes #538

@reviewbybees @ndeloof @carlossg 