### PR TITLE
Introduce Docker Packaging changelogs

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,3 +2,7 @@
 _extends: .github
 # We are using semver here. https://semver.org/
 version-template: $MAJOR.$MINOR.$PATCH
+template: |
+  <!-- Optional: add a release summary here -->
+  $CHANGES
+  NOTE: This is an experimental changelog. See [this page](https://github.com/jenkinsci/docker/blob/master/CHANGELOG.md) for more info

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,7 +3,7 @@ _extends: .github
 # We are using 3-digit LTS versioning here
 version-template: $MAJOR.$MINOR.$PATCH
 tag-template: jenkins-docker-packaging-$NEXT_PATCH_VERSION
-name-template: Role Strategy Plugin $NEXT_PATCH_VERSION
+name-template: Jenkins Docker Image $NEXT_PATCH_VERSION
 template: |
   <!-- Optional: add a release summary here -->
   ## Jenkins Core updates  

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,4 @@
+# https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 _extends: .github
-# We are using semver here
+# We are using semver here. https://semver.org/
 version-template: $MAJOR.$MINOR.$PATCH

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,7 +8,7 @@ template: |
   <!-- Optional: add a release summary here -->
   ## 📦 Jenkins Core updates  
   
-  * Update to Jenkins $NEXT_PATCH_VERSION ([chanelog](https://jenkins.io/changelog-stable/#v$NEXT_PATCH_VERSION)) 
+  * Update to Jenkins $NEXT_PATCH_VERSION ([changelog](https://jenkins.io/changelog-stable/#v$NEXT_PATCH_VERSION)) 
   
   $CHANGES
   

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,8 +1,14 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 _extends: .github
-# We are using semver here. https://semver.org/
+# We are using 3-digit LTS versioning here
 version-template: $MAJOR.$MINOR.$PATCH
+tag-template: jenkins-docker-packaging-$NEXT_PATCH_VERSION
+name-template: Role Strategy Plugin $NEXT_PATCH_VERSION
 template: |
   <!-- Optional: add a release summary here -->
+  ## Jenkins Core updates  
+  
+  * Update to Jenkins $NEXT_PATCH_VERSION ([chanelog](https://jenkins.io/changelog-stable/#v$NEXT_PATCH_VERSION)) 
+  
   $CHANGES
   NOTE: This is an experimental changelog. See [this page](https://github.com/jenkinsci/docker/blob/master/CHANGELOG.md) for more info

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,3 @@
+_extends: .github
+# We are using semver here
+version-template: $MAJOR.$MINOR.$PATCH

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,9 +6,10 @@ tag-template: jenkins-docker-packaging-$NEXT_PATCH_VERSION
 name-template: Jenkins Docker Image $NEXT_PATCH_VERSION
 template: |
   <!-- Optional: add a release summary here -->
-  ## Jenkins Core updates  
+  ## 📦 Jenkins Core updates  
   
   * Update to Jenkins $NEXT_PATCH_VERSION ([chanelog](https://jenkins.io/changelog-stable/#v$NEXT_PATCH_VERSION)) 
   
   $CHANGES
-  NOTE: This is an experimental changelog. See [this page](https://github.com/jenkinsci/docker/blob/master/CHANGELOG.md) for more info
+  
+  **NOTE:** This is an experimental changelog. See [this page](https://github.com/jenkinsci/docker/blob/master/CHANGELOG.md) for more info

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,10 @@ In this repository we follow the Jenkins LTS releases and release packaging chan
 There is no version mapping for Weekly releases, users should be using changelogs to track down the changes
 (see also [Issue #865](https://github.com/jenkinsci/docker/issues/865)).
 
-## Notable changes in Jenkins versions
+## Notable changes in Jenkins versions before 2.164.1
 
 Below you can find incomplete list of changes in Docker packaging for Jenkins releases
 
-2.99
------
+### 2.99
+
 *  `/bin/tini` has been relocated to `/sbin/tini`, location defined by alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,14 @@ Please refer to https://jenkins.io/changelog/ and https://jenkins.io/changelog-s
 
 ## Version scheme
 
-The repository follows the [Semantic Versioning 2.0.0](https://semver.org/) specification.
+The repository follows the 3-digit scheme of [Jenkins LTS releases](https://jenkins.io/download/lts/).
 
 ## Mapping of Docker packaging to Jenkins releases
 
-Currently there is no direct mapping of Docker packaging versions to Docker packages used in the official [jenkins/jenkins](https://hub.docker.com/r/jenkins/jenkins) image.
 Both Weekly and LTS distributions follow the Continuous Delivery approach and pick up the most recent versions available by the time of the release Pipeline execution.
-It is subject to change in the future.
+In this repository we follow the Jenkins LTS releases and release packaging changelogs for them.
+There is no version mapping for Weekly releases, users should be using chnagelogs to track down the changes
+(see also [Issue #865](https://github.com/jenkinsci/docker/issues/865)).
 
 ## Notable changes in Jenkins versions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 CHANGELOG
 =========
 
+| See [GitHub releases](https://github.com/jenkinsci/docker/releases) |
+| --- |
+
+## Status
+
+We are doing experimental changelogs for Jenkins master Docker packaging. 
+This release notes represent changes in in the packaging, but not in the bundled WAR files. 
+Please refer to https://jenkins.io/changelog/ and https://jenkins.io/changelog-stable/ for WAR file changelogs.
+
+## Version scheme
+
+The repository follows the [Semantic Versioning 2.0.0](https://semver.org/) specification.
+
+## Mapping of Docker packaging to Jenkins releases
+
+Currently there is no direct mapping of Docker packaging versions to Docker packages used in the official [jenkins/jenkins](https://hub.docker.com/r/jenkins/jenkins) image.
+Both Weekly and LTS distributions follow the Continuous Delivery approach and pick up the most recent versions available by the time of the release Pipeline execution.
+It is subject to change in the future.
+
+## Notable changes in Jenkins versions
+
+Below you can find incomplete list of changes in Docker packaging for Jenkins releases
+
 2.99
 -----
 *  `/bin/tini` has been relocated to `/sbin/tini`, location defined by alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ CHANGELOG
 
 ## Status
 
-We are doing experimental changelogs for Jenkins master Docker packaging. 
+We are doing experimental changelogs for Jenkins master Docker packaging
+([discussion in the developer list](https://groups.google.com/forum/#!topic/jenkinsci-dev/KvV_UjU02gE)). 
 This release notes represent changes in in the packaging, but not in the bundled WAR files. 
 Please refer to https://jenkins.io/changelog/ and https://jenkins.io/changelog-stable/ for WAR file changelogs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The repository follows the 3-digit scheme of [Jenkins LTS releases](https://jenk
 
 Both Weekly and LTS distributions follow the Continuous Delivery approach and pick up the most recent versions available by the time of the release Pipeline execution.
 In this repository we follow the Jenkins LTS releases and release packaging changelogs for them.
-There is no version mapping for Weekly releases, users should be using chnagelogs to track down the changes
+There is no version mapping for Weekly releases, users should be using changelogs to track down the changes
 (see also [Issue #865](https://github.com/jenkinsci/docker/issues/865)).
 
 ## Notable changes in Jenkins versions


### PR DESCRIPTION
I suggest adding experimental changelogs to the Docker packaging. Why? Docker packaging is as important as Jenkins core itself. Even if we follow the "continuous delivery" approach for Weekly releases, some changelogs could help users to track changes.

How would it work?

* We introduce meta-releases by adding GitHub tags
* We periodically cut new releases when we feel there is enough content
* Weekly releases just use the master branch and pick the latest version
* TBD: LTS packaging uses latest tags for packaging

WDYT @carlossg @batmat @slide ?
