### PR TITLE
Typos, updated version, only delete on success

### DIFF
--- a/11/ubuntu/bionic/openj9/Dockerfile
+++ b/11/ubuntu/bionic/openj9/Dockerfile
@@ -48,10 +48,10 @@ RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.176.2}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.235.4}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=33a6c3161cf8de9c8729fd83914d781319fd1569acf487c7b1121681dba190a5
+ARG JENKINS_SHA=e5688a8f07cc3d79ba3afa3cab367d083dd90daab77cebd461ba8e83a1e3c177
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/tests/plugins-cli/ref/Dockerfile
+++ b/tests/plugins-cli/ref/Dockerfile
@@ -1,3 +1,3 @@
-FROM bats-jenkins-install-plugins
+FROM bats-jenkins-plugins-cli
 
 RUN rm -rf /usr/share/jenkins/ref ; jenkins-plugin-cli --plugins junit:1.28 ant:1.3

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -58,8 +58,7 @@ function docker_build_child {
     local dir=$1; shift
     local tmp=$(mktemp "$dir/Dockerfile.XXXXXX")
     sed -e "s/FROM bats-jenkins/FROM $(sut_image)/" "$dir/Dockerfile" > "$tmp"
-    docker build -t "$tag" "$@" -f "$tmp" "$dir"
-    rm "$tmp"
+    docker build -t "$tag" "$@" -f "$tmp" "$dir" && rm "$tmp"
 }
 
 function get_jenkins_url {


### PR DESCRIPTION
There was a typo in the Dockerfile for the plugins-cli ref that used install-plugins instead of plugins-cli

The JENKINS_VERSION in the 11/ubuntu/bionic/openj9/Dockerfile was incorrect.

Only removed the temp Dockerfile on success, keep it in failure cases for debugging