### PR TITLE
removing quotes around CURL_OPTIONS

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -246,6 +246,7 @@ main() {
 
     # Get the update center URL based on the jenkins version
     jenkinsVersion="$(jenkinsMajorMinorVersion)"
+    # shellcheck disable=SC2086
     jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
     if [ -n "${jenkinsUcJson}" ]; then
         JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -246,7 +246,7 @@ main() {
 
     # Get the update center URL based on the jenkins version
     jenkinsVersion="$(jenkinsMajorMinorVersion)"
-    jenkinsUcJson=$(curl "${CURL_OPTIONS:--sSfL}" -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
+    jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
     if [ -n "${jenkinsUcJson}" ]; then
         JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}
         echo "Using version-specific update center: $JENKINS_UC_LATEST..."


### PR DESCRIPTION
in case CURL_OPTIONS is set to more than one flag the double quotes around it would not allow to recognize all the flags and break the script.