### PR TITLE
fix: allow test harness to run successfully with buildkit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 ROOT_DIR="$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/"
 
+export DOCKER_BUILDKIT=1
+export BUILDKIT_PROGRESS=plain
+
 all: shellcheck build test
 
 DOCKERFILES=$(shell find . -not -path '**/windows/*' -not -path './tests/*' -type f -name Dockerfile)

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -107,7 +107,7 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   run docker_build_child $SUT_IMAGE-install-plugins-update $BATS_TEST_DIRNAME/install-plugins/update --no-cache
   assert_success
   assert_line --partial 'Skipping already installed dependency workflow-step-api'
-  assert_line "Using provided plugin: ant"
+  assert_line --partial 'Using provided plugin: ant'
   # replace DOS line endings \r\n
   run bash -c "docker run --rm $SUT_IMAGE-install-plugins-update unzip -p /var/jenkins_home/plugins/junit.jpi META-INF/MANIFEST.MF | tr -d '\r'"
   assert_success

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -56,9 +56,11 @@ function docker_build {
 function docker_build_child {
     local tag=$1; shift
     local dir=$1; shift
-    local tmp=$(mktemp "$dir/Dockerfile.XXXXXX")
+    local tmp
+    tmp=$(mktemp "$dir/Dockerfile.XXXXXX")
     sed -e "s/FROM bats-jenkins/FROM $(sut_image)/" "$dir/Dockerfile" > "$tmp"
-    docker build -t "$tag" "$@" -f "$tmp" "$dir" && rm "$tmp"
+    docker build -t "$tag" "$@" -f "$tmp" "$dir" 2>&1
+    rm "$tmp"
 }
 
 function get_jenkins_url {


### PR DESCRIPTION
Depends on #1125 

So since Docker 20.10, [Buildkit](https://docs.docker.com/develop/develop-images/build_enhancements/) is enabled by default, it changes the behavior of `docker build <...>` outputs.

This PR ensures that buildkit is used and that it outputs the build steps' output (`progress==plain`).

Different cases when running the test harness:

- On Docker 20.10+ => nothing to worry abouth buildkit is used and test are expected to pass
- On Docker 19.04, 19.10 or 20.04 => buildkit is "force-enable" and test are expected to pass
- On older Docker version => there is no buildkit, but tests are expected to pass... for now. Please upgrade :)

Signed-off-by: Damien Duportal <damien.duportal@gmail.com>


- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
~- [ ] Link to relevant issues in GitHub or Jira~
~- [ ] Link to relevant pull requests, esp. upstream and downstream changes~
~- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue~
