### PR TITLE
Use the 8-jre-alpine image for smaller downloads

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jre-alpine
 
 RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils tini
 


### PR DESCRIPTION
I have been doing some testing with a Dockerized master built off of OpenJDK 8
JRE rather than the JDK, and haven't found any issues. This saves almost 20MB
off the download which is IMHO worth it.

    jenkins/jenkins                              8-jre               583c435f816c        6 minutes ago       200MB
    jenkins/jenkins                              8-jdk               cc1259cdb95e        9 minutes ago       219MB