### PR TITLE
Temporarily disable arm32v7

### DIFF
--- a/publish-experimental.sh
+++ b/publish-experimental.sh
@@ -25,8 +25,11 @@ if [[ "$DOCKERHUB_ORGANISATION" == "jenkins" ]]; then
     exit 1;
 fi
 
-ARCHS=(arm arm64 s390x ppc64le amd64)
-QEMUARCHS=(arm aarch64 s390x ppc64le x86_64)
+# re-enable arm when we move to AdoptOpenJDK
+#ARCHS=(arm arm64 s390x ppc64le amd64)
+#QEMUARCHS=(arm aarch64 s390x ppc64le x86_64)
+ARCHS=(arm64 s390x ppc64le amd64)
+QEMUARCHS=(aarch64 s390x ppc64le x86_64)
 QEMUVER="v3.0.0"
 BASEIMAGE=
 MANIFEST_TOOL_VERSION="v0.9.0"


### PR DESCRIPTION
The OpenJDK images for arm32v7 are not kept up anymore, this temporarily disables that arch until we switch to AdoptOpenJDK.