### PR TITLE
Remove experimental image publishing

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -19,23 +19,6 @@ Download the test helpers by updating the submodules
 
 Bats can be easily installed with `brew install bats` on OS X
 
-## Multiarch support
-
-Multiarch support is added via the `publish-experimental.sh` script, which relies on QEMU for emulating the architecture being built as well as the Docker `https://github.com/estesp/manifest-tool[manifest-tool]` for creating registry
-v2.2 "thick" manifests.
-
-When changes are pushed to the upstream Jenkins project, a job is triggered via the `Jenkinsfile` from this repo, which then runs the `publish-experimental.sh` script in parallel mode. Multiarch images created by the script are built/tagged/pushed to the Docker Hub `https://hub.docker.com/r/jenkins4eval/jenkins/[jenkins4eval/jenkins]` repo.
-
-Currently supported architectures:
-
-* amd64
-* arm32
-* arm64
-* s390x
-* ppc64le
-
-NOTE:This functionality may change/move at some point in the future.
-
 ## Debugging
 
 In order to debug the master, use the `-e DEBUG=true -p 5005:5005` when starting the container.
@@ -55,28 +38,4 @@ export DOCKERHUB_REPO=test-jenkins
 Docker repository in Use:
 * JENKINS_REPO: batmat/test-jenkins
 ...
---
-
-## Test the publishing of Multi-arch image using an overridden target repository
-
-Create a new dedicated target repository in your Docker Hub account, and use it like follows:
-
-[source]
---
-export DOCKERHUB_ORGANISATION=durgadas
-export DOCKERHUB_REPO=jenkins
-
-./publish-experimental.sh --variant alpine 
-
-# The log below will help confirm this override was taken in account:
-Docker repository in Use:
-* JENKINS_REPO: durgadas/jenkins
-...
---
-
-Also, one can execute the publish-experimental.sh using:
-
-[source]
---  
-make publish-experimental
 --

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,15 +46,6 @@ nodeWithTimeout('docker') {
         }
 
         parallel builders
-
-        def branchName = "${env.BRANCH_NAME}"
-        if (branchName ==~ 'master'){
-            stage('Publish Experimental') {
-                infra.withDockerCredentials {
-                    sh 'make publish-experimental'
-                }
-            }
-        }
     } else {
         /* In our trusted.ci environment we only want to be publishing our
          * containers from artifacts

--- a/multiarch/Dockerfile.alpine
+++ b/multiarch/Dockerfile.alpine
@@ -1,4 +1,4 @@
-# Placeholder for the specified arch that gets parsed in the publish-experimental.sh script.
+# Placeholder for the specified arch that gets parsed in the publish-images.sh script.
 FROM BASEIMAGE
 
 RUN apk add --no-cache git openssh-client curl unzip bash ttf-dejavu coreutils dpkg gnupg tar && rm -rf /tmp/*.apk /var/cache/apk/*

--- a/multiarch/Dockerfile.debian
+++ b/multiarch/Dockerfile.debian
@@ -1,4 +1,4 @@
-# Placeholder for the specified arch that gets parsed in the publish-experimental.sh script.
+# Placeholder for the specified arch that gets parsed in the publish-images.sh script.
 FROM BASEIMAGE
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl dpkg gpg tar && rm -rf /var/lib/apt/lists/*

--- a/multiarch/Dockerfile.slim
+++ b/multiarch/Dockerfile.slim
@@ -1,4 +1,4 @@
-# Placeholder for the specified arch that gets parsed in the publish-experimental.sh script.
+# Placeholder for the specified arch that gets parsed in the publish-images.sh script.
 FROM BASEIMAGE
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl dpkg gpg tar && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Remove experimental image publishing

7e270c32e43db9f7a1c039128fc2c7f0c61698f4 removed the publish-experimental script.  That commit enabled parallel builds and moved the publish.sh script into the .ci/ directory.  Unfortunately, it did not remove the reference to publish-experimental from the Jenkinsfile or other files in the repository.

This pull request assumes the intent was to move all publishing to trusted.ci, including both the publishing of experimental builds and official builds.

Even if that was not the intent, this pull request does not make things any worse. There is no make target for publish-experimental, so this will allow the job to complete successfully on ci.jenkins.io, though the ci.jenkins.io job will now only run tests and not publish any experimental images.

I'm happy to discard this pull request in favor of a pull request that places publishing of experimental images on ci.jenkins.io.  However, I wasn't confident that `make publish` on ci.jenkins.io would choose the experimental Dockerhub organization as intended.