### PR TITLE
Add docker baking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,6 @@ build:
 build-arm64:
 	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/arm64' --load linux-arm64
 
-build-arm64:
-	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/arm64' --load linux-arm64
-
 build-s390x:
 	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/s390x' --load linux-s390x
 

--- a/Makefile
+++ b/Makefile
@@ -12,27 +12,40 @@ shellcheck:
 	                             jenkins-support \
 	                             *.sh
 build:
-	@for d in ${DOCKERFILES} ; do \
-		docker build --file "$${d}" . ; \
-	done
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load linux
+
+build-arm64:
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/arm64' --load linux-arm64
+
+build-arm64:
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/arm64' --load linux-arm64
+
+build-s390x:
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/s390x' --load linux-s390x
+
+build-ppc64le:
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/ppc64le' --load linux-ppc64le
+
+build-multiarch:
+	docker buildx bake -f docker-bake.hcl --load linux
 
 build-debian:
-	docker build --file 8/debian/buster/hotspot/Dockerfile .
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load debian_jdk8
 
 build-alpine:
-	docker build --file 8/alpine/hotspot/Dockerfile .
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load alpine_jdk8
 
 build-slim:
-	docker build --file 8/debian/buster-slim/hotspot/Dockerfile .
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load debian_slim_jdk8
 
 build-jdk11:
-	docker build --file 11/debian/buster/hotspot/Dockerfile .
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load debian_slim_jdk8
 
 build-centos:
-	docker build --file 8/centos/centos8/hotspot/Dockerfile .
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load centos7_jdk8
 
 build-centos7:
-	docker build --file 8/centos/centos7/hotspot/Dockerfile .
+	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load centos8_jdk8
 
 bats:
 	# Latest tag is unfortunately 0.4.0 which is quite older than the latest master tip.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -54,8 +54,8 @@ variable "REGISTRY" {
   default = "docker.io"
 }
 
-variable "OWNER" {
-  default = "jenkins"
+variable "JENKINS_REPO" {
+  default = "jenkins/jenkins"
 }
 
 target "alpine_jdk8" {
@@ -65,7 +65,7 @@ target "alpine_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-alpine"]
+  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-alpine"]
   platforms = ["linux/amd64"]
 }
 
@@ -76,7 +76,7 @@ target "centos7_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-centos7"]
+  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos7"]
   platforms = ["linux/amd64"]
 }
 
@@ -87,7 +87,7 @@ target "centos8_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-centos"]
+  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos"]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
@@ -98,7 +98,7 @@ target "debian_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}"]
+  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}"]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
@@ -109,7 +109,7 @@ target "debian_jdk11" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-jdk11"]
+  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-jdk11"]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
 }
 
@@ -120,7 +120,7 @@ target "debian_slim_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-slim"]
+  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-slim"]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
@@ -132,7 +132,7 @@ target "windows_1809_jdk11" {
     JENKINS_SHA = JENKINS_SHA
   }
 
-  tags = ["${REGISTRY}/${OWNER}/jdk11-hotspot-windowsservercore-1809"]
+  tags = ["{REGISTRY}/${JENKINS_REPO}:jdk11-hotspot-windowsservercore-1809"]
 }
 
 target "windows_2019_jdk11" {
@@ -142,5 +142,5 @@ target "windows_2019_jdk11" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${OWNER}/jdk11-hotspot-windowsservercore-2019"]
+  tags = ["{REGISTRY}/${JENKINS_REPO}:jdk11-hotspot-windowsservercore-2019"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,148 @@
+// TODO handle latest / latest-variant / latest-lts
+
+group "linux" {
+  targets = [
+    "alpine_jdk8",
+    "centos7_jdk8",
+    "centos8_jdk8",
+    "debian_jdk8",
+    "debian_jdk11",
+    "debian_slim_jdk8",
+  ]
+}
+
+group "linux-arm64" {
+  targets = [
+    "centos8_jdk8",
+    "debian_jdk8",
+    "debian_jdk11",
+    "debian_slim_jdk8",
+  ]
+}
+
+group "linux-s390x" {
+  targets = [
+    "debian_jdk8",
+    "debian_jdk11",
+    "debian_slim_jdk8",
+  ]
+}
+
+group "linux-ppc64le" {
+  targets = [
+    "centos8_jdk8",
+    "debian_jdk8",
+    "debian_jdk11",
+    "debian_slim_jdk8",
+  ]
+}
+
+group "windows" {
+  targets = [
+    "windows_1809_jdk11",
+    "windows_2019_jdk11",
+  ]
+}
+
+variable "JENKINS_VERSION" {
+  default = "2.300"
+}
+
+variable "JENKINS_SHA" {
+  default = "2f6aa548373b038af4fb6a4d6eaa5d13679510008f1712532732bf77c55b9670"
+}
+
+variable "REGISTRY" {
+  default = "docker.io"
+}
+
+variable "OWNER" {
+  default = "jenkins"
+}
+
+target "alpine_jdk8" {
+  dockerfile = "8/alpine/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-alpine"]
+  platforms = ["linux/amd64"]
+}
+
+target "centos7_jdk8" {
+  dockerfile = "8/centos/centos7/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-centos7"]
+  platforms = ["linux/amd64"]
+}
+
+target "centos8_jdk8" {
+  dockerfile = "8/centos/centos8/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-centos"]
+  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
+}
+
+target "debian_jdk8" {
+  dockerfile = "8/debian/buster/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}"]
+  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
+}
+
+target "debian_jdk11" {
+  dockerfile = "11/debian/buster/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-jdk11"]
+  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
+}
+
+target "debian_slim_jdk8" {
+  dockerfile = "8/debian/buster-slim/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-slim"]
+  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
+}
+
+target "windows_1809_jdk11" {
+  dockerfile = "11/windows/windowsservercore-1809/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+
+  tags = ["${REGISTRY}/${OWNER}/jdk11-hotspot-windowsservercore-1809"]
+}
+
+target "windows_2019_jdk11" {
+  dockerfile = "11/windows/windowsservercore-2019/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+  }
+  tags = ["${REGISTRY}/${OWNER}/jdk11-hotspot-windowsservercore-2019"]
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -22,9 +22,7 @@ group "linux-arm64" {
 
 group "linux-s390x" {
   targets = [
-    "debian_jdk8",
     "debian_jdk11",
-    "debian_slim_jdk8",
   ]
 }
 
@@ -101,7 +99,7 @@ target "debian_jdk8" {
     JENKINS_SHA = JENKINS_SHA
   }
   tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}"]
-  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
 target "debian_jdk11" {
@@ -123,7 +121,7 @@ target "debian_slim_jdk8" {
     JENKINS_SHA = JENKINS_SHA
   }
   tags = ["${REGISTRY}/${OWNER}/jenkins:${JENKINS_VERSION}-slim"]
-  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
 target "windows_1809_jdk11" {


### PR DESCRIPTION
ref https://github.com/jenkinsci/docker/pull/1133#issuecomment-869594457

This is part 1 in a series of PRs

It converts the build process (CI only) to [docker buildx bake](https://docs.docker.com/engine/reference/commandline/buildx_bake/) which parallelises the build, and will allow moving shell script logic / makefile to declarative configuration

Already it shows that a number of the dockerfiles we have checked into the repo aren't being published which is not clear from looking at the scripts.

Remaining work for future PRs:
- Convert publishing scripts to bake
- Enable multi-arch on CI, `make` targets have been added in this PR to show how that will work
- Add ssh credentials to trusted ci credentials store for existing `s390x`, `ppc64le` static agents
- Update pipeline to load ssh credentials for above agents
- Create an arm64 VM
- Add ssh credentials to trusted ci for arm and add to pipeline
- Add builder definitions to trusted ci agent or pipeline, see description in https://github.com/jenkinsci/docker/pull/1133
- Enable publishing multi arch builds, should just be a matter of removing a `--set '*.platform=linux/amd64'`

Above steps do not need to all be done in order, probably won't enable CI until publishing is ready although can have a PR up earlier.

Any thoughts / feedback?

Help would be loved as well cc @dduportal / @olblak
