### PR TITLE
link to specific docker hub page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Official Jenkins Docker image
 
-The Jenkins Continuous Integration and Delivery server.
+The Jenkins Continuous Integration and Delivery server [available on Docker Hub](https://hub.docker.com/r/jenkins/jenkins).
 
 This is a fully functional Jenkins server.
 [https://jenkins.io/](https://jenkins.io/).


### PR DESCRIPTION
Often when I end up here, I want to glance at the official docker hub page. Hope this is OK - open to rewording or moving this link somewhere else (even at the bottom of the readme).