### PR TITLE
Schedule only when building master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,15 @@
 #!/usr/bin/env groovy
 
-properties([
-    buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '5')),
-    pipelineTriggers([cron('''H H/6 * * 0-2,4-6
-H 6,21 * * 3''')])
-])
+def listOfProperties = []
+listOfProperties << buildDiscarder(logRotator(numToKeepStr: '50', artifactNumToKeepStr: '5'))
 
+// Only master branch will run on a timer basis
+if (env.BRANCH_NAME.trim() == 'master') {
+    listOfProperties << pipelineTriggers([cron('''H H/6 * * 0-2,4-6
+H 6,21 * * 3''')])
+}
+
+properties(listOfProperties)
 
 stage('Build') {
     def builds = [:]


### PR DESCRIPTION
### What

Avoid running the cron on a PR basis but only of the master branch

See [PRs](https://ci.jenkins.io/job/Packaging/job/docker/view/change-requests/) that have been triggered continuously.

### Why

Unnecessary for PRs. And as a consequence it will mitigate the number of resources and the windows bottleneck.