### PR TITLE
Update JDK and Alpine version

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM openjdk:8u121-jdk-alpine
+FROM openjdk:8u131-jdk-alpine
 
 RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils
 


### PR DESCRIPTION
Requirement is to install Ansible 2.3 (which has lots of updates) on Jenkins. Unfortunately Alping 3.5.x does not support Ansible 2.3