### PR TITLE
Added JAVA_OPTS environment variable to jenkins-plugin-cli

### DIFF
--- a/jenkins-plugin-cli.ps1
+++ b/jenkins-plugin-cli.ps1
@@ -1,1 +1,1 @@
-& java -jar C:/ProgramData/Jenkins/jenkins-plugin-manager.jar $args
+& java "$env:JAVA_OPTS" -jar C:/ProgramData/Jenkins/jenkins-plugin-manager.jar $args

--- a/jenkins-plugin-cli.sh
+++ b/jenkins-plugin-cli.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java ${JAVA_OPTS:+"$JAVA_OPTS"} -jar /usr/lib/jenkins-plugin-manager.jar "$@"
+exec /bin/bash -c "java $JAVA_OPTS -jar /usr/lib/jenkins-plugin-manager.jar $*"

--- a/jenkins-plugin-cli.sh
+++ b/jenkins-plugin-cli.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-java -jar /usr/lib/jenkins-plugin-manager.jar "$@"
+java ${JAVA_OPTS:+"$JAVA_OPTS"} -jar /usr/lib/jenkins-plugin-manager.jar "$@"

--- a/jenkins-plugin-cli.sh
+++ b/jenkins-plugin-cli.sh
@@ -1,3 +1,3 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 exec /bin/bash -c "java $JAVA_OPTS -jar /usr/lib/jenkins-plugin-manager.jar $*"

--- a/tests/plugins-cli.bats
+++ b/tests/plugins-cli.bats
@@ -237,7 +237,7 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   run docker_build_child $SUT_IMAGE-plugins-cli-java-opts $BATS_TEST_DIRNAME/plugins-cli/java-opts
   assert_success
   # Assert JAVA_OPTS has been used and 'java.opts.test' has been set to JVM
-  assert_line --partial 'java.opts.test = true'
+  assert_line --regexp '\s*java.opts.test\s*=\s*true.*'
 }
 
 @test "[${SUT_DESCRIPTION}] clean work directory" {

--- a/tests/plugins-cli.bats
+++ b/tests/plugins-cli.bats
@@ -232,3 +232,15 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
   assert_success
 }
+
+@test "[${SUT_DESCRIPTION}] JAVA_OPTS environment variable is used with jenkins-plugin-cli" {
+  run docker_build_child $SUT_IMAGE-plugins-cli-java-opts $BATS_TEST_DIRNAME/plugins-cli/java-opts
+  assert_success
+  # Assert JAVA_OPTS has been used and 'java.opts.test' has been set to JVM
+  assert_line --partial 'java.opts.test = true'
+}
+
+@test "[${SUT_DESCRIPTION}] clean work directory" {
+  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
+  assert_success
+}

--- a/tests/plugins-cli/java-opts/Dockerfile
+++ b/tests/plugins-cli/java-opts/Dockerfile
@@ -1,0 +1,4 @@
+FROM bats-jenkins-plugins-cli
+
+ENV JAVA_OPTS="-Djava.opts.test=true -XshowSettings:properties"
+RUN jenkins-plugin-cli --version


### PR DESCRIPTION
This PR adds JAVA_OPTS environment variable to plugin-installation-manager-tool call.
It allows to use additional java options like ```http.proxyHost```, ```http.proxyPort```, etc.