### PR TITLE
chore: displaying dockerfile before building

### DIFF
--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -57,6 +57,7 @@ function docker_build_child {
     local tag=$1; shift
     local dir=$1; shift
     sed -e "s/FROM bats-jenkins/FROM $(sut_image)/" "$dir/Dockerfile" > "$dir/Dockerfile.tmp"
+    cat $dir/Dockerfile.tmp >&3
     docker build -t "$tag" "$@" -f "$dir/Dockerfile.tmp" "$dir"
 }
 


### PR DESCRIPTION
Hopefully this will help us see what the failure is when trying to build the containers during plugin update