### PR TITLE
Use updated OS packages at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-stretch
 
-RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,6 +1,6 @@
 FROM openjdk:11-jdk-stretch
 
-RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-slim
 
-RUN apt-get update && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
 
 # Disable assistive technologies since openjdk:slim installs headless JDK (without assistive technologies).
 # JFreeChart initialization fails unless assistive technologies are disabled.

--- a/multiarch/Dockerfile.debian
+++ b/multiarch/Dockerfile.debian
@@ -7,7 +7,7 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apt-get update && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.slim
+++ b/multiarch/Dockerfile.slim
@@ -7,7 +7,7 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apt-get update && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins


### PR DESCRIPTION
Due to how significantly out of date the various base images get, this
adds an `apt-get upgrade` step to the various Dockerfiles to ensure that
updated operating system packages are included. This will also help
prevent this image from becoming too outdated when OS packages are
discovered to contain CVEs in the future.

@reviewbybees @jeffret-b @jenkinsci/docker 