### PR TITLE
Allow parallel testing

### DIFF
--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -56,8 +56,10 @@ function docker_build {
 function docker_build_child {
     local tag=$1; shift
     local dir=$1; shift
-    sed -e "s/FROM bats-jenkins/FROM $(sut_image)/" "$dir/Dockerfile" > "$dir/Dockerfile.tmp"
-    docker build -t "$tag" "$@" -f "$dir/Dockerfile.tmp" "$dir"
+    local tmp=$(mktemp "$dir/Dockerfile.XXXXXX")
+    sed -e "s/FROM bats-jenkins/FROM $(sut_image)/" "$dir/Dockerfile" > "$tmp"
+    docker build -t "$tag" "$@" -f "$tmp" "$dir"
+    rm "$tmp"
 }
 
 function get_jenkins_url {


### PR DESCRIPTION
## Allow parallel testing

Use unqiue temporary file for the Dockerfile defined in each test.  Without this change, concurrent tests cannot be run reliably from the same directory.
