### PR TITLE
Extend timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ nodeWithTimeout('docker') {
 
 void nodeWithTimeout(String label, def body) {
     node(label) {
-        timeout(time: 40, unit: 'MINUTES') {
+        timeout(time: 180, unit: 'MINUTES') {
             body.call()
         }
     }


### PR DESCRIPTION
There are several builds occurring now for all the different architectures and variants which is causing
a timeout to occur many times. This extends the timeout to allow all the builds and pushes to complete.

I ran a test locally and up to the push point took about 108 minutes to complete, so I selected 180 just to be on the safe side.