### PR TITLE
.ci/publish.sh: Fetch token more frequently

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -234,6 +234,7 @@ TOKEN=$(login-token)
 lts_version=""
 version=""
 for version in $(get-latest-versions); do
+    TOKEN=$(login-token)
     if is-published "$version$variant"; then
         echo "Tag is already published: $version$variant"
     else
@@ -252,8 +253,10 @@ for version in $(get-latest-versions); do
     fi
 done
 
+TOKEN=$(login-token)
 publish-latest "${version}" "${variant}"
 
+TOKEN=$(login-token)
 if [ -n "${lts_version}" ]; then
     publish-lts "${lts_version}" "${variant}"
 else

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -43,14 +43,7 @@ docker-tag() {
 }
 
 login-token() {
-    ## Install jq in a temp directory. Sorry.
-    JQ_DIR="$(mktemp -d)"
-    JQ_BIN="${JQ_DIR}/jq"
-    curl --silent --show-error --location --output "${JQ_BIN}" https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-    sha256sum "${JQ_BIN}" | grep -q "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
-    chmod +x "${JQ_BIN}"
-
-    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | "${JQ_BIN}" -r '.token'
+    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | jq -r '.token'
 }
 
 is-published() {


### PR DESCRIPTION
When publishing more images at a time authentication token
from Docker may expire, stopping the process with 401 errors.


- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue