### PR TITLE
Switch the Alpine JDK8 image to the AdoptOpenJDK

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,7 @@
-FROM openjdk:8-jdk-alpine
+# FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
+# There is no official Alpine images at the moment.
+# Needs upgrade when/if there is an official alpine image.
+FROM adoptopenjdk/openjdk8:jdk8u262-b10-alpine
 
 RUN apk add --no-cache \
   bash \
@@ -44,10 +47,10 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.60.3}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.235.4}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=2d71b8f87c8417f9303a73d52901a59678ee6c0eefcf7325efed6035ff39372a
+ARG JENKINS_SHA=e5688a8f07cc3d79ba3afa3cab367d083dd90daab77cebd461ba8e83a1e3c177
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war


### PR DESCRIPTION
This change replaces the EOLed `openjdk:8-jdk-alpine` image to the unofficial AdoptOpenJDK image. Fixes #957 

TODOs:

- [x] - Update the dependency
- [x] - Perform manual smoke tests
- [x] - Align packages. This is likely a breaking change otherwise

Will cause conflicts in https://github.com/jenkinsci/docker/pull/956 once merged
