### PR TITLE
#790: allow manually upgraded plugins to be upgraded

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ NOTE: Avoid using a [bind mount](https://docs.docker.com/storage/bind-mounts/) f
 docker run -d -v jenkins_home:/var/jenkins_home -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts
 ```
 
-this will run Jenkins in detached mode with port forwarding and volume added. You can access logs with command 'docker logs CONTAINER_ID' in order to check first login token. ID of container will be returned from output of command above. 
+this will run Jenkins in detached mode with port forwarding and volume added. You can access logs with command 'docker logs CONTAINER_ID' in order to check first login token. ID of container will be returned from output of command above.
 
 ## Backing up data
 
@@ -264,6 +264,8 @@ As always - please ensure that you know how to drive docker - especially volume 
 By default, plugins will be upgraded if they haven't been upgraded manually and if the version from the docker image is newer than the version in the container. Versions installed by the docker image are tracked through a marker file.
 
 The default behaviour when upgrading from a docker image that didn't write marker files is to leave existing plugins in place. If you want to upgrade existing plugins without marker you may run the docker image with `-e TRY_UPGRADE_IF_NO_MARKER=true`. Then plugins will be upgraded if the version provided by the docker image is newer.
+
+To force upgrades of plugins that have been manually upgraded, run the docker image with `-e PLUGINS_FORCE_UPGRADE=true`.
 
 ## Hacking
 

--- a/jenkins-support
+++ b/jenkins-support
@@ -55,9 +55,15 @@ copy_reference_file() {
         if [[ -e $JENKINS_HOME/${version_marker} ]]; then
             marker_version=$(cat "$JENKINS_HOME/${version_marker}")
             if versionLT "$marker_version" "$container_version"; then
-                action="SKIPPED"
-                reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version)"
-                log=true
+                if [[ -n "$PLUGINS_FORCE_UPGRADE" ]]; then
+                    action="UPGRADED"
+                    reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version), forcing upgrade"
+                    log=true
+                else
+                    action="SKIPPED"
+                    reason="Installed version ($container_version) has been manually upgraded from initial version ($marker_version)"
+                    log=true
+                fi
             else
                 if [[ "$image_version" == "$container_version" ]]; then
                     action="SKIPPED"


### PR DESCRIPTION
Currently it is impossible to automatically upgrade plugins once they have been manually upgraded (see: https://github.com/jenkinsci/docker/issues/790) - this PR allows one to force plugin upgrades even if it has been manually upgraded.

I have not tested this yet though.