### PR TITLE
fix support for paths containing spaces

### DIFF
--- a/jenkins-support
+++ b/jenkins-support
@@ -112,7 +112,7 @@ copy_reference_file() {
             action="INSTALLED"
             log=true
             mkdir -p "$JENKINS_HOME/${dir:23}"
-            cp -pr "$(realpath ${f})" "$JENKINS_HOME/${rel}";
+            cp -pr "$(realpath "${f}")" "$JENKINS_HOME/${rel}";
         else
             action="SKIPPED"
         fi


### PR DESCRIPTION
fixes an issue caused by #722 
since the 'ref' folder might contain other folders such as a 'job' folder which might contain job names with spaces in them