### PR TITLE
Use JDK 8u272 Alpine image

### DIFF
--- a/8/alpine/hotspot/Dockerfile
+++ b/8/alpine/hotspot/Dockerfile
@@ -1,7 +1,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u262-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
 
 RUN apk add --no-cache \
   bash \


### PR DESCRIPTION
## Use JDK 8u272 Alpine image

Upgrade from 8u262 to 8u272.

See also https://github.com/jenkinsci/docker-agent/pull/155

See also https://github.com/jenkinsci/docker-ssh-agent/pull/67