### PR TITLE
Persist the permissions of the source file when copying overrides.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.tmp
+bats/
+tests/functions/init.groovy.d/
+tests/functions/copy_reference_file.log

--- a/jenkins-support
+++ b/jenkins-support
@@ -98,7 +98,7 @@ copy_reference_file() {
             action=${action:-"INSTALLED"}
             log=true
             mkdir -p "$JENKINS_HOME/${dir:23}"
-            cp -r "${f}" "$JENKINS_HOME/${rel}";
+            cp -pr "${f}" "$JENKINS_HOME/${rel}";
             # pin plugins on initial copy
             touch "$JENKINS_HOME/${rel}.pinned"
             echo "$image_version" > "$JENKINS_HOME/${version_marker}"
@@ -112,7 +112,7 @@ copy_reference_file() {
             action="INSTALLED"
             log=true
             mkdir -p "$JENKINS_HOME/${dir:23}"
-            cp -r "${f}" "$JENKINS_HOME/${rel}";
+            cp -pr "${f}" "$JENKINS_HOME/${rel}";
         else
             action="SKIPPED"
         fi

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -29,3 +29,13 @@ SUT_IMAGE=$(sut_image)
   run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 1.0-beta-1 1.0-alpha-1"
   assert_failure
 }
+
+@test "permissions are propagated from override file" {
+  run docker_build_child $SUT_IMAGE-functions $BATS_TEST_DIRNAME/functions
+  assert_success
+
+  # replace DOS line endings \r\n
+  run bash -c "docker run -v $BATS_TEST_DIRNAME/functions:/var/jenkins_home --rm $SUT_IMAGE-functions stat -c '%a' /var/jenkins_home/.ssh/config"
+  assert_success
+  assert_line '600'
+}

--- a/tests/functions/Dockerfile
+++ b/tests/functions/Dockerfile
@@ -1,0 +1,4 @@
+FROM bats-jenkins
+
+RUN mkdir -p /usr/share/jenkins/ref/.ssh && touch /usr/share/jenkins/ref/.ssh/config.override
+RUN chmod 600 /usr/share/jenkins/ref/.ssh/config.override


### PR DESCRIPTION
If, for whatever reason, a file has been created on the Jenkins home
volume with the wrong permissions (eg. ssh config/keys etc) then it is
currently impossible to override those permissions without going into
the volume and manually editing them.

This change updates the `copy_reference_file` function to use `cp -p`,
which preserves mode, ownership and timestamps of the source files
instead of the destination file being overwritten.