### PR TITLE
Bump openjdk images from Debian Stretch to Buster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-stretch
+FROM openjdk:8-jdk-buster
 
 # Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
 # Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository

--- a/Dockerfile-jdk11
+++ b/Dockerfile-jdk11
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-stretch
+FROM openjdk:11-jdk-buster
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && git lfs install && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile-slim
+++ b/Dockerfile-slim
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-slim
+FROM openjdk:8-jdk-slim-buster
 
 # Install git lfs on Debian stretch per https://github.com/git-lfs/git-lfs/wiki/Installation#debian-and-ubuntu
 # Avoid JENKINS-59569 - git LFS 2.7.1 fails clone with reference repository


### PR DESCRIPTION
Debian Stretch has reached end of life on 2020-07-06.
https://wiki.debian.org/DebianReleases#Production_Releases

Dockerfile-slim is also using Debian Buster but is not explicitly.
Changed to be explicitly.