### PR TITLE
Only publish LTS if one is available >= $start_after

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -225,13 +225,16 @@ for version in $(get-latest-versions); do
         fi
     fi
 
-    # Update lts tag
-    if [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    # Update lts tag (if we have an LTS version depending on $start_after)
+    if versionLT "$start_after" "$version" && [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
         lts_version="${version}"
     fi
 done
 
 publish-latest "${version}" "${variant}"
+
 if [ -n "${lts_version}" ]; then
     publish-lts "${lts_version}" "${variant}"
+else
+    echo "No LTS publishing"
 fi


### PR DESCRIPTION
Because the condition was not applied there, there was a failure until this fix trying to publish an LTS, but there was none tagged locally, which was resulting in the following error:

```
...
curl: (22) The requested URL returned error: 404 Not Found
DEBUG: Manifest for lts-jdk11:
Unable to get target digest for 'lts-jdk11 '
Creating tag lts-jdk11 pointing to 2.150.1-jdk11
Error response from daemon: manifest for batmat/test-jenkins:2.150.1-jdk11 not found
```

I think I had missed this issue originally while testing locally, because I added the `start_after` after having built and published everything from my testing onto the testing account https://hub.docker.com/r/batmat/test-jenkins/tags/