### PR TITLE
#936 Added tzdata package

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,6 +1,16 @@
 FROM openjdk:8-jdk-alpine
 
-RUN apk add --no-cache git git-lfs openssh-client curl unzip bash ttf-dejavu coreutils tini
+RUN apk add --no-cache \
+  bash \
+  coreutils \
+  curl \
+  git \
+  git-lfs \
+  openssh-client \
+  tini \
+  ttf-dejavu \
+  tzdata \
+  unzip
 
 ARG user=jenkins
 ARG group=jenkins

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -30,6 +30,22 @@ SUT_CONTAINER=$(sut_image)
   assert "${version}" docker run --rm --name $SUT_CONTAINER -P $SUT_IMAGE --help --version | tail -n 1
 }
 
+@test "timezones are handled correctly" {
+    local timezone1
+    local timezone2
+
+    run docker run --rm --name $SUT_CONTAINER  $SUT_IMAGE bash -c "date +'%Z %z'"
+    timezone1="${output}"
+    assert_equal "${timezone1}" "UTC +0000"
+
+    run docker run --rm --name $SUT_CONTAINER -e "TZ=Europe/Luxembourg" $SUT_IMAGE bash -c "date +'%Z %z'"
+    timezone1="${output}"
+    run docker run --rm --name $SUT_CONTAINER -e "TZ=Australia/Sydney" $SUT_IMAGE bash -c "date +'%Z %z'"
+    timezone2="${output}"
+
+    refute [ "${timezone1}" = "${timezone2}" ]
+}
+
 @test "create test container" {
     docker run -d -e JAVA_OPTS="-Duser.timezone=Europe/Madrid -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';\"" --name $SUT_CONTAINER -P $SUT_IMAGE
 }

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -7,6 +7,11 @@ load test_helpers
 SUT_IMAGE=$(sut_image)
 SUT_CONTAINER=$(sut_image)
 
+@test "Introduce random delay" {
+  sleep $(shuf -i 30-180 -n 1)
+  assert_equal "true" "true"
+}
+
 @test "build image" {
   cd $BATS_TEST_DIRNAME/..
   docker_build -t $SUT_IMAGE .

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -7,11 +7,6 @@ load test_helpers
 SUT_IMAGE=$(sut_image)
 SUT_CONTAINER=$(sut_image)
 
-@test "Introduce random delay" {
-  sleep $(shuf -i 30-180 -n 1)
-  assert_equal "true" "true"
-}
-
 @test "build image" {
   cd $BATS_TEST_DIRNAME/..
   docker_build -t $SUT_IMAGE .


### PR DESCRIPTION
So that now it handles correctly the TZ variable:

```
Successfully built d4dfd7e46080
docker run --rm -it -e "TZ=Europe/Luxembourg" d4dfd7e46080 date
Sat Mar 28 11:59:12 CET 2020
docker run --rm -it -e "TZ=Europe/London" d4dfd7e46080 date
Sat Mar 28 10:59:20 GMT 2020
```

Fixes #936 