### PR TITLE
Experiment parallelized Linux image tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ test-openj9-jdk11: test-run-openj9-jdk11
 test: build prepare-test
 	@for d in ${DOCKERFILES} ; do \
 		dir=`dirname $$d | sed -e "s_^\./__"` ; \
-		DIRECTORY=$${dir} bats/bin/bats tests ; \
+		DIRECTORY=$${dir} bats/bin/bats tests & \
 	done
 
 test-install-plugins: prepare-test

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,8 @@ test: build prepare-test
 	@for d in ${DOCKERFILES} ; do \
 		dir=`dirname $$d | sed -e "s_^\./__"` ; \
 		DIRECTORY=$${dir} bats/bin/bats tests & \
-	done
+	done; \
+	wait
 
 test-install-plugins: prepare-test
 	DIRECTORY="8/alpine/hotspot" bats/bin/bats tests/install-plugins.bats tests/install-plugins-plugins-cli.bats


### PR DESCRIPTION
This PR is an experiment to check the impact of parallelizing the bats tests from the `make step` step using shell background processes.

It is a draft as it is NOT aimed to be merged.

By impact, it means checking:

- Impact on the build time
- Impact on the resource exhaustion of the Linux agent which handles the builds

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>