### PR TITLE
Add Alma Linux alongside CentOS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @jenkinsci/team-docker-packaging
-
 */rhel/ubi*/ @olivergondza
+*/almalinux/almalinux8/ @saper

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,20 @@ updates:
   labels:
   - dependencies
 
+# AlmaLinux
+
+- package-ecosystem: docker
+  directory: "11/almalinux/almalinux8/hotspot"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  reviewers:
+  - saper
+  - slide
+  labels:
+  - dependencies
+
 # CentOS Linux
 
 - package-ecosystem: docker

--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -77,7 +77,7 @@ ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
 
 ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.10.0/jenkins-plugin-manager-2.10.0.jar
-RUN curl -fsSL ${PLUGIN_CLI_URL} -o /usr/lib/jenkins-plugin-manager.jar
+RUN curl -fsSL ${PLUGIN_CLI_URL} -o /opt/jenkins-plugin-manager.jar
 
 # for main web interface:
 EXPOSE ${http_port}

--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,0 +1,100 @@
+FROM almalinux:8.4
+
+RUN echo -e '[AdoptOpenJDK]\n\
+name=AdoptOpenJDK\n\
+baseurl=https://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/centos/$releasever/$basearch\n\
+enabled=1\n\
+gpgcheck=1\n\
+gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public' > /etc/yum.repos.d/adoptopenjdk.repo && \
+    dnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs update -y && \
+    dnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
+	adoptopenjdk-11-hotspot-11.0.11+9-3 \
+	fontconfig \
+	freetype \
+	git-lfs \
+	unzip \
+	&& \
+    dnf clean all
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+ARG http_port=8080
+ARG agent_port=50000
+ARG JENKINS_HOME=/var/jenkins_home
+ARG REF=/usr/share/jenkins/ref
+
+ENV JENKINS_HOME $JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
+ENV REF $REF
+
+# Jenkins is run with user `jenkins`, uid = 1000
+# If you bind mount a volume from the host or a data container,
+# ensure you use the same uid
+RUN mkdir -p $JENKINS_HOME \
+  && chown ${uid}:${gid} $JENKINS_HOME \
+  && groupadd -g ${gid} ${group} \
+  && useradd -N -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
+
+# Jenkins home directory is a volume, so configuration and build history
+# can be persisted and survive image upgrades
+VOLUME $JENKINS_HOME
+
+# $REF (defaults to `/usr/share/jenkins/ref/`) contains all reference configuration we want
+# to set on a fresh new installation. Use it to bundle additional plugins
+# or config file with your custom jenkins Docker image.
+RUN mkdir -p ${REF}/init.groovy.d
+
+# Use tini as subreaper in Docker container to adopt zombie processes
+ARG TINI_VERSION=v0.16.1
+COPY tini_pub.gpg ${JENKINS_HOME}/tini_pub.gpg
+RUN curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64 -o /sbin/tini \
+  && curl -fsSL https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-static-amd64.asc -o /sbin/tini.asc \
+  && gpg --no-tty --import ${JENKINS_HOME}/tini_pub.gpg \
+  && gpg --verify /sbin/tini.asc \
+  && rm -rf /sbin/tini.asc /root/.gnupg \
+  && chmod +x /sbin/tini
+
+# jenkins version being bundled in this docker image
+ARG JENKINS_VERSION
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.235.4}
+
+# jenkins.war checksum, download will be validated using it
+ARG JENKINS_SHA=e5688a8f07cc3d79ba3afa3cab367d083dd90daab77cebd461ba8e83a1e3c177
+
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
+
+# could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
+# see https://github.com/docker/docker/issues/8331
+RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
+  && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
+
+ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
+ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
+RUN chown -R ${user} "$JENKINS_HOME" "$REF"
+
+ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.10.0/jenkins-plugin-manager-2.10.0.jar
+RUN curl -fsSL ${PLUGIN_CLI_URL} -o /usr/lib/jenkins-plugin-manager.jar
+
+# for main web interface:
+EXPOSE ${http_port}
+
+# will be used by attached agents:
+EXPOSE ${agent_port}
+
+ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+USER ${user}
+
+COPY jenkins-support /usr/local/bin/jenkins-support
+COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY tini-shim.sh /bin/tini
+COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
+
+# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
+COPY install-plugins.sh /usr/local/bin/install-plugins.sh

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -6,7 +6,7 @@ This document explains how to develop on this repository.
 
 Build with the usual
 
-    make build-debian # or build-alpine build-slim build-jdk11 build-centos build-centos7
+    make build-debian # or build-alpine build-slim build-jdk11 build-almalinux build-centos build-centos7
 
 Tests are written using `https://github.com/sstephenson/bats[bats]` under the `tests` dir
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,7 @@ stage('Build') {
                     sh "make prepare-test"
                 }
 
-                def labels = ['debian', 'slim', 'alpine', 'jdk11', 'centos', 'centos7', 'rhel-ubi8-jdk11']
+                def labels = ['debian', 'slim', 'alpine', 'jdk11', 'almalinux', 'centos', 'centos7', 'rhel-ubi8-jdk11']
                 def builders = [:]
                 for (x in labels) {
                     def label = x

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ build-slim:
 build-jdk11:
 	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load debian_jdk11
 
+build-almalinux:
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load almalinux_jdk11
+
 build-centos:
 	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load centos8_jdk8
 
@@ -71,6 +74,9 @@ test-slim: test-run-slim
 
 test-jdk11: DIRECTORY=11/debian/buster/hotspot
 test-jdk11: test-run-jdk11
+
+test-almalinux: DIRECTORY=11/almalinux/almalinux8/hotspot
+test-almalinux: test-run-almalinux
 
 test-centos: DIRECTORY=8/centos/centos8/hotspot
 test-centos: test-run-centos

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -86,7 +86,7 @@ target "almalinux_jdk11" {
     JENKINS_SHA = JENKINS_SHA
   }
   tags = [
-    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-almalinux"]
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-almalinux",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:almalinux" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-almalinux" : "",
   ]

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,6 @@
 group "linux" {
   targets = [
+    "almalinux_jdk11",
     "alpine_jdk8",
     "centos7_jdk8",
     "centos8_jdk8",
@@ -12,6 +13,7 @@ group "linux" {
 
 group "linux-arm64" {
   targets = [
+    "almalinux_jdk11",
     "centos8_jdk8",
     "debian_jdk8",
     "debian_jdk11",
@@ -74,6 +76,21 @@ variable "GIT_LFS_VERSION" {
 
 variable "PLUGIN_CLI_VERSION" {
   default = "2.10.0"
+}
+
+target "almalinux_jdk11" {
+  dockerfile = "11/almalinux/almalinux8/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-almalinux"]
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:almalinux" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-almalinux" : "",
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
 }
 
 target "alpine_jdk8" {


### PR DESCRIPTION
Facing uncertain future of CentOS, let's give Alma Linux a chance
with their 8.4 release.

As of Thu Jun 17 00:01:40 UTC 2021 there is no CentOS 8.4 Docker image published. In the meantime Alma Linux stepped in to fill in the void and provided 8.4 release based on Red Hat Enterprise Linux 8.4.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Upstream git-lfs change: https://github.com/git-lfs/git-lfs/pull/4531, easy workaround applied in this PR

```
saper@debian10-amd64:~/jenkinsci-docker$ make test-almalinux
git submodule update --init --recursive
mkdir -p target
DIRECTORY="8/almalinux/almalinux8/hotspot" bats/bin/bats tests | tee target/results-almalinux.tap
1..45
ok 1 [8-almalinux-almalinux8-hotspot] build image
ok 2 [8-almalinux-almalinux8-hotspot] versionLT
ok 3 [8-almalinux-almalinux8-hotspot] permissions are propagated from override file
ok 4 [8-almalinux-almalinux8-hotspot] build image
ok 5 [8-almalinux-almalinux8-hotspot] plugins are installed with install-plugins.sh
ok 6 [8-almalinux-almalinux8-hotspot] plugins are installed with install-plugins.sh with non-default REF
ok 7 [8-almalinux-almalinux8-hotspot] plugins are installed with install-plugins.sh from a plugins file
ok 8 [8-almalinux-almalinux8-hotspot] plugins are installed with install-plugins.sh even when already exist
ok 9 [8-almalinux-almalinux8-hotspot] clean work directory
ok 10 [8-almalinux-almalinux8-hotspot] plugins are getting upgraded but not downgraded
ok 11 [8-almalinux-almalinux8-hotspot] clean work directory
ok 12 [8-almalinux-almalinux8-hotspot] do not upgrade if plugin has been manually updated
ok 13 [8-almalinux-almalinux8-hotspot] clean work directory
ok 14 [8-almalinux-almalinux8-hotspot] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true
ok 15 [8-almalinux-almalinux8-hotspot] clean work directory
ok 16 [8-almalinux-almalinux8-hotspot] plugins are installed with install-plugins.sh and no war
ok 17 [8-almalinux-almalinux8-hotspot] Use a custom jenkins.war
ok 18 [8-almalinux-almalinux8-hotspot] clean work directory
ok 19 [8-almalinux-almalinux8-hotspot] build image
ok 20 [8-almalinux-almalinux8-hotspot] plugins are installed with jenkins-plugin-cli
ok 21 [8-almalinux-almalinux8-hotspot] plugins are installed with jenkins-plugin-cli with non-default REF
ok 22 [8-almalinux-almalinux8-hotspot] plugins are installed with jenkins-plugin-cli from a plugins file
ok 23 [8-almalinux-almalinux8-hotspot] plugins are installed with jenkins-plugin-cli even when already exist
ok 24 [8-almalinux-almalinux8-hotspot] clean work directory
ok 25 [8-almalinux-almalinux8-hotspot] plugins are getting upgraded but not downgraded
ok 26 [8-almalinux-almalinux8-hotspot] clean work directory
ok 27 [8-almalinux-almalinux8-hotspot] do not upgrade if plugin has been manually updated
ok 28 [8-almalinux-almalinux8-hotspot] clean work directory
ok 29 [8-almalinux-almalinux8-hotspot] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true
ok 30 [8-almalinux-almalinux8-hotspot] clean work directory
ok 31 [8-almalinux-almalinux8-hotspot] plugins are installed with jenkins-plugin-cli and no war
ok 32 [8-almalinux-almalinux8-hotspot] Use a custom jenkins.war
ok 33 [8-almalinux-almalinux8-hotspot] clean work directory
ok 34 [8-almalinux-almalinux8-hotspot] JAVA_OPTS environment variable is used with jenkins-plugin-cli
ok 35 [8-almalinux-almalinux8-hotspot] clean work directory
ok 36 [8-almalinux-almalinux8-hotspot] build image
ok 37 [8-almalinux-almalinux8-hotspot] clean test containers
ok 38 [8-almalinux-almalinux8-hotspot] test multiple JENKINS_OPTS
ok 39 [8-almalinux-almalinux8-hotspot] test jenkins arguments
ok 40 [8-almalinux-almalinux8-hotspot] timezones are handled correctly
ok 41 [8-almalinux-almalinux8-hotspot] create test container
ok 42 [8-almalinux-almalinux8-hotspot] test container is running

ok 43 [8-almalinux-almalinux8-hotspot] Jenkins is initialized
ok 44 [8-almalinux-almalinux8-hotspot] JAVA_OPTS are set
ok 45 [8-almalinux-almalinux8-hotspot] clean test containers
docker run --rm -v "/home/saper/jenkinsci-docker":/usr/src/app \
				-w /usr/src/app node:12-alpine \
				sh -c "npm install tap-xunit -g && cat target/results-almalinux.tap | tap-xunit --package='jenkinsci.docker.almalinux' > target/junit-results-almalinux.xml"
Unable to find image 'node:12-alpine' locally
12-alpine: Pulling from library/node
ddad3d7c1e96: Pull complete 
3a8370f05d5d: Pull complete 
71a8563b7fea: Pull complete 
119c7e14957d: Pull complete 
Digest: sha256:152bd04c3bb9001eebaa1f5a9c5d8bb9253fd3ae8b4a261f5fe760dce38b98ff
Status: Downloaded newer image for node:12-alpine
/usr/local/bin/tap-xunit -> /usr/local/lib/node_modules/tap-xunit/bin/tap-xunit
/usr/local/bin/txunit -> /usr/local/lib/node_modules/tap-xunit/bin/tap-xunit
+ tap-xunit@2.4.1
added 21 packages from 21 contributors in 1.731s
```