### PR TITLE
WIP Update shellcheck to v0.5.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node('docker') {
 
         stage('shellcheck') {
             // newer versions of the image don't have cat installed and docker pipeline fails
-            docker.image('koalaman/shellcheck:v0.4.7').inside('--entrypoint=') {
+            docker.image('koalaman/shellcheck:v0.5.0').inside('--entrypoint=') {
                 // run shellcheck ignoring error SC1091
                 // Not following: /usr/local/bin/jenkins-support was not specified as input
                 sh "shellcheck -e SC1091 *.sh"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ node('docker') {
 
         stage('shellcheck') {
             // newer versions of the image don't have cat installed and docker pipeline fails
-            docker.image('koalaman/shellcheck:v0.4.6').inside('--entrypoint=') {
+            docker.image('koalaman/shellcheck:v0.4.7').inside('--entrypoint=') {
                 // run shellcheck ignoring error SC1091
                 // Not following: /usr/local/bin/jenkins-support was not specified as input
                 sh "shellcheck -e SC1091 *.sh"


### PR DESCRIPTION
I'm seeing a failure locally I do not see in CI, but I'm using 0.4.7, and CI is using 0.4.6. So taking this PR as an opportunity to 1) fix/understand this and 2) bump to latest shellcheck (available Docker image tag)