### PR TITLE
jenkins.sh needs default for COPY_REFERENCE_FILE_LOG

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -2,6 +2,7 @@
 
 : "${JENKINS_WAR:="/usr/share/jenkins/jenkins.war"}"
 : "${JENKINS_HOME:="/var/jenkins_home"}"
+: "${COPY_REFERENCE_FILE_LOG:="${JENKINS_HOME}/copy_reference_file.log"}"
 touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find /usr/share/jenkins/ref/ \( -type f -o -type l \) -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +


### PR DESCRIPTION
Faced this issue while adding a different entrypoint.

If COPY_REFERENCE_FILE_LOG environment variable is missing, it should assume a sane default i.e JENKINS_HOME/copy_reference_file.log