### PR TITLE
Jenkinsfile: Prevent CI timeout when ci.jenkins.io Docker agents are too busy

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,8 +67,8 @@ nodeWithTimeout('docker') {
 }
 
 void nodeWithTimeout(String label, def body) {
-    timeout(time: 40, unit: 'MINUTES') {
-        node(label) {
+    node(label) {
+        timeout(time: 40, unit: 'MINUTES') {
             body.call()
         }
     }


### PR DESCRIPTION
With this change the timeout will cover only the actual execution time, but build requests will stay in the queue and wait for agents