### PR TITLE
Enable CI testing of the jdk11 variant

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ nodeWithTimeout('docker') {
             sh "make prepare-test"
         }
 
-        def labels = ['debian', 'slim', 'alpine']
+        def labels = ['debian', 'slim', 'alpine', 'jdk11']
         def builders = [:]
         for (x in labels) {
             def label = x


### PR DESCRIPTION
Realized this was missing. Sorry didn't find a way to create a PR from my fork using the phone.

Hopefully there won't be any failure and we'll just be able to merge this.