### PR TITLE
allow install-plugins.sh to take a url as an option

### DIFF
--- a/tests/install-plugins/pluginsfile/plugins.txt
+++ b/tests/install-plugins/pluginsfile/plugins.txt
@@ -22,3 +22,6 @@ filesystem_scm:experimental  # comment at the end
 
 # Incrementals (JENKINS-52028)
 workflow-support:incrementals;org.jenkins-ci.plugins.workflow;2.19-rc289.d09828a05a74
+
+# from url
+subversion:::https://updates.jenkins.io/download/plugins/subversion/2.12.1/subversion.hpi


### PR DESCRIPTION
Allow self hosted plugins to be installed along side community supported plugins
using this format
`plugin-id:1.0-version:true:https://internal.url/plugin/1.0-version/plugin.hpi`