### PR TITLE
Run this every six hours

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,8 @@
 #!/usr/bin/env groovy
 
 properties([
-    buildDiscarder(logRotator(numToKeepStr: '5', artifactNumToKeepStr: '5')),
-    pipelineTriggers([cron('@daily')]),
+    buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '5')),
+    pipelineTriggers([cron('H/6 * * * *')]),
 ])
 
 node('docker') {


### PR DESCRIPTION
Given how release timing works out, the containers are usually about a full day late with a daily schedule. Instead, let's build this every six hours. Since the "no op" build that only determines that containers exist and updates 'latest' tags takes just 1-2 minutes, it should be safe enough to run that more regularly.

Additionally, since build records for this are fairly lightweight (logs are short enough to not be truncated on the UI even with a container build running), archive more of them to assist in any troubleshooting.