### PR TITLE
Allow specifying a different jenkins.war via the JENKINS_WAR env variable

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,5 +1,6 @@
 #! /bin/bash -e
 
+: "${JENKINS_WAR:="/usr/share/jenkins/jenkins.war"}"
 : "${JENKINS_HOME:="/var/jenkins_home"}"
 touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
@@ -19,7 +20,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     jenkins_opts_array+=( "$item" )
   done < <([[ $JENKINS_OPTS ]] && xargs printf '%s\0' <<<"$JENKINS_OPTS")
 
-  exec java -Duser.home="$JENKINS_HOME" "${java_opts_array[@]}" -jar /usr/share/jenkins/jenkins.war "${jenkins_opts_array[@]}" "$@"
+  exec java -Duser.home="$JENKINS_HOME" "${java_opts_array[@]}" -jar ${JENKINS_WAR} "${jenkins_opts_array[@]}" "$@"
 fi
 
 # As argument is not jenkins, assume user want to run his own process, for example a `bash` shell to explore this image


### PR DESCRIPTION
This allows some re-use of this script in situations where one might have a
jenkins.war coming out of JENKINS_HOME, like the use-case I have for Jenkins
Essentials.

Rather than fork this script, it seemed reasonable to allow this extra little
bit of variability in jenkins.sh