### PR TITLE
[BUG] build do not fail when cleaning up but there is no lock files

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -241,7 +241,7 @@ main() {
     fi
 
     echo "Cleaning up locks"
-    find . -iregex "$REF_DIR/.*.lock" | while read -r filepath; do
+    find "$REF_DIR" -regex ".*.lock" | while read -r filepath; do
         rm -r "$filepath"
     done
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -241,7 +241,10 @@ main() {
     fi
 
     echo "Cleaning up locks"
-    rm -rf "$REF_DIR"/*.lock
+    find . -iregex "$REF_DIR/.*.lock" | while read filepath; do
+        rm -r "$filepath"
+    done
+
 }
 
 main "$@"

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -241,7 +241,7 @@ main() {
     fi
 
     echo "Cleaning up locks"
-    rm -r "$REF_DIR"/*.lock
+    rm -rf "$REF_DIR"/*.lock
 }
 
 main "$@"

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -241,7 +241,7 @@ main() {
     fi
 
     echo "Cleaning up locks"
-    find . -iregex "$REF_DIR/.*.lock" | while read filepath; do
+    find . -iregex "$REF_DIR/.*.lock" | while read -r filepath; do
         rm -r "$filepath"
     done
 


### PR DESCRIPTION
Hello there,

The build fails when there is no plugins, because install-plugins.sh tries to `rm` lock files without `-f`.
This commit adds the `-f` option to the `rm` of "Cleaning up locks", allowing the script to finish gracefully.

Happy Hacktoberfest !