### PR TITLE
Use Debian Buster for JDK 11 Docker image

### DIFF
--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,6 +1,6 @@
-FROM openjdk:11-jdk
+FROM debian:buster
 
-RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y openjdk-11-jdk git git-lfs curl tini unzip && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins
@@ -31,14 +31,7 @@ VOLUME $JENKINS_HOME
 RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
 
 # Use tini as subreaper in Docker container to adopt zombie processes
-ARG TINI_VERSION=v0.16.1
-COPY tini_pub.gpg ${JENKINS_HOME}/tini_pub.gpg
-RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture) -o /sbin/tini \
-  && curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture).asc -o /sbin/tini.asc \
-  && gpg --import ${JENKINS_HOME}/tini_pub.gpg \
-  && gpg --verify /sbin/tini.asc \
-  && rm -rf /sbin/tini.asc /root/.gnupg \
-  && chmod +x /sbin/tini
+RUN ln /usr/bin/tini /sbin/tini
 
 COPY init.groovy /usr/share/jenkins/ref/init.groovy.d/tcp-slave-agent-port.groovy
 


### PR DESCRIPTION
The docker image build fails now because openjdk:jdk-11 is based on Debian Sid and there is not a build of tini 0.16.1 available for Debian Sid.

Debian Sid is the unstable Debian.  It is intentionally never released. It does not have a security team.  It is the least stable of any of the Debian versions.

Debian Buster will be Debian 10 when it is released in the first half of 2019.  It already includes Java 11 as the default Java and is already providing Java 11.0.1 as its default JDK.  Rather than be based on Sid (that is never stable), let's base ourselves on Buster that is becoming more and more stable.  Buster receives packages from Sid after specific stability criteria are met.  It should generally be more stable than Sid.

Since tini is included in Debian Buster, this change also switches to use tini as bundled with Debian Buster, instead of using a specific pre-built version of tini.