### PR TITLE
[JENKINS-54725] Filter older releases for JDK11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ publish:
 	./publish.sh ; \
 	./publish.sh --variant alpine ; \
 	./publish.sh --variant slim ; \
-	./publish.sh --variant jdk11 ;
+	./publish.sh --variant jdk11 --start-after 2.151 ;
 
 clean:
 	rm -rf tests/test_helper/bats-*; \


### PR DESCRIPTION
Introduce a `--start-after VERSION` switch to allow for not publishing every 20 last releases for a given `publish.sh` script call.

Here we use it to only publish current latest weekly (2.152) for the JDK11 variant.

Manually tested using the following:

```shell
JENKINS_REPO=batmat/test-jenkins JENKINSCI_REPO=batmat/test-jenkinsci ./publish.sh --variant jdk11 --start-after 2.151
```

And the full blown version (still running):

```bash
$ export JENKINS_REPO=batmat/test-jenkins
$ export JENKINSCI_REPO=batmat/test-jenkinsci
$ make publish
...
```

Result can be seen at:
* https://hub.docker.com/r/batmat/test-jenkins/tags/ and
* https://hub.docker.com/r/batmat/test-jenkinsci/tags/