### PR TITLE
Use JDK 8u275 on Alpine

### DIFF
--- a/8/alpine/hotspot/Dockerfile
+++ b/8/alpine/hotspot/Dockerfile
@@ -1,7 +1,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u272-b10-alpine
+FROM adoptopenjdk/openjdk8:jdk8u275-b01-alpine
 
 RUN apk add --no-cache \
   bash \


### PR DESCRIPTION
Latest JDK 8 release on Alpine

Changes from jdk8u272b10 to jdk8u275b01 unlikely to affect Jenkins, but simpler to remain current than to fall behind.
