### PR TITLE
also update manually updated plugins if version in image is newer

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ As always - please ensure that you know how to drive docker - especially volume 
 
 ## Upgrading plugins
 
-By default, plugins will be upgraded if they haven't been upgraded manually and if the version from the docker image is newer than the version in the container. Versions installed by the docker image are tracked through a marker file.
+By default, plugins will be upgraded if the version from the docker image is newer than the version in the container. Versions installed by the docker image are tracked through a marker file.
 
 The default behaviour when upgrading from a docker image that didn't write marker files is to leave existing plugins in place. If you want to upgrade existing plugins without marker you may run the docker image with `-e TRY_UPGRADE_IF_NO_MARKER=true`. Then plugins will be upgraded if the version provided by the docker image is newer.
 

--- a/jenkins-support
+++ b/jenkins-support
@@ -47,31 +47,23 @@ copy_reference_file() {
     local reason;
     local container_version;
     local image_version;
-    local marker_version;
     local log; log=false
     if [[ ${rel} == plugins/*.jpi ]]; then
         container_version=$(get_plugin_version "$JENKINS_HOME/${rel}")
         image_version=$(get_plugin_version "${f}")
         if [[ -e $JENKINS_HOME/${version_marker} ]]; then
-            marker_version=$(cat "$JENKINS_HOME/${version_marker}")
-            if versionLT "$marker_version" "$container_version"; then
+            if [[ "$image_version" == "$container_version" ]]; then
                 action="SKIPPED"
-                reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version)"
-                log=true
+                reason="Version from image is the same as the installed version $image_version"
             else
-                if [[ "$image_version" == "$container_version" ]]; then
+                if versionLT "$image_version" "$container_version"; then
                     action="SKIPPED"
-                    reason="Version from image is the same as the installed version $image_version"
+                    log=true
+                    reason="Image version ($image_version) is older than installed version ($container_version)"
                 else
-                    if versionLT "$image_version" "$container_version"; then
-                        action="SKIPPED"
-                        log=true
-                        reason="Image version ($image_version) is older than installed version ($container_version)"
-                    else
-                        action="UPGRADED"
-                        log=true
-                        reason="Image version ($image_version) is newer than installed version ($container_version)"
-                    fi
+                    action="UPGRADED"
+                    log=true
+                    reason="Image version ($image_version) is newer than installed version ($container_version)"
                 fi
             fi
         else

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -129,27 +129,6 @@ SUT_IMAGE=$(sut_image)
     run bash -c "rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
 }
 
-@test "do not upgrade if plugin has been manually updated" {
-  run docker_build_child $SUT_IMAGE-install-plugins $BATS_TEST_DIRNAME/install-plugins
-  assert_success
-  local work; work="$BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  mkdir -p $work
-  # Image contains maven-plugin 2.7.1 and ant-plugin 1.3
-  run bash -c "docker run -u $UID -v $work:/var/jenkins_home --rm $SUT_IMAGE-install-plugins curl --connect-timeout 20 --retry 5 --retry-delay 0 --retry-max-time 60 -s -f -L https://updates.jenkins.io/download/plugins/maven-plugin/2.12.1/maven-plugin.hpi -o /var/jenkins_home/plugins/maven-plugin.jpi"
-  assert_success
-  run unzip_manifest maven-plugin.jpi $work
-  assert_line 'Plugin-Version: 2.12.1'
-  run docker_build_child $SUT_IMAGE-upgrade-plugins $BATS_TEST_DIRNAME/upgrade-plugins
-  assert_success
-  # Images contains maven-plugin 2.13 and ant-plugin 1.2
-  run bash -c "docker run -u $UID -v $work:/var/jenkins_home --rm $SUT_IMAGE-upgrade-plugins true"
-  assert_success
-  run unzip_manifest maven-plugin.jpi $work
-  assert_success
-  # Shouldn't be updated
-  refute_line 'Plugin-Version: 2.13'
-}
-
 @test "clean work directory" {
     run bash -c "rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
 }


### PR DESCRIPTION
In case there is no reason to stick to manually updated plugins ever if they are older than the currently installed ones then this PR could be used to simplify the code.

It would fix issue https://github.com/jenkinsci/docker/issues/790 which I raised. That issue contains a detailed explanation why I think this might be useful.