### PR TITLE
[JENKINS-52028] - Support downloading plugins from the Incrementals repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,6 +59,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
 
 ENV JENKINS_UC https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
+ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref
 
 # for main web interface:

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ During the download, the script will use update centers defined by the following
 * `JENKINS_UC_EXPERIMENTAL` - [Experimental Update Center](https://jenkins.io/blog/2013/09/23/experimental-plugins-update-center/).
   This center offers Alpha and Beta versions of plugins.
   Default value: https://updates.jenkins.io/experimental
+* `JENKINS_INCREMENTALS_REPO_MIRROR` -
+  Defines Maven mirror to be used to download plugins from the
+  [Incrementals repo](https://jenkins.io/blog/2018/05/15/incremental-deployment/).
+  Default value: https://repo.jenkins-ci.org/incrementals
 
 It is possible to override the environment variables in images.
 
@@ -179,6 +183,11 @@ There are also custom version specifiers:
   For Jenkins LTS images
   (example: `git:latest`)
 * `experimental` - download the latest version from the experimental update center defined by the `JENKINS_UC_EXPERIMENTAL` environment variable (example: `filesystem_scm:experimental`)
+* `incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74`
+- download the plugin from the [Incrementals repo](https://jenkins.io/blog/2018/05/15/incremental-deployment/).
+  * For this option you need to specify `groupId` of the plugin.
+    Note that this value may change between plugin versions without notice.
+
 
 ### Script usage
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -69,6 +69,14 @@ doDownload() {
     elif [[ "$version" == "experimental" && -n "$JENKINS_UC_EXPERIMENTAL" ]]; then
         # Download from the experimental update center
         url="$JENKINS_UC_EXPERIMENTAL/latest/${plugin}.hpi"
+    elif [[ "$version" == incrementals* ]] ; then
+        # Download from Incrementals repo: https://jenkins.io/blog/2018/05/15/incremental-deployment/
+        # Example URL: https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc289.d09828a05a74/workflow-support-2.19-rc289.d09828a05a74.hpi
+        local groupId incrementalsVersion
+        arrIN=(${version//;/ })
+        groupId=${arrIN[1]}
+        incrementalsVersion=${arrIN[2]}
+        url="${JENKINS_INCREMENTALS_REPO_MIRROR}/$(echo "${groupId}" | tr '.' '/')/${plugin}/${incrementalsVersion}/${plugin}-${incrementalsVersion}.hpi"
     else
         JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
         url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"

--- a/tests/install-plugins/pluginsfile/plugins.txt
+++ b/tests/install-plugins/pluginsfile/plugins.txt
@@ -19,3 +19,6 @@ filesystem_scm:experimental  # comment at the end
  
     #  
      # empty line
+
+# Incrementals (JENKINS-52028)
+workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74


### PR DESCRIPTION
During the Java 10 hackathon we discovered that we need to apply patches to some plugins, e.g. Pipeline: Support (https://github.com/jenkinsci/workflow-support-plugin/pull/65).

In order to deliver the fixes quickly in our Docker images, we need to be able to install plugins directly from Incrementals. So... here is a patch for it. I submitted it against the master branch since it's generic enough.

After the patch, it will be possible to install plugins via the following string in plugins.txt

```
workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74
```

https://issues.jenkins-ci.org/browse/JENKINS-52028

@carlossg @jglick @svanoort @jenkinsci/java10-support 

Also cc @raul-arabaolaza since it may be interesting to him