### PR TITLE
Multiarch updates

### DIFF
--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -160,8 +160,7 @@ is-published() {
         if [ "$http_code" -eq "404" ] || [ "$http_code" -eq "200" ]; then
             break
         fi
-        # get a new token
-        echo "Trying to get a new token..."
+        echo "Requesting new auth token..."
         TOKEN=$(login-token)
         retries=$((retries + 1))
     done
@@ -191,12 +190,10 @@ get-manifest() {
 	output=$(curl $opts -q -fsSL -w "|%{http_code}" -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $TOKEN" "https://index.docker.io/v2/${JENKINS_REPO}/manifests/$tag")
         http_code=$(echo "$output" | cut -d'|' -f2)
         manifest=$(echo "$output" | cut -d'|' -f1)
-
         if [ "$http_code" -eq "404" ] || [ "$http_code" -eq "200" ]; then
             break
         fi
-
-        # the token may have expired at this point
+        echo "Requesting new auth token..."
         TOKEN=$(login-token)
         retries=$((retries + 1))
     done

--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -380,8 +380,10 @@ while [[ $# -gt 0 ]]; do
         shift
         ;;
         -a|--arch)
-        ARCHS=($(echo "$2" | cut -d':' -f1))
-        QEMUARCHS=($(echo "$2" | cut -d':' -f2))
+        arch=$(echo "$2" | cut -d':' -f1)
+        qemuarch=$(echo "$2" | cut -d':' -f2)
+        ARCHS=("$arch")
+        QEMUARCHS=("$qemuarch")
         if [[ ${#QEMUARCHS[@]} -eq 0 ]]; then
             QEMUARCHS=("${ARCHS[@]}")
         fi


### PR DESCRIPTION
Some of the openjdk images have changed such that they don't work without using the `stretch` version instead of the base image. These changes correct that as well as introduce retries for manifest operations. The time it takes to do certain tasks causes the token to "timeout" and not work after a period of time, if the script receives a 401 (Unauthorized) (really a non 404 or 200) response, it will request a new login token to retrieve manifests and retry the `curl` invocation with the new TOKEN value.

Added the capability to specify a `-a` parameter to only build a single arch. This is mainly for debug, testing purposes.