### PR TITLE
chore: stop attempting to publish latest

### DIFF
--- a/.ci/publish-tags.sh
+++ b/.ci/publish-tags.sh
@@ -81,17 +81,17 @@ publish-variant() {
     local variant=$2
     local archs=$3
     local tag=$4
-	echo "Processing ${tag} on these architectures: ${archs}"
+	  echo "Processing ${tag} on these architectures: ${archs}"
 
     for arch in ${archs}; do
         if [[ "$force" = true ]]; then
             echo "Force processing tag!"
 
-            echo "Pulling ${version}-${variant}-${arch}"
+            echo "Pulling ${JENKINS_REPO}:${version}-${variant}-${arch}"
             # Pull down images to be re-tagged
             docker pull "${JENKINS_REPO}:${version}-${variant}-${arch}"
 
-            echo "Re-tagging image from ${version}-${variant}-${arch} to ${JENKINS_REPO}:${tag}-${arch}"
+            echo "Re-tagging image from ${JENKINS_REPO}:${version}-${variant}-${arch} to ${JENKINS_REPO}:${tag}-${arch}"
             docker-tag "${JENKINS_REPO}:${version}-${variant}-${arch}" "${JENKINS_REPO}:${tag}-${arch}"
 
             docker push "${JENKINS_REPO}:${variant}-${arch}"
@@ -102,11 +102,11 @@ publish-variant() {
             echo "Removed images from local disk"
         else
             if ! compare-digests "${version}-${variant}-${arch}" "${tag}-${arch}"; then
-                echo "Pulling ${version}-${variant}-${arch}"
+                echo "Pulling ${JENKINS_REPO}:${version}-${variant}-${arch}"
                 # Pull down images to be re-tagged
                 docker pull "${JENKINS_REPO}:${version}-${variant}-${arch}"
 
-                echo "Re-tagging image from ${version}-${variant}-${arch} to ${JENKINS_REPO}:${tag}-${arch}"
+                echo "Re-tagging image from ${JENKINS_REPO}:${version}-${variant}-${arch} to ${JENKINS_REPO}:${tag}-${arch}"
                 docker-tag "${JENKINS_REPO}:${version}-${variant}-${arch}" "${JENKINS_REPO}:${tag}-${arch}"
 
                 docker push "${JENKINS_REPO}:${tag}-${arch}"
@@ -165,7 +165,7 @@ publish-lts-debian() {
 publish-latest() {
     local version=$1
     local variant="debian"
-	local archs="arm64 s390x ppc64le amd64"
+	  local archs="arm64 s390x ppc64le amd64"
     publish-variant "${version}"  "${variant}"  "${archs}"  "latest"
 }
 

--- a/.ci/publish-tags.sh
+++ b/.ci/publish-tags.sh
@@ -81,7 +81,7 @@ publish-variant() {
     local variant=$2
     local archs=$3
     local tag=$4
-	  echo "Processing ${tag} on these architectures: ${archs}"
+    echo "Processing ${tag} on these architectures: ${archs}"
 
     for arch in ${archs}; do
         if [[ "$force" = true ]]; then
@@ -165,7 +165,7 @@ publish-lts-debian() {
 publish-latest() {
     local version=$1
     local variant="debian"
-	  local archs="arm64 s390x ppc64le amd64"
+    local archs="arm64 s390x ppc64le amd64"
     publish-variant "${version}"  "${variant}"  "${archs}"  "latest"
 }
 

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -101,15 +101,15 @@ publish() {
     fi
 
     if [ "$variant" == "-alpine" ] ; then
-	dockerfile="./8/alpine/hotspot/Dockerfile"
+      dockerfile="./8/alpine/hotspot/Dockerfile"
     elif [ "$variant" == "-slim" ] ; then
-	dockerfile="./8/debian/buster-slim/hotspot/Dockerfile"
+      dockerfile="./8/debian/buster-slim/hotspot/Dockerfile"
     elif [ "$variant" == "-jdk11" ] ; then
-	dockerfile="./11/debian/buster/hotspot/Dockerfile"
+      dockerfile="./11/debian/buster/hotspot/Dockerfile"
     elif [ "$variant" == "-centos" ] ; then
-	dockerfile="./8/centos/centos8/hotspot/Dockerfile"
+      dockerfile="./8/centos/centos8/hotspot/Dockerfile"
     elif [ "$variant" == "-centos7" ] ; then
-	dockerfile="./8/centos/centos7/hotspot/Dockerfile"
+      dockerfile="./8/centos/centos7/hotspot/Dockerfile"
     fi
 
     sha=$(curl -q -fsSL "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war.sha256" )

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -101,15 +101,15 @@ publish() {
     fi
 
     if [ "$variant" == "-alpine" ] ; then
-      dockerfile="./8/alpine/hotspot/Dockerfile"
+        dockerfile="./8/alpine/hotspot/Dockerfile"
     elif [ "$variant" == "-slim" ] ; then
-      dockerfile="./8/debian/buster-slim/hotspot/Dockerfile"
+        dockerfile="./8/debian/buster-slim/hotspot/Dockerfile"
     elif [ "$variant" == "-jdk11" ] ; then
-      dockerfile="./11/debian/buster/hotspot/Dockerfile"
+        dockerfile="./11/debian/buster/hotspot/Dockerfile"
     elif [ "$variant" == "-centos" ] ; then
-      dockerfile="./8/centos/centos8/hotspot/Dockerfile"
+        dockerfile="./8/centos/centos8/hotspot/Dockerfile"
     elif [ "$variant" == "-centos7" ] ; then
-      dockerfile="./8/centos/centos7/hotspot/Dockerfile"
+        dockerfile="./8/centos/centos7/hotspot/Dockerfile"
     fi
 
     sha=$(curl -q -fsSL "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war.sha256" )

--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,7 @@ publish-tag-lts-alpine:
 publish-tags-lts-slim:
 	./.ci/publish-tags.sh --tag lts-slim ;
 
-publish-tags-latest:
-	./.ci/publish-tags.sh --tag latest ;
-
-publish-tags: publish-tags-debian publish-tag-alpine publish-tags-slim publish-tags-lts-debian publish-tag-lts-alpine publish-tags-lts-slim publish-tags-latest
+publish-tags: publish-tags-debian publish-tag-alpine publish-tags-slim publish-tags-lts-debian publish-tag-lts-alpine publish-tags-lts-slim
 
 publish-manifests-debian:
 	./.ci/publish-manifests.sh --variant debian ;
@@ -150,9 +147,6 @@ publish-manifests-lts-alpine:
 publish-manifests-lts-slim:
 	./.ci/publish-manifests.sh --variant lts-slim ;
 
-publish-manifests-latest:
-	./.ci/publish-manifests.sh --variant latest ;
-
 publish-manifests-versions-debian:
 	./.ci/publish-manifests.sh --variant versions-debian ;
 
@@ -162,7 +156,7 @@ publish-manifests-versions-alpine:
 publish-manifests-versions-slim:
 	./.ci/publish-manifests.sh --variant versions-slim ;
 
-publish-manifests: publish-manifests-debian publish-manifests-alpine publish-manifests-slim publish-manifests-lts-debian publish-manifests-lts-alpine publish-manifests-lts-slim publish-manifests-latest publish-manifests-versions-debian publish-manifests-versions-alpine publish-manifests-versions-slim
+publish-manifests: publish-manifests-debian publish-manifests-alpine publish-manifests-slim publish-manifests-lts-debian publish-manifests-lts-alpine publish-manifests-lts-slim publish-manifests-versions-debian publish-manifests-versions-alpine publish-manifests-versions-slim
 
 clean:
 	rm -rf tests/test_helper/bats-*; \


### PR DESCRIPTION
publishing 'latest' is currently failing, the make target has only recently
been fixed. Looking at some later PRs that rework the build process, latest 
has been removed.

Am hoping that this will fix the master build to give some confidence that 
the build is functioning