### PR TITLE
Consider non empty last line of plugins.txt

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -190,7 +190,7 @@ main() {
 
     # Read plugins from stdin or from the command line arguments
     if [[ ($# -eq 0) ]]; then
-        while read -r line; do
+        while read -r line || [ "$line" != "" ]; do
             plugins+=("${line}")
         done
     else


### PR DESCRIPTION
Hello,

Previous code version does not consider last line content.
Example:
```
A
B
C[EOF]
```
will only consider A and B plugins

This PR takes the last line content, "C" in the example, as a plugin too.

Regards,

Clotilde