### PR TITLE
Download the declared dependency version, rather than latest

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -107,6 +107,7 @@ resolveDependencies() {
     for d in "${array[@]}"
     do
         plugin="$(cut -d':' -f1 - <<< "$d")"
+        plugin_version="$(cut -d':' -f2 - <<< "$d")"
         if [[ $d == *"resolution:=optional"* ]]; then
             echo "Skipping optional dependency $plugin"
         else
@@ -117,12 +118,12 @@ resolveDependencies() {
                 local minVersion; minVersion=$(versionFromPlugin "${d}")
                 if versionLT "${versionInstalled}" "${minVersion}"; then
                     echo "Upgrading bundled dependency $d ($minVersion > $versionInstalled)"
-                    download "$plugin" &
+                    download "$plugin" $plugin_version &
                 else
                     echo "Skipping already installed dependency $d ($minVersion <= $versionInstalled)"
                 fi
             else
-                download "$plugin" &
+                download "$plugin" $plugin_version &
             fi
         fi
     done

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -118,12 +118,12 @@ resolveDependencies() {
                 local minVersion; minVersion=$(versionFromPlugin "${d}")
                 if versionLT "${versionInstalled}" "${minVersion}"; then
                     echo "Upgrading bundled dependency $d ($minVersion > $versionInstalled)"
-                    download "$plugin" $plugin_version &
+                    download "$plugin" "$plugin_version" &
                 else
                     echo "Skipping already installed dependency $d ($minVersion <= $versionInstalled)"
                 fi
             else
-                download "$plugin" $plugin_version &
+                download "$plugin" "$plugin_version" &
             fi
         fi
     done


### PR DESCRIPTION
We found this change useful. Maybe it should be the default, as it is confusing otherwise when configuring JENKINS_UC_DOWNLOAD that many of the plugins are attempted to be loaded from another location.