### PR TITLE
Create Dockerfile-ARM32v7 Dockerfile

### DIFF
--- a/Dockerfile-ARM32v7
+++ b/Dockerfile-ARM32v7
@@ -1,0 +1,16 @@
+FROM raspbian/stretch
+
+# Installing Java
+RUN apt-get update
+RUN apt-get install oracle-java8-jdk -y
+RUN java -version
+
+# Installing Jenkins
+RUN apt-get install curl -y
+RUN curl -O http://pkg.jenkins-ci.org/debian/jenkins-ci.org.key
+RUN apt-get remove curl -y
+RUN apt-key add jenkins-ci.org.key
+RUN sh -c 'echo deb http://pkg.jenkins-ci.org/debian binary/ > /etc/apt/sources.list.d/jenkins.list'
+RUN sudo apt-get install jenkins -y
+
+CMD ["systemctl", "start", "jenkins"]


### PR DESCRIPTION
This docker image can run on arm32v7 machines. You can then build this docker image using the following commands:

1. `docker run --rm --privileged hypriot/qemu-register`
2. `docker build --build-arg BASE_ARCH=arm32v7 -t jenkins:arm32v7-latest .`
3. `docker manifest create jenkins:latest jenkins:arm32v7-latest`
4. `docker manifest annotate --arch armv7 my_image:latest my_image:arm32v7-latest`