### PR TITLE
`publish-experimental` - Add prune for images at the end of the build

### DIFF
--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -404,6 +404,9 @@ if [ "$debug" = true ]; then
     set -x
 fi
 
+# setup cleanup to run on EXIT or ERR signals
+trap "cleanup" EXIT ERR
+
 get-manifest-tool
 get-qemu-handlers
 
@@ -437,5 +440,3 @@ publish-latest "${version}" "${variant}"
 if [ -n "${lts_version}" ]; then
     publish-lts "${lts_version}" "${variant}"
 fi
-
-cleanup

--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -355,6 +355,7 @@ cleanup() {
     rm -f manifest-tool
     rm -f ./multiarch/qemu-*
     rm -rf ./multiarch/Dockerfile-*
+    docker system prune --all --force
 }
 
 # Process arguments


### PR DESCRIPTION
This will clean up the created images, which on my machine was around 17GB.