### PR TITLE
-Duser.home=$JENKINS_HOME

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -19,7 +19,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     jenkins_opts_array+=( "$item" )
   done < <([[ $JENKINS_OPTS ]] && xargs printf '%s\0' <<<"$JENKINS_OPTS")
 
-  exec java "${java_opts_array[@]}" -jar /usr/share/jenkins/jenkins.war "${jenkins_opts_array[@]}" "$@"
+  exec java -Duser.home="$JENKINS_HOME" "${java_opts_array[@]}" -jar /usr/share/jenkins/jenkins.war "${jenkins_opts_array[@]}" "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for example a `bash` shell to explore this image


### PR DESCRIPTION
Works around [JENKINS-45755](https://issues.jenkins-ci.org/browse/JENKINS-45755), regardless of when https://github.com/jenkinsci/remoting/pull/197 is delivered. Otherwise [you get junk](https://stackoverflow.com/q/1503284/12916) if your UID is not right.

@reviewbybees esp. @oleg-nenashev & @carlossg