### PR TITLE
Experimental publishing: Add DOCKER_CONFIG echo in the path that is being used

### DIFF
--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -223,6 +223,7 @@ publish() {
                 echo "DOCKER_CONFIG ($DOCKER_CONFIG) does not exist"
                 exit -1
             fi
+            docker info
             docker -D --log-level debug push "${JENKINS_REPO}:${tag}-${arch}"
         fi
     done

--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -219,6 +219,10 @@ publish() {
 
         # " line to fix syntax highlightning
         if [ ! "$dry_run" = true ]; then
+            if [ ! -e "$DOCKER_CONFIG" ]; then
+                echo "DOCKER_CONFIG ($DOCKER_CONFIG) does not exist"
+                exit -1
+            fi
             docker -D --log-level debug push "${JENKINS_REPO}:${tag}-${arch}"
         fi
     done


### PR DESCRIPTION
The previous addition of DOCKER_CONFIG check is not being called (yet), so add the same code to the path that is currently erroring.