### PR TITLE
Fixes jenkinsci/docker/#784 - Can't override curl options in install-plugins.sh

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -83,6 +83,9 @@ doDownload() {
     fi
 
     echo "Downloading plugin: $plugin from $url"
+    # We actually want to allow variable value to be split into multiple options passed to curl.
+    # This is needed to allow long options and any options that take value.
+    # shellcheck disable=SC2086
     retry_command curl ${CURL_OPTIONS:--sSfL} --connect-timeout "${CURL_CONNECTION_TIMEOUT:-20}" --retry "${CURL_RETRY:-3}" --retry-delay "${CURL_RETRY_DELAY:-0}" --retry-max-time "${CURL_RETRY_MAX_TIME:-60}" "$url" -o "$jpi"
     return $?
 }

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -83,7 +83,7 @@ doDownload() {
     fi
 
     echo "Downloading plugin: $plugin from $url"
-    retry_command curl "${CURL_OPTIONS:--sSfL}" --connect-timeout "${CURL_CONNECTION_TIMEOUT:-20}" --retry "${CURL_RETRY:-3}" --retry-delay "${CURL_RETRY_DELAY:-0}" --retry-max-time "${CURL_RETRY_MAX_TIME:-60}" "$url" -o "$jpi"
+    retry_command curl ${CURL_OPTIONS:--sSfL} --connect-timeout "${CURL_CONNECTION_TIMEOUT:-20}" --retry "${CURL_RETRY:-3}" --retry-delay "${CURL_RETRY_DELAY:-0}" --retry-max-time "${CURL_RETRY_MAX_TIME:-60}" "$url" -o "$jpi"
     return $?
 }
 


### PR DESCRIPTION
Fetching plugins with overriden options as following:
```
FROM jenkins/jenkins:lts
ENV CURL_OPTIONS="-sSfL --tlsv1.2"
COPY default_plugins.txt /usr/share/jenkins/ref/
RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/default_plugins.txt
```
Without the change options are passed as single option which is incorrect. With the change two options are passed which is correct and things work perfectly.