### PR TITLE
Dockerfile: add git-lfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM openjdk:8-jdk-stretch
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM openjdk:8-jdk-stretch
 
-RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl && rm -rf /var/lib/apt/lists/*
+# Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
+# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-alpine
 
-RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils tini
+RUN apk add --no-cache git git-lfs openssh-client curl unzip bash ttf-dejavu coreutils tini
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,6 +1,6 @@
 FROM centos
 
-RUN yum update -y && yum install -y epel-release && yum install -y git curl dpkg java java-devel unzip which && yum clean all
+RUN yum update -y && yum install -y epel-release && yum install -y git git-lfs curl dpkg java java-devel unzip which && yum clean all
 ENV JAVA_HOME /etc/alternatives/jre_openjdk
 
 ARG user=jenkins

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -1,6 +1,6 @@
 FROM centos
 
-RUN yum update -y && yum install -y epel-release && yum install -y git git-lfs curl dpkg java java-devel unzip which && yum clean all
+RUN yum update -y && yum install -y epel-release && yum install -y git curl dpkg java java-devel unzip which && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh | bash && yum install -y git-lfs && yum clean all
 ENV JAVA_HOME /etc/alternatives/jre_openjdk
 
 ARG user=jenkins

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,7 +1,6 @@
 FROM openjdk:11-jdk-stretch
 
-RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,6 +1,7 @@
 FROM openjdk:11-jdk-stretch
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN printf "deb http://httpredir.debian.org/debian stretch-backports main non-free\ndeb-src http://httpredir.debian.org/debian stretch-backports main non-free" > /etc/apt/sources.list.d/backports.list
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-openj9
+++ b/Dockerfile-openj9
@@ -3,6 +3,7 @@ FROM adoptopenjdk:8-jdk-openj9-bionic
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends git curl gnupg fontconfig unzip nano \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install \
   && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins

--- a/Dockerfile-openj9-jdk11
+++ b/Dockerfile-openj9-jdk11
@@ -3,6 +3,7 @@ FROM adoptopenjdk:11-jdk-openj9-bionic
 RUN apt-get update \
   && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends git curl gnupg fontconfig unzip nano \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install \
   && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,8 @@
 FROM openjdk:8-jdk-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg unzip libfreetype6 libfontconfig1 && rm -rf /var/lib/apt/lists/*
+# Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
+# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,6 +1,6 @@
 FROM openjdk:8-jdk-slim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg unzip libfreetype6 libfontconfig1 && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.alpine
+++ b/multiarch/Dockerfile.alpine
@@ -7,7 +7,7 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils tini
+RUN apk add --no-cache git git-lfs openssh-client curl unzip bash ttf-dejavu coreutils tini
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.debian
+++ b/multiarch/Dockerfile.debian
@@ -7,7 +7,9 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl && rm -rf /var/lib/apt/lists/*
+# Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
+# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.debian
+++ b/multiarch/Dockerfile.debian
@@ -7,7 +7,7 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.slim
+++ b/multiarch/Dockerfile.slim
@@ -7,7 +7,7 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.slim
+++ b/multiarch/Dockerfile.slim
@@ -7,7 +7,9 @@ FROM BASEIMAGE
 # If we're building normally, for amd64, CROSS_BUILD lines are removed
 CROSS_BUILD_COPY multiarch/qemu-ARCH-static /usr/bin/
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg && rm -rf /var/lib/apt/lists/*
+# Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
+# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
+RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 
 ARG user=jenkins
 ARG group=jenkins


### PR DESCRIPTION
We ship the git plugin, but all git lfs related behaviour fails, because
the image doesn't ship the git-lfs package.

Closes #801.

cc @oleg-nenashev 