### PR TITLE
Update Java versions

### DIFF
--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-alpine
 
 RUN apk add --no-cache \
   bash \

--- a/11/debian/buster-slim/hotspot/Dockerfile
+++ b/11/debian/buster-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:debianslim
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-debianslim-slim
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git git-lfs curl gpg unzip libfreetype6 libfontconfig1 && git lfs install && rm -rf /var/lib/apt/lists/*
 

--- a/11/debian/buster/hotspot/Dockerfile
+++ b/11/debian/buster/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:debian
+FROM adoptopenjdk/openjdk11:jdk-11.0.10_9-debian
 
 RUN apt-get update && apt-get upgrade -y && apt-get install -y git curl && curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs unzip && git lfs install && rm -rf /var/lib/apt/lists/*
 

--- a/8/alpine/hotspot/Dockerfile
+++ b/8/alpine/hotspot/Dockerfile
@@ -1,7 +1,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u275-b01-alpine
+FROM adoptopenjdk/openjdk8:jdk8u282-b08-alpine
 
 RUN apk add --no-cache \
   bash \

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -6,7 +6,7 @@ This document explains how to develop on this repository.
 
 Build with the usual
 
-    docker build -t jenkins/jenkins .
+    make build-debian # or build-alpine build-slim build-jdk11 build-centos build-centos7 build-openj9 build-openj9-jdk11
 
 Tests are written using `https://github.com/sstephenson/bats[bats]` under the `tests` dir
 


### PR DESCRIPTION
## Update to Java 8u282 & 11.0.10

- Replace JDK 11.0.9 with JDK 11.0.10
- Update build directions for current dir structure
- Use JDK 8u282 in Alpine image

Does not update the Debian Stretch image because the Debian Stretch base image (openjdk:8-jdk-stretch) is no longer being updated by the openjdk project on Dockerhub.
