### PR TITLE
Experiment parallelized Linux docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ shellcheck:
 	                             *.sh
 build:
 	@for d in ${DOCKERFILES} ; do \
-		docker build --file "$${d}" . ; \
+		docker build --file "$${d}" . & \
 	done
 
 build-debian:

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,8 @@ shellcheck:
 build:
 	@for d in ${DOCKERFILES} ; do \
 		docker build --file "$${d}" . & \
-	done
+	done; \
+	wait
 
 build-debian:
 	docker build --file 8/debian/buster/hotspot/Dockerfile .


### PR DESCRIPTION
This PR is an experiment to check the impact of parallelizing the docker builds commands from the `make build` step using shell background processes.

It is a draft as it is NOT aimed to be merged.

By impact, it means checking:

- Impact on the build time
- Impact on the resource exhaustion of the Linux agent which handles the builds

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>