### PR TITLE
Add debug flags to publish-experimental.sh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ publish:
 	./publish.sh --variant jdk11 --start-after 2.151 ;
 
 publish-experimental:
-	./publish-experimental.sh ; \
+	./publish-experimental.sh -d ; \
 	./publish-experimental.sh --variant alpine ; \
 	./publish-experimental.sh --variant slim ; 
 

--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -219,7 +219,7 @@ publish() {
 
         # " line to fix syntax highlightning
         if [ ! "$dry_run" = true ]; then
-            docker --log-level debug push "${JENKINS_REPO}:${tag}-${arch}"
+            docker -D --log-level debug push "${JENKINS_REPO}:${tag}-${arch}"
         fi
     done
 }
@@ -257,7 +257,7 @@ tag-and-push() {
 
         if [ ! "$dry_run" = true ]; then
             echo "Pushing ${JENKINS_REPO}:${target}-${arch}"
-            docker --log-level debug push "${JENKINS_REPO}:${target}-${arch}"
+            docker -D --log-level debug push "${JENKINS_REPO}:${target}-${arch}"
         else
             echo "Would push ${JENKINS_REPO}:${target}-${arch}"
         fi


### PR DESCRIPTION
Adding debug flags to `docker push` and `publish-experimental.sh` to help debug permission issue.