### PR TITLE
Fix terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,13 @@ For more info check Docker docs section on [Use volumes](https://docs.docker.com
 
 # Setting the number of executors
 
-You can define the number of executors on the built-in Jenkins master node using a groovy script.
-By default it is set to 2 executors, but you can extend the image and change it to your desired number of executors (recommended 0 executors on the master node) :
+You can define the number of executors on the Jenkins built-in node using a groovy script.
+By default it is set to 2 executors, but you can extend the image and change it to your desired number of executors (recommended 0 executors on the built-in node) :
 
 `executors.groovy`
 ```
 import jenkins.model.*
-Jenkins.instance.setNumExecutors(0) // Recommended to not run builds on the master node
+Jenkins.instance.setNumExecutors(0) // Recommended to not run builds on the built-in node
 ```
 
 and `Dockerfile`

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a fully functional Jenkins server.
 docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts
 ```
 
-NOTE: read the section [_Connecting agents_](#attaching-agents) below for the role of the `50000` port mapping.
+NOTE: read the section [_Connecting agents_](#connecting-agents) below for the role of the `50000` port mapping.
 
 This will store the workspace in `/var/jenkins_home`.
 All Jenkins data lives in there - including plugins and configuration.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is a fully functional Jenkins server.
 docker run -p 8080:8080 -p 50000:50000 jenkins/jenkins:lts
 ```
 
-NOTE: read below the _build executors_ part for the role of the `50000` port mapping.
+NOTE: read the section [_Connecting agents_](#attaching-agents) below for the role of the `50000` port mapping.
 
 This will store the workspace in `/var/jenkins_home`.
 All Jenkins data lives in there - including plugins and configuration.
@@ -53,13 +53,13 @@ For more info check Docker docs section on [Use volumes](https://docs.docker.com
 
 # Setting the number of executors
 
-You can define the number of executors on your Jenkins controller using a groovy script.
-By default it is set to 2 executors, but you can extend the image and change it to your desired number of executors (recommended 0 executors on the controller) :
+You can define the number of executors on the built-in Jenkins master node using a groovy script.
+By default it is set to 2 executors, but you can extend the image and change it to your desired number of executors (recommended 0 executors on the master node) :
 
 `executors.groovy`
 ```
 import jenkins.model.*
-Jenkins.instance.setNumExecutors(0) // Recommended to not enable executors on the controller
+Jenkins.instance.setNumExecutors(0) // Recommended to not run builds on the master node
 ```
 
 and `Dockerfile`
@@ -69,15 +69,16 @@ FROM jenkins/jenkins:lts
 COPY --chown=jenkins:jenkins executors.groovy /usr/share/jenkins/ref/init.groovy.d/executors.groovy
 ```
 
-# Attaching build executors
+# Connecting agents
 
 You can run builds on the controller out of the box.
 The Jenkins project recommends that no executors be enabled on the controller.
 
-In order to attach agents **through an inbound connection**, map the port: `-p 50000:50000`.
-That port will be used when you connect agents.
+In order to connect agents **through an inbound TCP connection**, map the port: `-p 50000:50000`.
+That port will be used when you connect agents to the controller.
 
-If you are only using [SSH (outbound) build agents](), port mapping is not required.
+If you are only using [SSH (outbound) build agents](https://plugins.jenkins.io/ssh-slaves/), this port is not required, as connections are established from the controller.
+If you connect agents using web sockets (since Jenkins 2.217), the TCP agent port is not used either.
 
 # Passing JVM parameters
 


### PR DESCRIPTION
Fixes terminology, including the wrong changes applied in #1101.

"Controller" is not the correct term for the node built-in to Jenkins, we do not yet have a new term.

"Connecting" vs. "Attaching" is a personal preference, unless there's some special significance to the latter I recommend the former -- I've never seen "attaching" used in this context (and given Docker uses _attach_ for e.g. `docker start -a`, seems potentially misleading)

Origin branch, please delete on merge.