### PR TITLE
Remove call to sed and added necessary packages to apt-get install

### DIFF
--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg unzip && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -2,14 +2,6 @@ FROM openjdk:8-jdk-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
 
-# Disable assistive technologies since openjdk:slim installs headless JDK (without assistive technologies).
-# JFreeChart initialization fails unless assistive technologies are disabled.
-# Broken JFreeChart causes failures rendering trend graphs.
-# Seems like a configuration error in openjdk:8-jdk-slim, headless JDK inconsistent with assistive technologies.
-# Upstream OpenJDK pull request: https://github.com/docker-library/openjdk/pull/189
-# Upstream Debian slim bug report: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=896907
-RUN sed -i 's/assistive_technologies=.*/assistive_technologies=/g' /etc/java-8-openjdk/accessibility.properties
-
 ARG user=jenkins
 ARG group=jenkins
 ARG uid=1000

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg unzip && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins


### PR DESCRIPTION
The upstream slim image no longer requires this sed, so remove it to stop the build from failing.