### PR TITLE
add version in resolveDependencies function, fixes download latest ve…

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -107,6 +107,7 @@ resolveDependencies() {
     for d in "${array[@]}"
     do
         plugin="$(cut -d':' -f1 - <<< "$d")"
+        version="$(cut -d':' -f2 - <<< "$d")"
         if [[ $d == *"resolution:=optional"* ]]; then
             echo "Skipping optional dependency $plugin"
         else
@@ -122,7 +123,7 @@ resolveDependencies() {
                     echo "Skipping already bundled dependency $d ($minVersion <= $versionInstalled)"
                 fi
             else
-                download "$plugin" &
+                download "$plugin" "$version" &
             fi
         fi
     done


### PR DESCRIPTION
we use script to install the workflow-job plugin
```
install-plugin.sh workflow-job
```
workflow-job depends on workflow-api:2.15,mailer:2.10,workflow-support:2.14

we hope downloaded mailer:2.10

but,
```
Downloading plugin: mailer from https://updates.jenkins-ci.org/download/plugins/mailer/latest/mailer.hpi
```
