### PR TITLE
Run docker system-prune always

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,6 +28,8 @@ stage('Build') {
                     def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
                     junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
                     if (windowsTestStatus > 0) {
+                        // If something bad happened let's clean up the docker images
+                        powershell(script: '& docker system prune --force --all', returnStatus: true)
                         error('Windows test stage failed.')
                     }
                 }
@@ -42,6 +44,8 @@ stage('Build') {
                         }
                     }
                 }
+                // Let's always clean up the docker images at the very end
+                powershell(script: '& docker system prune --force --all', returnStatus: true)
             } else {
                 /* In our trusted.ci environment we only want to be publishing our
                 * containers from artifacts
@@ -92,8 +96,15 @@ stage('Build') {
                     // Create a map to pass in to the 'parallel' step so we can fire all the builds at once
                     builders[label] = {
                         stage("Test ${label}") {
-                            sh "make test-$label"
-                            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                            try {
+                                sh "make test-$label"
+                            } catch(err) {
+                                // If something bad happened let's clean up the docker images
+                                sh(script: 'docker system prune --force --all', returnStatus: true)
+                                error("${err.toString()}")
+                            } finally {
+                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                            }
                         }
                     }
                 }
@@ -108,6 +119,9 @@ stage('Build') {
                         }
                     }
                 }
+
+                // Let's always clean up the docker images at the very end
+                sh(script: 'docker system prune --force --all', returnStatus: true)
             } else {
                 /* In our trusted.ci environment we only want to be publishing our
                 * containers from artifacts

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,8 +99,6 @@ stage('Build') {
                             try {
                                 sh "make test-$label"
                             } catch(err) {
-                                // If something bad happened let's clean up the docker images
-                                sh(script: 'docker system prune --force --all', returnStatus: true)
                                 error("${err.toString()}")
                             } finally {
                                 junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')


### PR DESCRIPTION
### What

Fixes

```
[2020-11-06T08:06:15.954Z] stderr:
[2020-11-06T08:06:15.954Z] re-exec error: exit status 1: output: write \\?\C:\ProgramData\docker\tmp\hcs668360599\Files\Users\jenkins\AppData\Local\javasharedresources\C290M11F1A64P_sharedcc_jenkins_G41L00: There is not enough space on the disk.
```

### Follow up

I'm also working on a declarative pipeline