### PR TITLE
Ensure that Buildkit is used

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 ROOT_DIR="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/"
 
+# Ensure that docker builds are using BuildKit for an efficient caching
+export DOCKER_BUILDKIT=1
+
 all: shellcheck build test
 
 DOCKERFILES=$(shell find . -not -path '**/windows/*' -not -path './tests/*' -type f -name Dockerfile)


### PR DESCRIPTION
The goal of this PR is to enable the BUILDKIT engine for docker build, trying to improve build times.

In the current state, it might not change a lot (I expected from 0 to 10s on a ~26 min build: it's nothing), but it sets the ground for a lot of usages (improved layer caching, multi stage build to enhance paralelization) in the future.

As per https://docs.docker.com/develop/develop-images/build_enhancements/:
* With Docker < 18.09, the environment variable is not evaluated and the behavior of `docker build`
* With Docker >= 18.09 < 20.10, the environment variable is evaluated and `docker build` uses buildkit
* With Docker >= 20.10, the environment variable is not evaluated but `docker build` uses buildkit by default