### PR TITLE
Fix install-plugins.sh for update-center changes

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -243,7 +243,7 @@ main() {
     echo "Registering preinstalled plugins..."
     installedPlugins="$(installedPlugins)"
 
-    # Check if there's a version-specific update center, which is the case for LTS versions
+    # Get the update center URL based on the jenkins version
     jenkinsVersion="$(jenkinsMajorMinorVersion)"
     jenkinsUcJson=$(curl -Ls -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
     if [ -n "${jenkinsUcJson}" ]; then

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -245,9 +245,9 @@ main() {
 
     # Check if there's a version-specific update center, which is the case for LTS versions
     jenkinsVersion="$(jenkinsMajorMinorVersion)"
-    jenkinsUcJson=$(curl -Ls -o /dev/null -w %{url_effective} $JENKINS_UC/update-center.json?version=$jenkinsVersion)
+    jenkinsUcJson=$(curl -Ls -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
     if [ -n "${jenkinsUcJson}" ]; then
-        JENKINS_UC_LATEST=$(echo $jenkinsUcJson | sed -e 's/update-center\.json$//')
+        JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}
         echo "Using version-specific update center: $JENKINS_UC_LATEST..."
     else
         JENKINS_UC_LATEST=

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -245,8 +245,9 @@ main() {
 
     # Check if there's a version-specific update center, which is the case for LTS versions
     jenkinsVersion="$(jenkinsMajorMinorVersion)"
-    if curl -fsL -o /dev/null "$JENKINS_UC/$jenkinsVersion"; then
-        JENKINS_UC_LATEST="$JENKINS_UC/$jenkinsVersion"
+    jenkinsUcJson=$(curl -Ls -o /dev/null -w %{url_effective} $JENKINS_UC/update-center.json?version=$jenkinsVersion)
+    if [ -n "${jenkinsUcJson}" ]; then
+        JENKINS_UC_LATEST=$(echo $jenkinsUcJson | sed -e 's/update-center\.json$//')
         echo "Using version-specific update center: $JENKINS_UC_LATEST..."
     else
         JENKINS_UC_LATEST=


### PR DESCRIPTION
This uses the ?version= URL to determine the version specific update center. This is the canonical way to get the version specific update center, if one exists. Otherwise, it will return the update center for the latest.

cc @daniel-beck 