### PR TITLE
[Hactoberfest] Fail the execution at the end if any publishing failures

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -124,6 +124,9 @@ if($target -eq "publish") {
             Write-Host "Publishing $Build => tag=$tag"
             $cmd = "docker push {0}/{1}:{2}" -f $Organization, $Repository, $tag
             Invoke-Expression $cmd
+            if($lastExitCode -ne 0) {
+                $publishFailed = 1
+            }
 
             if($PushVersions) {
                 $buildTag = "$JenkinsVersion-$tag"

--- a/make.ps1
+++ b/make.ps1
@@ -117,6 +117,8 @@ if($target -eq "test") {
 }
 
 if($target -eq "publish") {
+    # Only fail the run afterwards in case of any issues when publishing the docker images
+    $publishFailed = 0
     if(![System.String]::IsNullOrWhiteSpace($Build) -and $builds.ContainsKey($Build)) {
         foreach($tag in $Builds[$Build]['Tags']) {
             Write-Host "Publishing $Build => tag=$tag"
@@ -131,6 +133,9 @@ if($target -eq "publish") {
                 Write-Host "Publishing $Build => tag=$buildTag"
                 $cmd = "docker push {0}/{1}:{2}" -f $Organization, $Repository, $buildTag
                 Invoke-Expression $cmd
+                if($lastExitCode -ne 0) {
+                    $publishFailed = 1
+                }
             }
         }
     } else {
@@ -139,6 +144,9 @@ if($target -eq "publish") {
                 Write-Host "Publishing $b => tag=$tag"
                 $cmd = "docker push {0}/{1}:{2}" -f $Organization, $Repository, $tag
                 Invoke-Expression $cmd
+                if($lastExitCode -ne 0) {
+                    $publishFailed = 1
+                }
 
                 if($PushVersions) {
                     $buildTag = "$JenkinsVersion-$tag"
@@ -148,9 +156,18 @@ if($target -eq "publish") {
                     Write-Host "Publishing $Build => tag=$buildTag"
                     $cmd = "docker push {0}/{1}:{2}" -f $Organization, $Repository, $buildTag
                     Invoke-Expression $cmd
+                    if($lastExitCode -ne 0) {
+                        $publishFailed = 1
+                    }
                 }
             }
         }
+    }
+
+    # Fail if any issues when publising the docker images
+    if($publishFailed -ne 0) {
+        Write-Error "Publish failed!"
+        exit 1
     }
 }
 


### PR DESCRIPTION
Similar to https://github.com/jenkinsci/docker/pull/1011

### What

Fail the build if any issues with publishing the docker images

It does not fail fast to be able to provide as many details as possible.
