### PR TITLE
Disable assistive technologies in Dockerfile-slim

### DIFF
--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -6,7 +6,8 @@ RUN apt-get update && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lis
 # JFreeChart initialization fails unless assistive technologies are disabled.
 # Broken JFreeChart causes failures rendering trend graphs.
 # Seems like a configuration error in openjdk:8-jdk-slim, headless JDK inconsistent with assistive technologies.
-# Upstream pull request: https://github.com/docker-library/openjdk/pull/189
+# Upstream OpenJDK pull request: https://github.com/docker-library/openjdk/pull/189
+# Upstream Debian slim bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896907
 RUN sed -i 's/assistive_technologies=.*/assistive_technologies=/g' /etc/java-8-openjdk/accessibility.properties
 
 ARG user=jenkins

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lis
 # JFreeChart initialization fails unless assistive technologies are disabled.
 # Broken JFreeChart causes failures rendering trend graphs.
 # Seems like a configuration error in openjdk:8-jdk-slim, headless JDK inconsistent with assistive technologies.
+# Upstream pull request: https://github.com/docker-library/openjdk/pull/189
 RUN sed -i 's/assistive_technologies=.*/assistive_technologies=/g' /etc/java-8-openjdk/accessibility.properties
 
 ARG user=jenkins

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -2,6 +2,12 @@ FROM openjdk:8-jdk-slim
 
 RUN apt-get update && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
 
+# Disable assistive technologies since openjdk:slim installs headless JDK (without assistive technologies).
+# JFreeChart initialization fails unless assistive technologies are disabled.
+# Broken JFreeChart causes failures rendering trend graphs.
+# Seems like a configuration error in openjdk:8-jdk-slim, headless JDK inconsistent with assistive technologies.
+RUN sed -i 's/assistive_technologies=.*/assistive_technologies=/g' /etc/java-8-openjdk/accessibility.properties
+
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000


### PR DESCRIPTION
Fix issue #630 - Disable assistive technologies in the Dockerfile-slim image since openjdk:slim installs headless JDK (without assistive technologies).  JFreeChart initialization fails unless assistive technologies are disabled.  When JFreeChart initialization fails, trend graphs and other graphs do not render.

Seems like a configuration error in openjdk:8-jdk-slim, installing a headless JDK inconsistent but then configuring assistive technologies (which are not available with a headless JDK).

See https://hub.docker.com/_/openjdk/ where it says:

openjdk:slim

This image installs the -headless package of OpenJDK and so is missing many of the UI-related Java libraries and some common packages contained in the default tag. It only contains the minimal packages needed to run Java.