### PR TITLE
Remove test that requires very specific setup

### DIFF
--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -30,13 +30,3 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 1.0-beta-1 1.0-alpha-1"
   assert_failure
 }
-
-@test "[${SUT_DESCRIPTION}] permissions are propagated from override file" {
-  run docker_build_child $SUT_IMAGE-functions $BATS_TEST_DIRNAME/functions
-  assert_success
-
-  # replace DOS line endings \r\n
-  run bash -c "docker run -v $BATS_TEST_DIRNAME/functions:/var/jenkins_home --rm $SUT_IMAGE-functions stat -c '%a' /var/jenkins_home/.ssh/config"
-  assert_success
-  assert_line '600'
-}

--- a/tests/functions/Dockerfile
+++ b/tests/functions/Dockerfile
@@ -1,4 +1,0 @@
-FROM bats-jenkins
-
-RUN mkdir -p /usr/share/jenkins/ref/.ssh && touch /usr/share/jenkins/ref/.ssh/config.override
-RUN chmod 600 /usr/share/jenkins/ref/.ssh/config.override


### PR DESCRIPTION
This test requires the user on the host to use the `uid` of 1000.

I've done some experimentation with @dduportal and haven't managed to get the test in a way that works with a user without 1000 UID, I've looked at changing the uid of the user in infra but it's not easy to use 1000 as the AWS ami pre-creates that user, (the reason we changed from the default user was so that we use a user that doesn't have sudo permissions)

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
