### PR TITLE
Also check the jenkins-support file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ shellcheck:
 	# TODO: remove SC1117 exclusion when on shellcheck > 0.5.0
 	$(ROOT_DIR)/tools/shellcheck -e SC1091 \
 	                             -e SC1117 \
+	                             jenkins-support \
 	                             *.sh
 
 .PHONY: shellcheck

--- a/jenkins-support
+++ b/jenkins-support
@@ -112,7 +112,7 @@ copy_reference_file() {
             action="INSTALLED"
             log=true
             mkdir -p "$JENKINS_HOME/${dir:23}"
-            cp -pr "$(realpath ${f})" "$JENKINS_HOME/${rel}";
+            cp -pr "$(realpath "${f}")" "$JENKINS_HOME/${rel}";
         else
             action="SKIPPED"
         fi
@@ -140,7 +140,7 @@ function retry_command() {
   local success_attempt=0
   local exitCode=0
 
-  while (( $attempt < $max_attempts ))
+  while (( attempt < max_attempts ))
   do
     set +e
     "$@"
@@ -150,17 +150,17 @@ function retry_command() {
     if [[ $exitCode == 0 ]]
     then
       success_attempt=$(( success_attempt + 1 ))
-      if (( $success_attempt >= $max_success_attempt))
+      if (( success_attempt >= max_success_attempt))
       then
         break
       else
-        sleep $success_timeout
+        sleep "$success_timeout"
         continue
       fi
     fi
 
     echo "$(date -u '+%T') Failure ($exitCode) Retrying in $timeout seconds..." 1>&2
-    sleep $timeout
+    sleep "$timeout"
     success_attempt=0
     attempt=$(( attempt + 1 ))
     timeout=$(( timeout ))
@@ -168,7 +168,7 @@ function retry_command() {
 
   if [[ $exitCode != 0 ]]
   then
-    echo "$(date -u '+%T') Failed in the last attempt ($@)" 1>&2
+    echo "$(date -u '+%T') Failed in the last attempt ($*)" 1>&2
   fi
 
   return $exitCode


### PR DESCRIPTION
*.sh is already scanned, so `jenkins-support` was not scanned until now. This PR adds this file and fixes violations.

Before fixing:

```
make shellcheck                                                                                                                                                               b3ec1e2 
# TODO: remove SC1117 exclusion when on shellcheck > 0.5.0
"/home/tiste/dev/github/jenkinsci/docker/"/tools/shellcheck -e SC1091 \
                             -e SC1117 \
                             jenkins-support \
                             *.sh

In jenkins-support line 115:
            cp -pr "$(realpath ${f})" "$JENKINS_HOME/${rel}";
                               ^-- SC2086: Double quote to prevent globbing and word splitting.


In jenkins-support line 143:
  while (( $attempt < $max_attempts ))
           ^-- SC2004: $/${} is unnecessary on arithmetic variables.
                      ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In jenkins-support line 153:
      if (( $success_attempt >= $max_success_attempt))
            ^-- SC2004: $/${} is unnecessary on arithmetic variables.
                                ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In jenkins-support line 157:
        sleep $success_timeout
              ^-- SC2086: Double quote to prevent globbing and word splitting.


In jenkins-support line 163:
    sleep $timeout
          ^-- SC2086: Double quote to prevent globbing and word splitting.


In jenkins-support line 171:
    echo "$(date -u '+%T') Failed in the last attempt ($@)" 1>&2
                                                       ^-- SC2145: Argument mixes string and array. Use * or separate argument.

make: *** [Makefile:5: shellcheck] Error 1
```