### PR TITLE
Issue #559 - Do not reinstall already installed plugins

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -111,7 +111,7 @@ resolveDependencies() {
             echo "Skipping optional dependency $plugin"
         else
             local pluginInstalled
-            if pluginInstalled="$(echo "${bundledPlugins}" | grep "^${plugin}:")"; then
+            if pluginInstalled="$(echo -e "${bundledPlugins}\n${installedPlugins}" | grep "^${plugin}:")"; then
                 pluginInstalled="${pluginInstalled//[$'\r']}"
                 local versionInstalled; versionInstalled=$(versionFromPlugin "${pluginInstalled}")
                 local minVersion; minVersion=$(versionFromPlugin "${d}")
@@ -119,7 +119,7 @@ resolveDependencies() {
                     echo "Upgrading bundled dependency $d ($minVersion > $versionInstalled)"
                     download "$plugin" &
                 else
-                    echo "Skipping already bundled dependency $d ($minVersion <= $versionInstalled)"
+                    echo "Skipping already installed dependency $d ($minVersion <= $versionInstalled)"
                 fi
             else
                 download "$plugin" &
@@ -205,6 +205,9 @@ main() {
 
     echo "Analyzing war..."
     bundledPlugins="$(bundledPlugins)"
+
+    echo "Registering preinstalled plugins..."
+    installedPlugins="$(installedPlugins)"
 
     # Check if there's a version-specific update center, which is the case for LTS versions
     jenkinsVersion="$(jenkinsMajorMinorVersion)"

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -26,7 +26,7 @@ load test_helpers
 @test "plugins are installed with install-plugins.sh" {
   run docker build -t $SUT_IMAGE-install-plugins $BATS_TEST_DIRNAME/install-plugins
   assert_success
-  refute_line --partial 'Skipping already bundled dependency'
+  refute_line --partial 'Skipping already installed dependency'
   # replace DOS line endings \r\n
   run bash -c "docker run --rm $SUT_IMAGE-install-plugins ls --color=never -1 /var/jenkins_home/plugins | tr -d '\r'"
   assert_success
@@ -55,7 +55,7 @@ load test_helpers
 @test "plugins are installed with install-plugins.sh from a plugins file" {
   run docker build -t $SUT_IMAGE-install-plugins-pluginsfile $BATS_TEST_DIRNAME/install-plugins/pluginsfile
   assert_success
-  refute_line --partial 'Skipping already bundled dependency'
+  refute_line --partial 'Skipping already installed dependency'
   # replace DOS line endings \r\n
   run bash -c "docker run --rm $SUT_IMAGE-install-plugins ls --color=never -1 /var/jenkins_home/plugins | tr -d '\r'"
   assert_success
@@ -85,11 +85,16 @@ load test_helpers
   run docker build -t $SUT_IMAGE-install-plugins-update --no-cache $BATS_TEST_DIRNAME/install-plugins/update
   assert_success
   assert_line "Using provided plugin: ant"
-  refute_line --partial 'Skipping already bundled dependency'
   # replace DOS line endings \r\n
   run bash -c "docker run --rm $SUT_IMAGE-install-plugins-update unzip -p /var/jenkins_home/plugins/maven-plugin.jpi META-INF/MANIFEST.MF | tr -d '\r'"
   assert_success
   assert_line 'Plugin-Version: 2.13'
+}
+
+@test "dependencies are not installed with install-plugins.sh when they already exist" {
+  run docker build -t $SUT_IMAGE-install-plugins-update --no-cache $BATS_TEST_DIRNAME/install-plugins/update
+  assert_success
+  assert_line --partial 'Skipping already installed dependency'
 }
 
 @test "plugins are getting upgraded but not downgraded" {

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -84,17 +84,12 @@ load test_helpers
 @test "plugins are installed with install-plugins.sh even when already exist" {
   run docker build -t $SUT_IMAGE-install-plugins-update --no-cache $BATS_TEST_DIRNAME/install-plugins/update
   assert_success
+  assert_line --partial 'Skipping already installed dependency'
   assert_line "Using provided plugin: ant"
   # replace DOS line endings \r\n
   run bash -c "docker run --rm $SUT_IMAGE-install-plugins-update unzip -p /var/jenkins_home/plugins/maven-plugin.jpi META-INF/MANIFEST.MF | tr -d '\r'"
   assert_success
   assert_line 'Plugin-Version: 2.13'
-}
-
-@test "dependencies are not installed with install-plugins.sh when they already exist" {
-  run docker build -t $SUT_IMAGE-install-plugins-update --no-cache $BATS_TEST_DIRNAME/install-plugins/update
-  assert_success
-  assert_line --partial 'Skipping already installed dependency'
 }
 
 @test "plugins are getting upgraded but not downgraded" {

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -84,7 +84,7 @@ load test_helpers
 @test "plugins are installed with install-plugins.sh even when already exist" {
   run docker build -t $SUT_IMAGE-install-plugins-update --no-cache $BATS_TEST_DIRNAME/install-plugins/update
   assert_success
-  assert_line --partial 'Skipping already installed dependency'
+  assert_line --partial 'Skipping already installed dependency javadoc'
   assert_line "Using provided plugin: ant"
   # replace DOS line endings \r\n
   run bash -c "docker run --rm $SUT_IMAGE-install-plugins-update unzip -p /var/jenkins_home/plugins/maven-plugin.jpi META-INF/MANIFEST.MF | tr -d '\r'"


### PR DESCRIPTION
This enhances downloading plugins when using a docker image that already has some pre-installed plugins.

Related: #559