### PR TITLE
Fix #629: add a shim for tini under /bin/tini

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,7 @@ USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support
 COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY tini-shim.sh /bin/tini
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -60,6 +60,7 @@ USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support
 COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY tini-shim.sh /bin/tini
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -70,6 +70,7 @@ USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support
 COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY tini-shim.sh /bin/tini
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # from a derived Dockerfile, can use `RUN plugins.sh active.txt` to setup /usr/share/jenkins/ref/plugins from a support bundle

--- a/tini-shim.sh
+++ b/tini-shim.sh
@@ -2,9 +2,12 @@
 set -euo pipefail
 
 cat <<EOF
-Please update your scripts to use /sbin/tini going forward.
-Previous path has been preserved for backwards compatibility in Alpine 3.4,
-but WILL BE REMOVED in Alpine 3.5. (or Jenkins 2.107.1 or something like this for our case)
+***************************************************************************
+* WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING WARNING *
+***************************************************************************
+Please update your scripts to use /sbin/tini or simply tini going forward.
+Previous path has been preserved for backwards compatibility,
+but WILL BE REMOVED in the future. (around Jenkins >= 2.107.2+)
 
 Now sleeping 2 minutes...
 EOF

--- a/tini-shim.sh
+++ b/tini-shim.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+set -euo pipefail
+
+cat <<EOF
+Please update your scripts to use /sbin/tini going forward.
+Previous path has been preserved for backwards compatibility in Alpine 3.4,
+but WILL BE REMOVED in Alpine 3.5. (or Jenkins 2.107.1 or something like this for our case)
+
+Now sleeping 2 minutes...
+EOF
+
+sleep 120
+
+exec tini "$@"


### PR DESCRIPTION
Follow up of the discussion/proposal on https://github.com/jenkinsci/docker/issues/629#issuecomment-366198079

```shell
$  docker run -ti local-test-image /bin/tini
Please update your scripts to use /sbin/tini going forward.
Previous path has been preserved for backwards compatibility in Alpine 3.4,
but WILL BE REMOVED in Alpine 3.5. (or Jenkins 2.107.1 or something like this for our case)

Now sleeping 2 minutes...
tini (tini version 0.16.1)
Usage: tini [OPTIONS] PROGRAM -- [ARGS] | --version

Execute a program under the supervision of a valid init process (tini)

Command line options:

  --version: Show version and exit.
  -h: Show this help message and exit.
  -s: Register as a process subreaper (requires Linux >= 3.4).
  -v: Generate more verbose output. Repeat up to 3 times.
  -g: Send signals to the child's process group.
  -l: Show license and exit.

Environment variables:

  TINI_SUBREAPER: Register as a process subreaper (requires Linux >= 3.4)
  TINI_VERBOSITY: Set the verbosity level (default: 1)
```