### PR TITLE
Look further back to handle LTS.4/LTS.1 dual release days

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -84,7 +84,7 @@ get-digest() {
 }
 
 get-latest-versions() {
-    curl -q -fsSL https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml | grep '<version>.*</version>' | grep -E -o '[0-9]+(\.[0-9]+)+' | sort-versions | uniq | tail -n 20
+    curl -q -fsSL https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml | grep '<version>.*</version>' | grep -E -o '[0-9]+(\.[0-9]+)+' | sort-versions | uniq | tail -n 30
 }
 
 publish() {


### PR DESCRIPTION
We published both 2.176.4 and 2.190.1 today to allow admins to apply security fixes without having to perform a major update.

Unfortunately, no images for 2.176.4 were generated, and I think _this_ is the reason.

So look back further.