### PR TITLE
Explicitly set JAVA_HOME in the CentOS image + Add `which` package to the CentOS image

### DIFF
--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,6 +1,7 @@
 FROM centos
 
 RUN yum update -y && yum install -y epel-release && yum install -y git curl dpkg java java-devel unzip which && yum clean all
+ENV JAVA_HOME /etc/alternatives/jre_openjdk
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,6 +1,6 @@
 FROM centos
 
-RUN yum update -y && yum install -y epel-release && yum install -y git curl dpkg java java-devel unzip && yum clean all
+RUN yum update -y && yum install -y epel-release && yum install -y git curl dpkg java java-devel unzip which && yum clean all
 
 ARG user=jenkins
 ARG group=jenkins


### PR DESCRIPTION
For different programs like `maven` and` gradle` they don't find the java because they don't have the package installed `which`.

Is It necessary add the `JAVA_HOME` environment variable?

https://github.com/jenkinsci/docker/pull/826#issuecomment-511852014