### PR TITLE
provide a way to build multiple arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM openjdk:8-jdk
+ARG ARCH_PREFIX
+FROM ${ARCH_PREFIX}openjdk:8-jdk
 
 RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ node('docker') {
         stage('Build') {
             docker.build('jenkins')
             docker.build('jenkins:alpine', '--file Dockerfile-alpine .')
+            docker.build('arm32v7/jenkins','--build-arg ARCH_PREFIX=arm32v7/')
         }
 
         stage('Test') {


### PR DESCRIPTION
Would like to create an official Jenkins container that could be ran on a raspberrypi or other arch. 
I thought that this could be a first step, but don't know how the tag should be manage in the publishing workflow. 

(Not sure: is this the right place to do so ?)