### PR TITLE
Use Debian Stretch with java 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk
+FROM openjdk:8-jdk-stretch
 
 RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -35,7 +35,7 @@ ARG TINI_VERSION=v0.16.1
 COPY tini_pub.gpg ${JENKINS_HOME}/tini_pub.gpg
 RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture) -o /sbin/tini \
   && curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-$(dpkg --print-architecture).asc -o /sbin/tini.asc \
-  && gpg --import ${JENKINS_HOME}/tini_pub.gpg \
+  && gpg --no-tty --import ${JENKINS_HOME}/tini_pub.gpg \
   && gpg --verify /sbin/tini.asc \
   && rm -rf /sbin/tini.asc /root/.gnupg \
   && chmod +x /sbin/tini

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -17,9 +17,9 @@ ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
 # If you bind mount a volume from the host or a data container,
 # ensure you use the same uid
 RUN mkdir -p $JENKINS_HOME \
-    && chown ${uid}:${gid} $JENKINS_HOME \
-    && groupadd -g ${gid} ${group} \
-    && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+  && chown ${uid}:${gid} $JENKINS_HOME \
+  && groupadd -g ${gid} ${group} \
+  && useradd -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
 
 # Jenkins home directory is a volume, so configuration and build history
 # can be persisted and survive image upgrades
@@ -63,9 +63,8 @@ ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-w
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331
-RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war
-RUN sha256sum /usr/share/jenkins/jenkins.war
-RUN echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
+RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
+  && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
 
 ENV JENKINS_UC https://updates.jenkins.io
 # TODO: revert before the GA release of Java 11 support (JENKINS-55087)

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk
+FROM openjdk:11-jdk-stretch
 
 RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Explicitly use openjdk:8-jdk-stretch & openjdk:11-jdk-stretch

When the openjdk:11-jdk image was released initially, it was based on Debian Sid, the unstable version of Debian.  The most recent version of the openjdk:11-jdk image is based on Debian Stretch, the stable version of Debian.

The checksums for the Debian images we'll be using with this pull request are:

```
REPOSITORY TAG                DIGEST                                                                  IMAGE ID
========== ================== ======================================================================= ============
openjdk    8-jdk              sha256:fd26a0ce164bee965095ba91ee7c4f21f3f98f54247e240c1f98255bd200cbe8 f2194a7e67df
openjdk    8-jdk-stretch      sha256:fd26a0ce164bee965095ba91ee7c4f21f3f98f54247e240c1f98255bd200cbe8 f2194a7e67df

openjdk    11-jdk             sha256:e01aa552356f6f78a4bf2dd3576874c3e7b58c64cce0cc5bf1d538911d2dc86e 9bbe44eb5d03
openjdk    11-jdk-stretch     sha256:e01aa552356f6f78a4bf2dd3576874c3e7b58c64cce0cc5bf1d538911d2dc86e 9bbe44eb5d03
openjdk    11.0.1-jdk-stretch sha256:e01aa552356f6f78a4bf2dd3576874c3e7b58c64cce0cc5bf1d538911d2dc86e 9bbe44eb5d03
```

This change switches jenkins/jenkins:jdk11 from using Debian Sid to using Debian Stretch, just like jenkins/jenkins:lts.  That reduces many of the operating system differences between the jenkins/jenkins:lts image and the jenkins/jenkins:jdk11 image.

This change does not change the operating system delivered with jenkins/jenkins:lts, but does clarify that the image is based on Debian stretch.

Supersedes #782 since we don't need an unreleased Debian operating system since the docker image for JDK 11 with Debian Stretch is now available.
