### PR TITLE
Fail fast while publishing variants

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,9 +48,9 @@ test-jdk11: prepare-test
 test: test-debian test-alpine test-slim test-jdk11
 
 publish:
-	./publish.sh ; \
-	./publish.sh --variant alpine ; \
-	./publish.sh --variant slim ; \
+	./publish.sh && \
+	./publish.sh --variant alpine && \
+	./publish.sh --variant slim && \
 	./publish.sh --variant jdk11 --start-after 2.151 ;
 
 clean:


### PR DESCRIPTION
It's currently misleading: if an error occurs on a given variant, the whole thing will continue happily.

This is probably nice because it will keep publishing other variants if one has an issue, but it also certainly blurries what is going wrong in the publishing process. So I think we should rather use `&&`.