### PR TITLE
fix: use 'jq' to get the DockerHub Bearer token

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -43,8 +43,14 @@ docker-tag() {
 }
 
 login-token() {
-    # could use jq .token
-    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | grep -o '"token":"[^"]*"' | cut -d':' -f 2 | xargs echo
+    ## Install jq in a temp directory. Sorry.
+    JQ_DIR="$(mktemp -d)"
+    JQ_BIN="${JQ_DIR}/jq"
+    curl --silent --show-error --location --output "${JQ_BIN}" https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
+    sha256sum "${JQ_BIN}" | grep -q "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
+    chmod +x "${JQ_BIN}"
+
+    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | "${JQ_BIN}" -r '.token'
 }
 
 is-published() {


### PR DESCRIPTION
* Goal: replace the broken shell parsing
* Yes, I know, installing tools at build time is not the best.
  Expect `jq` to be installed in the VM template soon.
* Security Mitigation: `jq` is installed on a temp file,
  not added to the path, and checksum controlled for the fixed version 1.6

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>
