### PR TITLE
Update Java 11 experimental image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ RUN mkdir ${JAVA_LIB_DIR} \
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.127}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.128}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=5ab171dc956939e8b43bf81512577a74e540ecd99388e6b51e0b477d1cf2910b
@@ -69,6 +69,7 @@ RUN echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
 
 ENV JENKINS_UC https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
+ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" /usr/share/jenkins/ref
 
 # for main web interface:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ARG JENKINS_VERSION
 ENV JENKINS_VERSION ${JENKINS_VERSION:-2.128}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=5ab171dc956939e8b43bf81512577a74e540ecd99388e6b51e0b477d1cf2910b
+ARG JENKINS_SHA=e9288b78093507953550214c395bb6f1baf7a23c172a6cb9c035e5a7305ae7a2
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/README.md
+++ b/README.md
@@ -163,6 +163,10 @@ During the download, the script will use update centers defined by the following
 * `JENKINS_UC_EXPERIMENTAL` - [Experimental Update Center](https://jenkins.io/blog/2013/09/23/experimental-plugins-update-center/).
   This center offers Alpha and Beta versions of plugins.
   Default value: https://updates.jenkins.io/experimental
+* `JENKINS_INCREMENTALS_REPO_MIRROR` -
+  Defines Maven mirror to be used to download plugins from the
+  [Incrementals repo](https://jenkins.io/blog/2018/05/15/incremental-deployment/).
+  Default value: https://repo.jenkins-ci.org/incrementals
 
 It is possible to override the environment variables in images.
 
@@ -179,6 +183,11 @@ There are also custom version specifiers:
   For Jenkins LTS images
   (example: `git:latest`)
 * `experimental` - download the latest version from the experimental update center defined by the `JENKINS_UC_EXPERIMENTAL` environment variable (example: `filesystem_scm:experimental`)
+* `incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74`
+- download the plugin from the [Incrementals repo](https://jenkins.io/blog/2018/05/15/incremental-deployment/).
+  * For this option you need to specify `groupId` of the plugin.
+    Note that this value may change between plugin versions without notice.
+
 
 ### Script usage
 
@@ -256,6 +265,12 @@ Tests are written using [bats](https://github.com/sstephenson/bats) under the `t
     DOCKERFILE=Dockerfile-alpine bats tests
 
 Bats can be easily installed with `brew install bats` on OS X
+
+# Debugging
+
+In order to debug the master, use the `-e DEBUG=true -p 5005:5005` when starting the container. 
+Jenkins will be suspended on the startup in such case,
+and then it will be possible to attach a debugger from IDE to it.
 
 # Questions?
 

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -69,6 +69,14 @@ doDownload() {
     elif [[ "$version" == "experimental" && -n "$JENKINS_UC_EXPERIMENTAL" ]]; then
         # Download from the experimental update center
         url="$JENKINS_UC_EXPERIMENTAL/latest/${plugin}.hpi"
+    elif [[ "$version" == incrementals* ]] ; then
+        # Download from Incrementals repo: https://jenkins.io/blog/2018/05/15/incremental-deployment/
+        # Example URL: https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc289.d09828a05a74/workflow-support-2.19-rc289.d09828a05a74.hpi
+        local groupId incrementalsVersion
+        arrIN=(${version//;/ })
+        groupId=${arrIN[1]}
+        incrementalsVersion=${arrIN[2]}
+        url="${JENKINS_INCREMENTALS_REPO_MIRROR}/$(echo "${groupId}" | tr '.' '/')/${plugin}/${incrementalsVersion}/${plugin}-${incrementalsVersion}.hpi"
     else
         JENKINS_UC_DOWNLOAD=${JENKINS_UC_DOWNLOAD:-"$JENKINS_UC/download"}
         url="$JENKINS_UC_DOWNLOAD/plugins/$plugin/$version/${plugin}.hpi"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -15,6 +15,13 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     java_opts_array+=( "$item" )
   done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
 
+  if [[ "$DEBUG" ]] ; then
+    java_opts_array+=( \
+      '-Xdebug' \
+      '-Xrunjdwp:server=y,transport=dt_socket,address=5005,suspend=y' \
+    )
+  fi
+
   jenkins_opts_array=( )
   while IFS= read -r -d '' item; do
     jenkins_opts_array+=( "$item" )

--- a/tests/install-plugins/pluginsfile/plugins.txt
+++ b/tests/install-plugins/pluginsfile/plugins.txt
@@ -19,3 +19,6 @@ filesystem_scm:experimental  # comment at the end
  
     #  
      # empty line
+
+# Incrementals (JENKINS-52028)
+workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74


### PR DESCRIPTION
Same as #694 , but for Java 11.

* Add support of experimentals from #693 
* Add support of Debugging
* Bump to the 2.128 baseline

jdk-11-ea+18 has not been pushed to Docker yet, so I cannot verify the theory in [JENKINS-51871](https://issues.jenkins-ci.org/browse/JENKINS-51871).
According to http://jdk.java.net/11/release-notes the build just adds GoDaddy certificates so there should be no relation. CC @dwnusbaum 
