### PR TITLE
[JENKINS-51985] add jdk11 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.tmp
 bats/
 tests/functions/init.groovy.d/
+tests/functions/java_cp/
 tests/functions/copy_reference_file.log
 manifest-tool
 multiarch/qemu-*

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -83,7 +83,7 @@ ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support
-COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY jenkins-jdk11.sh /usr/local/bin/jenkins.sh
 COPY tini-shim.sh /bin/tini
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,9 +54,7 @@ node('docker') {
          */
         stage('Publish') {
             infra.withDockerCredentials {
-                sh './publish.sh'
-                sh './publish.sh --variant alpine'
-                sh './publish.sh --variant slim'
+                sh 'make publish'
             }
         }
     }

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,11 @@ test-jdk11: prepare-test
 
 test: test-debian test-alpine test-slim test-jdk11
 
+publish:
+	./publish.sh' ; \
+	sh './publish.sh --variant alpine' ; \
+	sh './publish.sh --variant slim'
+
 clean:
 	rm -rf tests/test_helper/bats-*; \
 	rm -rf bats

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ shellcheck:
 	                             jenkins-support \
 	                             *.sh
 
-build: build-debian build-alpine build-slim
+build: build-debian build-alpine build-slim build-jdk11
 
 build-debian:
 	docker build --file Dockerfile .
@@ -19,6 +19,9 @@ build-alpine:
 
 build-slim:
 	docker build --file Dockerfile-slim .
+
+build-jdk11:
+	docker build --file Dockerfile-jdk11 .
 
 bats:
 	git clone https://github.com/sstephenson/bats.git
@@ -35,7 +38,10 @@ test-alpine: prepare-test
 test-slim: prepare-test
 	DOCKERFILE=Dockerfile-slim bats/bin/bats tests
 
-test: test-debian test-alpine test-slim
+test-jdk11: prepare-test
+	DOCKERFILE=Dockerfile-jdk11 bats/bin/bats tests
+
+test: test-debian test-alpine test-slim test-jdk11
 
 clean:
 	rm -rf tests/test_helper/bats-*; \

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ test: test-debian test-alpine test-slim test-jdk11
 publish:
 	./publish.sh' ; \
 	sh './publish.sh --variant alpine' ; \
-	sh './publish.sh --variant slim'
+	sh './publish.sh --variant slim' ; \
+	sh './publish.sh --variant jdk11' ; \
 
 clean:
 	rm -rf tests/test_helper/bats-*; \

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -180,7 +180,7 @@ jenkinsMajorMinorVersion() {
     JENKINS_WAR=/usr/share/jenkins/jenkins.war
     if [[ -f "$JENKINS_WAR" ]]; then
         local version major minor
-        version="$(java -jar /usr/share/jenkins/jenkins.war --version)"
+        version="$(java -jar $JENKINS_WAR --version)"
         major="$(echo "$version" | cut -d '.' -f 1)"
         minor="$(echo "$version" | cut -d '.' -f 2)"
         echo "$major.$minor"

--- a/publish.sh
+++ b/publish.sh
@@ -1,11 +1,20 @@
 #!/bin/bash -eu
 
-# Publish any versions of the docker image not yet pushed to jenkins/jenkins
+# Publish any versions of the docker image not yet pushed to ${JENKINS_REPO}
 # Arguments:
 #   -n dry run, do not build or publish images
 #   -d debug
 
 set -o pipefail
+
+: "${JENKINS_REPO:=jenkins/jenkins}"
+: "${JENKINSCI_REPO:=jenkinsci/jenkins}"
+
+cat <<EOF
+Docker repositories in Use:
+* JENKINS_REPO: ${JENKINS_REPO}
+* JENKINSCI_REPO: ${JENKINSCI_REPO}
+EOF
 
 sort-versions() {
     if [ "$(uname)" == 'Darwin' ]; then
@@ -17,7 +26,7 @@ sort-versions() {
 
 # Try tagging with and without -f to support all versions of docker
 docker-tag() {
-    local from="jenkins/jenkins:$1"
+    local from="${JENKINS_REPO}:$1"
     local to="$2/jenkins:$3"
     local out
 
@@ -31,7 +40,7 @@ docker-tag() {
 
 login-token() {
     # could use jq .token
-    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:jenkins/jenkins:pull" | grep -o '"token":"[^"]*"' | cut -d':' -f 2 | xargs echo
+    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | grep -o '"token":"[^"]*"' | cut -d':' -f 2 | xargs echo
 }
 
 is-published() {
@@ -41,7 +50,7 @@ is-published() {
         opts="-v"
     fi
     local http_code;
-    http_code=$(curl $opts -q -fsL -o /dev/null -w "%{http_code}" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $TOKEN" "https://index.docker.io/v2/jenkins/jenkins/manifests/$tag")
+    http_code=$(curl $opts -q -fsL -o /dev/null -w "%{http_code}" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $TOKEN" "https://index.docker.io/v2/${JENKINS_REPO}/manifests/$tag")
     if [ "$http_code" -eq "404" ]; then
         false
     elif [ "$http_code" -eq "200" ]; then
@@ -58,7 +67,7 @@ get-manifest() {
     if [ "$debug" = true ]; then
         opts="-v"
     fi
-    curl $opts -q -fsSL -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $TOKEN" "https://index.docker.io/v2/jenkins/jenkins/manifests/$tag"
+    curl $opts -q -fsSL -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $TOKEN" "https://index.docker.io/v2/${JENKINS_REPO}/manifests/$tag"
 }
 
 get-digest() {
@@ -91,14 +100,14 @@ publish() {
     docker build --file "Dockerfile$variant" \
                  --build-arg "JENKINS_VERSION=$version" \
                  --build-arg "JENKINS_SHA=$sha" \
-                 --tag "jenkins/jenkins:${tag}" \
-                 --tag "jenkinsci/jenkins:${tag}" \
+                 --tag "${JENKINS_REPO}:${tag}" \
+                 --tag "${JENKINSCI_REPO}:${tag}" \
                  "${build_opts[@]+"${build_opts[@]}"}" .
 
     # " line to fix syntax highlightning
     if [ ! "$dry_run" = true ]; then
-        docker push "jenkins/jenkins:${tag}"
-        docker push "jenkinsci/jenkins:${tag}"        
+        docker push "${JENKINS_REPO}:${tag}"
+        docker push "${JENKINSCI_REPO}:${tag}"
     fi
 }
 
@@ -131,12 +140,13 @@ tag-and-push() {
         echo "Creating tag ${target} pointing to ${source}"
         docker-tag "${source}" "jenkins" "${target}"
         docker-tag "${source}" "jenkinsci" "${target}"
+        destination="${REPO:-${JENKINS_REPO}}:${target}"
         if [ ! "$dry_run" = true ]; then
-            echo "Pushing jenkins/jenkins:${target}"
-            docker push "jenkins/jenkins:${target}"
-            docker push "jenkinsci/jenkins:${target}"
+            echo "Pushing ${destination}"
+            docker push "${destination}"
+            docker push "${destination}"
         else
-            echo "Would push jenkins/jenkins:${target}"
+            echo "Would push ${destination}"
         fi
     fi
 }


### PR DESCRIPTION
[JENKINS-51985](https://issues.jenkins-ci.org/browse/JENKINS-51985)

This PR merges the `java11` branch into `master` and adds the jdk11 build to the list of built _variants_.

`publish.sh` has also been modified so one can override the Docker Hub repositories to `docker push` to. Usable this way for instance:

```shell
JENKINS_REPO=batmat/test-jenkins JENKINSCI_REPO=batmat/test-jenkinsci ./publish.sh  --variant jdk11
```

@jenkinsci/java11-support 