### PR TITLE
Use docker buildx bake for publishing

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -13,7 +13,7 @@ source ./.ci/common-functions.sh > /dev/null 2>&1
 : "${DOCKERHUB_ORGANISATION:=jenkins}"
 : "${DOCKERHUB_REPO:=jenkins}"
 
-JENKINS_REPO="${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}"
+export JENKINS_REPO="${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}"
 
 cat <<EOF
 Docker repository in Use:
@@ -28,29 +28,8 @@ sort-versions() {
     fi
 }
 
-# Try tagging with and without -f to support all versions of docker
-docker-tag() {
-    local from="${JENKINS_REPO}:$1"
-    local to="$2/${DOCKERHUB_REPO}:$3"
-    local out
-
-    docker pull "$from"
-    if out=$(docker tag -f "$from" "$to" 2>&1); then
-        echo "$out"
-    else
-        docker tag "$from" "$to"
-    fi
-}
-
 login-token() {
-    ## Install jq in a temp directory. Sorry.
-    JQ_DIR="$(mktemp -d)"
-    JQ_BIN="${JQ_DIR}/jq"
-    curl --silent --show-error --location --output "${JQ_BIN}" https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64
-    sha256sum "${JQ_BIN}" | grep -q "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44"
-    chmod +x "${JQ_BIN}"
-
-    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | "${JQ_BIN}" -r '.token'
+    curl -q -sSL "https://auth.docker.io/token?service=registry.docker.io&scope=repository:${JENKINS_REPO}:pull" | jq -r '.token'
 }
 
 is-published() {
@@ -71,125 +50,37 @@ is-published() {
     fi
 }
 
-get-manifest() {
-    local tag=$1
-    local opts=""
-    if [ "$debug" = true ]; then
-        opts="-v"
-    fi
-    curl $opts -q -fsSL -H "Accept: application/vnd.docker.distribution.manifest.v2+json" -H "Authorization: Bearer $TOKEN" "https://index.docker.io/v2/${JENKINS_REPO}/manifests/$tag"
-}
-
-get-digest() {
-    local manifest
-    manifest=$(get-manifest "$1")
-    #get-manifest "$1" | jq .config.digest
-    if [ "$debug" = true ]; then
-        >&2 echo "DEBUG: Manifest for $1: $manifest"
-    fi
-    echo "$manifest" | grep -A 10 -o '"config".*' | grep digest | head -1 | cut -d':' -f 2,3 | xargs echo
-}
-
 get-latest-versions() {
     curl -q -fsSL https://repo.jenkins-ci.org/releases-20210630/org/jenkins-ci/main/jenkins-war/maven-metadata.xml | grep '<version>.*</version>' | grep -E -o '[0-9]+(\.[0-9]+)+' | sort-versions | uniq | tail -n 30
 }
 
 publish() {
     local version=$1
-    local variant=$2
-    local tag="${version}${variant}"
+    local latest_weekly=$2
+    local latest_lts=$3
     local sha
-    local build_opts=(--no-cache --pull)
-    local dockerfile="./8/debian/buster/hotspot/Dockerfile"
+    local build_opts=(--pull --push)
 
     if [ "$dry_run" = true ]; then
         build_opts=()
     fi
 
-    if [ "$variant" == "-alpine" ] ; then
-        dockerfile="./8/alpine/hotspot/Dockerfile"
-    elif [ "$variant" == "-slim" ] ; then
-        dockerfile="./8/debian/buster-slim/hotspot/Dockerfile"
-    elif [ "$variant" == "-jdk11" ] ; then
-        dockerfile="./11/debian/buster/hotspot/Dockerfile"
-    elif [ "$variant" == "-centos" ] ; then
-        dockerfile="./8/centos/centos8/hotspot/Dockerfile"
-    elif [ "$variant" == "-centos7" ] ; then
-        dockerfile="./8/centos/centos7/hotspot/Dockerfile"
-    fi
-
     sha=$(curl -q -fsSL "https://repo.jenkins-ci.org/releases-20210630/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war.sha256" )
 
-    docker build --file "${dockerfile}" \
-                 --build-arg "JENKINS_VERSION=$version" \
-                 --build-arg "JENKINS_SHA=$sha" \
-                 --tag "${JENKINS_REPO}:${tag}" \
-                 "${build_opts[@]+"${build_opts[@]}"}" .
 
-    # " line to fix syntax highlightning
-    if [ ! "$dry_run" = true ]; then
-        docker push "${JENKINS_REPO}:${tag}"
-    else
+    export JENKINS_VERSION=$version
+    export JENKINS_SHA=$sha
+    export LATEST_WEEKLY=$latest_weekly
+    export LATEST_LTS=$latest_lts
+    set -x
+    docker buildx bake --file docker-bake.hcl \
+                 --set '*.platform=linux/amd64' \
+                 "${build_opts[@]+"${build_opts[@]}"}" linux
+    set +x
+    if [ "$dry_run" = true ]; then
         echo "Dry run mode: no docker push"
     fi
-}
 
-tag-and-push() {
-    local source=$1
-    local target=$2
-    local digest_source
-    local digest_target
-
-    if [ "$debug" = true ]; then
-        >&2 echo "DEBUG: Getting digest for ${source}"
-    fi
-    # if tag doesn't exist yet, ie. dry run
-    if ! digest_source=$(get-digest "${source}"); then
-        echo "Unable to get source digest for '${source} ${digest_source}'"
-        digest_source=""
-    fi
-
-    if [ "$debug" = true ]; then
-        >&2 echo "DEBUG: Getting digest for ${target}"
-    fi
-    if ! digest_target=$(get-digest "${target}"); then
-        echo "Unable to get target digest for '${target} ${digest_target}'"
-        digest_target=""
-    fi
-
-    if [ "$digest_source" == "$digest_target" ] && [ -n "${digest_target}" ]; then
-        echo "Images ${source} [$digest_source] and ${target} [$digest_target] are already the same, not updating tags"
-    else
-        echo "Creating tag ${target} pointing to ${source}"
-        docker-tag "${source}" "${DOCKERHUB_ORGANISATION}" "${target}"
-        destination="${REPO:-${JENKINS_REPO}}:${target}"
-        if [ ! "$dry_run" = true ]; then
-            echo "Pushing ${destination}"
-            docker push "${destination}"
-        else
-            echo "Would push ${destination}"
-        fi
-    fi
-}
-
-publish-latest() {
-    local version=$1
-    local variant=$2
-    echo "publishing latest: $version$variant"
-
-    # push latest (for master) or the name of the branch (for other branches)
-    if [ -z "${variant}" ]; then
-        tag-and-push "${version}${variant}" "latest"
-    else
-        tag-and-push "${version}${variant}" "${variant#-}"
-    fi
-}
-
-publish-lts() {
-    local version=$1
-    local variant=$2
-    tag-and-push "${version}${variant}" "lts${variant}"
-    tag-and-push "${version}${variant}" "${version}-lts${variant}"
 }
 
 # Process arguments
@@ -197,7 +88,7 @@ publish-lts() {
 dry_run=false
 debug=false
 variant=""
-start_after="1.0" # By default, we will publish anything missing (only the last 20 actually)
+start_after="1.0" # By default, we will publish anything missing (only the last 30 actually)
 
 while [[ $# -gt 0 ]]; do
     key="$1"
@@ -231,31 +122,34 @@ fi
 
 TOKEN=$(login-token)
 
-lts_version=""
-version=""
-for version in $(get-latest-versions); do
+versions=$(get-latest-versions)
+latest_weekly_version=$(echo "${versions}" | tail -n 1)
+
+latest_lts_version=$(echo "${versions}" | grep -E '[0-9]\.[0-9]+\.[0-9]' | tail -n 1 || echo "No LTS versions")
+
+for version in $versions; do
     if is-published "$version$variant"; then
         echo "Tag is already published: $version$variant"
     else
         echo "$version$variant not published yet"
-        if versionLT "$start_after" "$version"; then # if start_after < version
-            echo "Version $version higher than $start_after: publishing $version$variant"
-            publish "$version" "$variant"
+
+        if [[ $version == "${latest_weekly_version}" ]]; then
+          latest_weekly="true"
         else
-            echo "Version $version lower or equal to $start_after, no publishing (variant=$variant)."
+          latest_weekly="false"
+        fi
+
+        if [[ $version == "${latest_lts_version}" ]]; then
+          latest_lts="true"
+        else
+          latest_lts="false"
+        fi
+
+        if versionLT "$start_after" "$version"; then # if start_after < version
+            echo "Version $version higher than $start_after: publishing $version latest_weekly:${latest_weekly} latest_lts:${latest_lts}"
+            publish "$version" "${latest_weekly}" "${latest_lts}"
+        else
+            echo "Version $version lower or equal to $start_after, no publishing."
         fi
     fi
-
-    # Update lts tag (if we have an LTS version depending on $start_after)
-    if versionLT "$start_after" "$version" && [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        lts_version="${version}"
-    fi
 done
-
-publish-latest "${version}" "${variant}"
-
-if [ -n "${lts_version}" ]; then
-    publish-lts "${lts_version}" "${variant}"
-else
-    echo "No LTS publishing"
-fi

--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,7 @@ test-install-plugins: prepare-test
 	DIRECTORY="8/alpine/hotspot" bats/bin/bats tests/install-plugins.bats tests/install-plugins-plugins-cli.bats
 
 publish:
-	./.ci/publish.sh ; \
-	./.ci/publish.sh --variant alpine ; \
-	./.ci/publish.sh --variant slim ; \
-	./.ci/publish.sh --variant jdk11 --start-after 2.151 ; \
-	./.ci/publish.sh --variant centos --start-after 2.181 ; \
-	./.ci/publish.sh --variant centos7 --start-after 2.199 ;
+	./.ci/publish.sh
 
 publish-images-variant:
 	./.ci/publish-images.sh --variant ${VARIANT} --arch ${ARCH} ;

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,5 +1,3 @@
-// TODO handle latest / latest-variant / latest-lts
-
 group "linux" {
   targets = [
     "alpine_jdk8",
@@ -58,6 +56,14 @@ variable "JENKINS_REPO" {
   default = "jenkins/jenkins"
 }
 
+variable "LATEST_WEEKLY" {
+  default = "false"
+}
+
+variable "LATEST_LTS" {
+  default = "false"
+}
+
 target "alpine_jdk8" {
   dockerfile = "8/alpine/hotspot/Dockerfile"
   context = "."
@@ -65,7 +71,11 @@ target "alpine_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-alpine"]
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-alpine",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:alpine" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-alpine" : "",
+  ]
   platforms = ["linux/amd64"]
 }
 
@@ -76,7 +86,11 @@ target "centos7_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos7"]
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos7",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:centos7" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-centos7" : "",
+  ]
   platforms = ["linux/amd64"]
 }
 
@@ -87,7 +101,11 @@ target "centos8_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos"]
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:centos" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-centos" : "",
+  ]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
@@ -98,7 +116,11 @@ target "debian_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}"]
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:latest" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts" : "",
+  ]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
@@ -109,7 +131,11 @@ target "debian_jdk11" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-jdk11"]
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-jdk11",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:jdk11" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-jdk11" : "",
+  ]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64", "linux/s390x"]
 }
 
@@ -120,7 +146,11 @@ target "debian_slim_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-slim"]
+  tags = [
+    "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-slim",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:slim" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-slim" : "",
+  ]
   platforms = ["linux/amd64", "linux/ppc64le", "linux/arm64"]
 }
 
@@ -132,7 +162,11 @@ target "windows_1809_jdk11" {
     JENKINS_SHA = JENKINS_SHA
   }
 
-  tags = ["{REGISTRY}/${JENKINS_REPO}:jdk11-hotspot-windowsservercore-1809"]
+  tags = [
+    "{REGISTRY}/${JENKINS_REPO}:jdk11-hotspot-windowsservercore-1809",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:windowsservercore-1809" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-windowsservercore-1809" : "",
+  ]
 }
 
 target "windows_2019_jdk11" {
@@ -142,5 +176,9 @@ target "windows_2019_jdk11" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
   }
-  tags = ["{REGISTRY}/${JENKINS_REPO}:jdk11-hotspot-windowsservercore-2019"]
+  tags = [
+    "{REGISTRY}/${JENKINS_REPO}:jdk11-hotspot-windowsservercore-2019",
+    equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:windowsservercore-2019" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-windowsservercore-2019" : "",
+  ]
 }


### PR DESCRIPTION
This PR enables use of `docker buildx bake` for publishing images, which should drastically improve publish time.

**This does not enable mult-arch, the platform is overridden to only be `amd64`.**

Windows script is not touched as part of this, I wonder if the windows images are even used? They currently don't push a pinned version of Jenkins, whatever is built last seems to be the image in use. Anyway if people think it's required I think it's fine to do in another PR


There's more that could be removed,

* Most of the `Makefile`
* .ci/publish-images.sh
* .ci/publish-manifests.sh
* .ci/publish-tags.sh

But could do that when we enable multi arch builds

(If we want to try this tomorrow I'll be around and can fix forward if there's any issues, next week I'll be away)