### PR TITLE
Add git ppa to install latest version of git

### DIFF
--- a/11/debian/buster-slim/hotspot/Dockerfile
+++ b/11/debian/buster-slim/hotspot/Dockerfile
@@ -1,6 +1,19 @@
 FROM adoptopenjdk/openjdk11:debianslim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg unzip libfreetype6 libfontconfig1 && git lfs install && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl gpg unzip libfreetype6 libfontconfig1 \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/11/debian/buster/hotspot/Dockerfile
+++ b/11/debian/buster/hotspot/Dockerfile
@@ -1,6 +1,19 @@
 FROM adoptopenjdk/openjdk11:debian
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs unzip && git lfs install && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl gpg unzip \
+  && add-apt-repository -y ppa:git-core/ppa -m \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/11/ubuntu/bionic/openj9/Dockerfile
+++ b/11/ubuntu/bionic/openj9/Dockerfile
@@ -1,10 +1,18 @@
 FROM adoptopenjdk:11-jdk-openj9-bionic
 
-RUN apt-get update \
+RUN set -eux \
+  && apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends git curl gnupg fontconfig unzip nano \
-  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends software-properties-common curl gnupg fontconfig unzip nano\
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/8/debian/buster-slim/hotspot/Dockerfile
+++ b/8/debian/buster-slim/hotspot/Dockerfile
@@ -1,6 +1,19 @@
 FROM adoptopenjdk/openjdk8:debianslim
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg unzip libfreetype6 libfontconfig1 && git lfs install && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl gpg unzip libfreetype6 libfontconfig1 \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/8/debian/buster/hotspot/Dockerfile
+++ b/8/debian/buster/hotspot/Dockerfile
@@ -1,8 +1,19 @@
 FROM adoptopenjdk/openjdk8:debian
 
-# Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
-# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl gpg unzip libfreetype6 libfontconfig1 \
+  && add-apt-repository -y ppa:git-core/ppa -m \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/8/debian/stretch/hotspot/Dockerfile
+++ b/8/debian/stretch/hotspot/Dockerfile
@@ -1,8 +1,19 @@
 FROM openjdk:8-jdk-stretch
 
-# Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
-# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl gpg unzip \
+  && add-apt-repository -y ppa:git-core/ppa -m \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/8/ubuntu/bionic/openj9/Dockerfile
+++ b/8/ubuntu/bionic/openj9/Dockerfile
@@ -1,10 +1,18 @@
 FROM adoptopenjdk:8-jdk-openj9-bionic
 
-RUN apt-get update \
+RUN set -eux \
+  && apt-get update \
   && apt-get upgrade -y \
-  && apt-get install -y --no-install-recommends git curl gnupg fontconfig unzip nano \
-  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get install -y --no-install-recommends software-properties-common curl gnupg fontconfig unzip nano \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins

--- a/multiarch/Dockerfile.debian
+++ b/multiarch/Dockerfile.debian
@@ -1,7 +1,20 @@
 # Placeholder for the specified arch that gets parsed in the publish-experimental.sh script.
 FROM BASEIMAGE
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl dpkg gpg tar && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl dpkg gpg tar \
+  && add-apt-repository -y ppa:git-core/ppa -m \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins
@@ -13,18 +26,6 @@ ARG JENKINS_HOME=/var/jenkins_home
 
 ENV JENKINS_HOME $JENKINS_HOME
 ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-
-# Install git lfs per https://github.com/git-lfs/git-lfs#from-binary
-# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
-ARG GIT_LFS_VERSION=v2.11.0
-ENV GIT_LFS_VERSION $GIT_LFS_VERSION
-RUN curl -fsSLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz \
-  && curl -fsSLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/sha256sums.asc \
-  && curl -L https://github.com/bk2204.gpg | gpg --no-tty --import \
-  && gpg -d sha256sums.asc | grep git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz | sha256sum -c \
-  && tar -zvxf git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz git-lfs \
-  && mv git-lfs /usr/bin/ \
-  && rm -rf git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz sha256sums.asc /root/.gnupg
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,

--- a/multiarch/Dockerfile.slim
+++ b/multiarch/Dockerfile.slim
@@ -1,7 +1,20 @@
 # Placeholder for the specified arch that gets parsed in the publish-experimental.sh script.
 FROM BASEIMAGE
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl dpkg gpg tar && rm -rf /var/lib/apt/lists/*
+RUN set -eux \
+  && apt-get update \
+  && apt-get upgrade -y \
+  && apt-get install -y software-properties-common curl dpkg gpg tar \
+  && add-apt-repository -y ppa:git-core/ppa -m \
+  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 \
+  && sed -i -e 's|hirsute|xenial|' /etc/apt/sources.list.d/git-core-ubuntu-ppa-hirsute.list \
+  && apt-get update \
+  && apt-get install -y git curl \
+  && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash \
+  && apt-get install -y git-lfs \
+  && git lfs install \
+  && rm -rf /var/lib/apt/lists/* \
+  && git version
 
 ARG user=jenkins
 ARG group=jenkins
@@ -13,18 +26,6 @@ ARG JENKINS_HOME=/var/jenkins_home
 
 ENV JENKINS_HOME $JENKINS_HOME
 ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-
-# Install git lfs per https://github.com/git-lfs/git-lfs#from-binary
-# Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository
-ARG GIT_LFS_VERSION=v2.11.0
-ENV GIT_LFS_VERSION $GIT_LFS_VERSION
-RUN curl -fsSLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz \
-  && curl -fsSLO https://github.com/git-lfs/git-lfs/releases/download/${GIT_LFS_VERSION}/sha256sums.asc \
-  && curl -L https://github.com/bk2204.gpg | gpg --no-tty --import \
-  && gpg -d sha256sums.asc | grep git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz | sha256sum -c \
-  && tar -zvxf git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz git-lfs \
-  && mv git-lfs /usr/bin/ \
-  && rm -rf git-lfs-linux-$(dpkg --print-architecture)-${GIT_LFS_VERSION}.tar.gz sha256sums.asc /root/.gnupg
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,


### PR DESCRIPTION
Debian and Ubuntu come with significantly older versions of git, this adds the ppa that has the latest git release, which is currently 2.29.0.

```
jenkins@95e512092aa4:/$ git --version
git version 2.29.0
jenkins@95e512092aa4:/$ git lfs --version
git-lfs/2.12.0 (GitHub; linux amd64; go 1.13.4)
```
