### PR TITLE
Remove hardcoded COPY_REFERENCE_FILE_LOG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -58,8 +58,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support

--- a/Dockerfile-centos
+++ b/Dockerfile-centos
@@ -69,8 +69,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -68,7 +68,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 ENV JENKINS_ENABLE_FUTURE_JAVA=true
 
 USER ${user}

--- a/Dockerfile-openj9
+++ b/Dockerfile-openj9
@@ -72,8 +72,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support

--- a/Dockerfile-openj9-jdk11
+++ b/Dockerfile-openj9-jdk11
@@ -72,8 +72,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -70,8 +70,6 @@ EXPOSE ${http_port}
 # will be used by attached slave agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-
 USER ${user}
 
 COPY jenkins-support /usr/local/bin/jenkins-support


### PR DESCRIPTION
I would like to be able to run this docker-image with a different `JENKINS_HOME` set. It generally works.

I am removing `COPY_REFERENCE_FILE_LOG` though, as even though it might sound paradox (env var == dynamic), since it is set during build-time, this value will not change on runtime even if `JENKINS_HOME` is overwritten during container runtime.

Which means, a user would additionally have to overwrite `COPY_REFERENCE_FILE_LOG` which seems counterintuitive to me :)

Removing this already works, since already make use of a sane default here: https://github.com/jenkinsci/docker/blob/master/jenkins.sh#L5 - which works perfectly as it is evaluated during runtime.