### PR TITLE
Bump timeout to 40 minutes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,9 +5,7 @@ properties([
     pipelineTriggers([cron('H H/6 * * *')]),
 ])
 
-timeout(20) {
-
-node('docker') {
+nodeWithTimeout('docker') {
     deleteDir()
 
     stage('Checkout') {
@@ -60,4 +58,10 @@ node('docker') {
     }
 }
 
+void nodeWithTimeout(String label, def body) {
+    timeout(time: 40, unit: 'MINUTES') {
+        node(label) {
+            body.call()
+        }
+    }
 }


### PR DESCRIPTION
Now we build more variants, we need a bit more time.

This low timeout has been the cause of many PR build failures recently, including last #771 or #770 for instance.