### PR TITLE
Support set custom uid and gid for jenkins user

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -17,8 +17,8 @@ RUN apk add --no-cache \
 
 ARG user=jenkins
 ARG group=jenkins
-ARG uid=1000
-ARG gid=1000
+ARG uid
+ARG gid
 ARG http_port=8080
 ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
@@ -27,6 +27,8 @@ ARG REF=/usr/share/jenkins/ref
 ENV JENKINS_HOME $JENKINS_HOME
 ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
 ENV REF $REF
+ENV uid ${uid:-1000}
+ENV gid ${gid:-1000}
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,


### PR DESCRIPTION
For correct work with docker socket need permission to jenkins user uid on the host system