### PR TITLE
Added new common usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ this will automatically create a 'jenkins_home' [docker volume](https://docs.doc
 
 NOTE: Avoid using a [bind mount](https://docs.docker.com/storage/bind-mounts/) from a folder on the host machine into `/var/jenkins_home`, as this might result in file permission issues (the user used inside the container might not have rights to the folder on the host machine). If you _really_ need to bind mount jenkins_home, ensure that the directory on the host is accessible by the jenkins user inside the container (jenkins user - uid 1000) or use `-u some_other_user` parameter with `docker run`.
 
+```
+docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts
+```
+
+this will run Jenkins in detached mode with port forwarding and volume added. You can access logs with command 'docker logs CONTAINER_ID' in order to check first login token. ID of container will be returned from output of command above. 
+
 ## Backing up data
 
 If you bind mount in a volume - you can simply back up that directory


### PR DESCRIPTION
Usually when experienced user check for this page - he will copy and paste command in terminal. Container from first command is running without detached mode, so control-c is killing it. Of course you can start it with docker start, but with that you can just start work with it.