### PR TITLE
Hacktoberfest - Update find command to filter out windows Dockerfiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROOT_DIR="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/"
 
 all: shellcheck build test
 
-DOCKERFILES=$(shell find . -type f -not -path "./tests/*" -name Dockerfile)
+DOCKERFILES=$(shell find . -not -path '**/windows/*' -not -path './tests/*' -type f -name Dockerfile)
 
 shellcheck:
 	$(ROOT_DIR)/tools/shellcheck -e SC1091 \


### PR DESCRIPTION
The current Makefile finds all the Dockerfiles in the repo, but this was before the Windows stuff was merged in. This filters out the Windows directories so the Linux systems don't try and build the Windows docker images.