### PR TITLE
Execute script pre-boot of Jenkins

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,7 @@
 #! /bin/bash -e
 
+[ -x '/usr/share/jenkins/preboot.sh' ] && /usr/share/jenkins/preboot.sh
+
 : "${JENKINS_HOME:="/var/jenkins_home"}"
 touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"


### PR DESCRIPTION
This supports executing a script, if it exists, before Jenkins starts up.  An example could be preparing a `$JENKINS_HOME` before booting.

fixes #446