### PR TITLE
Simplify debugging of Jenkins master within Docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,12 @@ Tests are written using [bats](https://github.com/sstephenson/bats) under the `t
 
 Bats can be easily installed with `brew install bats` on OS X
 
+# Debugging
+
+In order to debug the master, use the `-e DEBUG=true -p 5005:5005` when starting the container. 
+Jenkins will be suspended on the startup in such case,
+and then it will be possible to attach a debugger from IDE to it.
+
 # Questions?
 
 Jump on irc.freenode.net and the #jenkins room. Ask!

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -15,6 +15,13 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     java_opts_array+=( "$item" )
   done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
 
+  if [[ "$DEBUG" ]] ; then
+    java_opts_array+=( \
+      '-Xdebug' \
+      '-Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=y' \
+    )
+  fi
+
   jenkins_opts_array=( )
   while IFS= read -r -d '' item; do
     jenkins_opts_array+=( "$item" )


### PR DESCRIPTION
I would like to upstream some code from https://github.com/oleg-nenashev/demo-jenkins-config-as-code and https://github.com/jenkinsci/jenkins/pull/3492.

I debug Jenkins a lot, and it would be helpful to simplify debugging for developers who do not want to copy-paste debug options every time.

