### PR TITLE
Added description of custom plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ This CLI will perform downloads from update centers, and internet access is requ
 
 See the CLI's [documentation](https://github.com/jenkinsci/plugin-installation-manager-tool) for more information,
 or run `jenkins-plugin-cli --help` to see the available options.
+
+### Installing Custom Plugins
+
+Installing prebuilt, custom plugins can be accomplished by copying the plugin HPI file into `/usr/share/jenkins/ref/plugins/` within the `Dockerfile`:
+
+```
+COPY path/to/custom.hpi /usr/share/jenkins/ref/plugins/
+```
  
 ### Usage
 


### PR DESCRIPTION
Added a description in the plugin section that describes installing custom plugins. There's a number of ways listed to install remote plugins via the `plugins.txt` but that only helps with remotely-available plugins. In some cases a developer may have a custom written plugin they need to load as part of building a container. The method described is to copy the HPI file into the `/usr/share/jenkins/ref/plugins/` directory which then joins the rest of any other remotely-installed plugins.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
