### PR TITLE
Convert from docker.inside to a local docker wrapper shell script and update shellcheck

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,12 +17,9 @@ node('docker') {
     if (!infra.isTrusted()) {
 
         stage('shellcheck') {
-            // newer versions of the image don't have cat installed and docker pipeline fails
-            docker.image('koalaman/shellcheck:v0.4.6').inside('--entrypoint=') {
-                // run shellcheck ignoring error SC1091
-                // Not following: /usr/local/bin/jenkins-support was not specified as input
-                sh "shellcheck -e SC1091 *.sh"
-            }
+            // run shellcheck ignoring error SC1091
+            // Not following: /usr/local/bin/jenkins-support was not specified as input
+            sh 'make shellcheck'
         }
 
         /* Outside of the trusted.ci environment, we're building and testing

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+ROOT_DIR="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/"
+
+shellcheck:
+	$(ROOT_DIR)/tools/shellcheck -e SC1091 *.sh
+
+.PHONY: shellcheck

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ROOT_DIR="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/"
 
 shellcheck:
-	$(ROOT_DIR)/tools/shellcheck -e SC1091 *.sh
+	$(ROOT_DIR)/tools/shellcheck -e SC1091 -e SC1117 *.sh
 
 .PHONY: shellcheck

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 ROOT_DIR="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/"
 
 shellcheck:
-	$(ROOT_DIR)/tools/shellcheck -e SC1091 -e SC1117 *.sh
+	# TODO: remove SC1117 exclusion when on shellcheck > 0.5.0
+	$(ROOT_DIR)/tools/shellcheck -e SC1091 \
+	                             -e SC1117 \
+	                             *.sh
 
 .PHONY: shellcheck

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -73,7 +73,7 @@ doDownload() {
         # Download from Incrementals repo: https://jenkins.io/blog/2018/05/15/incremental-deployment/
         # Example URL: https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/plugins/workflow/workflow-support/2.19-rc289.d09828a05a74/workflow-support-2.19-rc289.d09828a05a74.hpi
         local groupId incrementalsVersion
-        arrIN=(${version//;/ })
+        arrIN=("${version//;/ }")
         groupId=${arrIN[1]}
         incrementalsVersion=${arrIN[2]}
         url="${JENKINS_INCREMENTALS_REPO_MIRROR}/$(echo "${groupId}" | tr '.' '/')/${plugin}/${incrementalsVersion}/${plugin}-${incrementalsVersion}.hpi"

--- a/tools/shellcheck
+++ b/tools/shellcheck
@@ -3,4 +3,4 @@
 exec docker run --rm \
     -w "${PWD}" \
     -v "${PWD}:${PWD}" \
-    koalaman/shellcheck:v0.4.7 $@
+    koalaman/shellcheck:v0.5.0 $@

--- a/tools/shellcheck
+++ b/tools/shellcheck
@@ -3,4 +3,4 @@
 exec docker run --rm \
     -w "${PWD}" \
     -v "${PWD}:${PWD}" \
-    koalaman/shellcheck:v0.4.6 $@
+    koalaman/shellcheck:v0.4.7 $@

--- a/tools/shellcheck
+++ b/tools/shellcheck
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+exec docker run --rm \
+    -w "${PWD}" \
+    -v "${PWD}:${PWD}" \
+    koalaman/shellcheck:v0.4.6 $@


### PR DESCRIPTION
This makes it easy for anyone to use this locally as it would behave in CI.
The first commit does *not* change the shellcheck version in use, hence does (should?) not require any content change in the shell scripts.

This change will also allow upgrading `shellcheck` to latest.