### PR TITLE
use root to check file permission

### DIFF
--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -35,7 +35,7 @@ SUT_IMAGE=$(sut_image)
   assert_success
 
   # replace DOS line endings \r\n
-  run bash -c "docker run -v $BATS_TEST_DIRNAME/functions:/var/jenkins_home --rm $SUT_IMAGE-functions stat -c '%a' /var/jenkins_home/.ssh/config"
+  run bash -c "docker run -u root -v $BATS_TEST_DIRNAME/functions:/var/jenkins_home --rm $SUT_IMAGE-functions stat -c '%a' /var/jenkins_home/.ssh/config"
   assert_success
   assert_line '600'
 }


### PR DESCRIPTION
If we don't use user `root` we'll failed on test `permissions are propagated from override file` since we're running bind mounting and the container user is `jenkins` by default.
```bash
$ DOCKERFILE=Dockerfile bats tests
 ✓ build image
 ✓ versionLT
 ✗ permissions are propagated from override file
   (from function `assert_success' in file tests/test_helper/bats-assert/src/assert.bash, line 114,
    in test file tests/functions.bats, line 39)
     `assert_success' failed

   -- command failed --
   status : 1
   output (2 lines):
     touch: cannot touch '/var/jenkins_home/copy_reference_file.log': Permission denied
     Can not write to /var/jenkins_home/copy_reference_file.log. Wrong volume permissions?
   --
```