### PR TITLE
Update openj9 images (java 8 one no longer exists)

### DIFF
--- a/11/ubuntu/focal/openj9/Dockerfile
+++ b/11/ubuntu/focal/openj9/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:11.0.10_9-jdk-openj9-0.24.0-focal
+FROM adoptopenjdk:11.0.11_9-jdk-openj9-0.26.0-focal
 
 RUN apt-get update \
   && apt-get upgrade -y \

--- a/8/ubuntu/focal/openj9/Dockerfile
+++ b/8/ubuntu/focal/openj9/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk:8u292-b10-jdk-openj9-0.24.0-focal
+FROM adoptopenjdk:8u292-b10-jdk-openj9-0.26.0-focal
 
 RUN apt-get update \
   && apt-get upgrade -y \


### PR DESCRIPTION
```
docker pull adoptopenjdk:8u292-b10-jdk-openj9-0.24.0-focal
Error response from daemon: manifest for adoptopenjdk:8u292-b10-jdk-openj9-0.24.0-focal not found: manifest unknown: manifest unknown

➜  docker git:(master) ✗ docker pull adoptopenjdk:8u292-b10-jdk-openj9-0.26.0-focal
8u292-b10-jdk-openj9-0.26.0-focal: Pulling from library/adoptopenjdk
```