### PR TITLE
Fix failure loop if installing plugins fails

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -195,7 +195,7 @@ main() {
     local plugins=()
 
     mkdir -p "$REF_DIR" || exit 1
-    rm -f $FAILED
+    rm -f "$FAILED"
 
     # Read plugins from stdin or from the command line arguments
     if [[ ($# -eq 0) ]]; then

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -195,6 +195,7 @@ main() {
     local plugins=()
 
     mkdir -p "$REF_DIR" || exit 1
+    rm -f $FAILED
 
     # Read plugins from stdin or from the command line arguments
     if [[ ($# -eq 0) ]]; then


### PR DESCRIPTION
`install-plugins.sh` detects failures by checking for the presence of "$REF_DIR/failed-plugins.txt". However failed-plugins.txt is not deleted when the script starts, so errors in a prior run will cause all future runs to fail. This can cause a jenkins master provisioned by the [jenkins helm chart](https://github.com/helm/charts/tree/master/stable/jenkins) to get stuck in a failure loop as follows:

1. A new jenkins master pod is created.
2. The master pod's init container runs `install-plugins.sh`, which fails due to a transient error.
3. Kubernetes backs off and restarts the init container.
4. `install-plugins.sh` successfully downloads all requested plugins, but exits with an error because failed-plugins.txt is still present.
5. Repeat steps 3 and 4 ad nauseam. Since the init container has not completed successfully the jenkins master never starts up.