### PR TITLE
Bring back "chore: Bump Bats to 1.3.0 (#1127)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,7 @@ build-centos7:
 	docker buildx bake -f docker-bake.hcl --set '*.platform=linux/amd64' --load centos7_jdk8
 
 bats:
-	# Latest tag is unfortunately 0.4.0 which is quite older than the latest master tip.
-	# So we clone and reset to this well known current sha:
-	git clone https://github.com/sstephenson/bats.git ; \
-	cd bats; \
-	git reset --hard 03608115df2071fff4eaaff1605768c275e5f81f
+	git clone -b v1.3.0 https://github.com/bats-core/bats-core bats
 
 prepare-test: bats
 	git submodule update --init --recursive

--- a/tests/install-plugins.bats
+++ b/tests/install-plugins.bats
@@ -7,6 +7,10 @@ load test_helpers
 SUT_IMAGE=$(sut_image)
 SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
 
+teardown() {
+  clean_work_directory "${BATS_TEST_DIRNAME}" "${SUT_IMAGE}"
+}
+
 @test "[${SUT_DESCRIPTION}] build image" {
   cd $BATS_TEST_DIRNAME/..
   docker_build -t $SUT_IMAGE .
@@ -114,11 +118,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_line 'Plugin-Version: 1.28'
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] plugins are getting upgraded but not downgraded" {
   # Initial execution
   run docker_build_child $SUT_IMAGE-install-plugins $BATS_TEST_DIRNAME/install-plugins
@@ -148,11 +147,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_line 'Plugin-Version: 1.3'
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] do not upgrade if plugin has been manually updated" {
   run docker_build_child $SUT_IMAGE-install-plugins $BATS_TEST_DIRNAME/install-plugins
   assert_success
@@ -178,11 +172,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_success
   assert_line 'Plugin-Version: 1.3'
   refute_line 'Plugin-Version: 1.2'
-}
-
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
 }
 
 @test "[${SUT_DESCRIPTION}] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true" {
@@ -212,11 +201,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   refute_line 'Plugin-Version: 1.2'
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] plugins are installed with install-plugins.sh and no war" {
   run docker_build_child $SUT_IMAGE-install-plugins-no-war $BATS_TEST_DIRNAME/install-plugins/no-war
   assert_success
@@ -228,9 +212,4 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_success
   # Assert the weird plugin is there
   assert_output --partial 'my-happy-plugin:1.1'
-}
-
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
 }

--- a/tests/plugins-cli.bats
+++ b/tests/plugins-cli.bats
@@ -7,6 +7,10 @@ load test_helpers
 SUT_IMAGE=$(sut_image)
 SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
 
+teardown() {
+  clean_work_directory "${BATS_TEST_DIRNAME}" "${SUT_IMAGE}"
+}
+
 @test "[${SUT_DESCRIPTION}] build image" {
   cd $BATS_TEST_DIRNAME/..
   docker_build -t $SUT_IMAGE .
@@ -112,11 +116,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_line 'Plugin-Version: 1.28'
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] plugins are getting upgraded but not downgraded" {
   # Initial execution
   run docker_build_child $SUT_IMAGE-plugins-cli $BATS_TEST_DIRNAME/plugins-cli
@@ -146,11 +145,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_line 'Plugin-Version: 1.3'
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] do not upgrade if plugin has been manually updated" {
   run docker_build_child $SUT_IMAGE-plugins-cli $BATS_TEST_DIRNAME/plugins-cli
   assert_success
@@ -176,11 +170,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_success
   assert_line 'Plugin-Version: 1.3'
   refute_line 'Plugin-Version: 1.2'
-}
-
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
 }
 
 @test "[${SUT_DESCRIPTION}] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true" {
@@ -210,11 +199,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   refute_line 'Plugin-Version: 1.2'
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] plugins are installed with jenkins-plugin-cli and no war" {
   run docker_build_child $SUT_IMAGE-plugins-cli-no-war $BATS_TEST_DIRNAME/plugins-cli/no-war
   assert_success
@@ -225,19 +209,9 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   assert_success
 }
 
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
-}
-
 @test "[${SUT_DESCRIPTION}] JAVA_OPTS environment variable is used with jenkins-plugin-cli" {
-  run docker_build_child $SUT_IMAGE-plugins-cli-java-opts $BATS_TEST_DIRNAME/plugins-cli/java-opts
+  run docker_build_child $SUT_IMAGE-plugins-cli-java-opts $BATS_TEST_DIRNAME/plugins-cli/java-opts --no-cache
   assert_success
   # Assert JAVA_OPTS has been used and 'java.opts.test' has been set to JVM
-  assert_line --regexp '\s*java.opts.test\s*=\s*true.*'
-}
-
-@test "[${SUT_DESCRIPTION}] clean work directory" {
-  run bash -c "ls -la $BATS_TEST_DIRNAME/upgrade-plugins ; rm -rf $BATS_TEST_DIRNAME/upgrade-plugins/work-${SUT_IMAGE}"
-  assert_success
+  assert_line --regexp 'java.opts.test.*=.*true'
 }

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -13,11 +13,9 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
   docker_build -t $SUT_IMAGE .
 }
 
-@test "[${SUT_DESCRIPTION}] clean test containers" {
-    cleanup $SUT_CONTAINER
-}
-
 @test "[${SUT_DESCRIPTION}] test multiple JENKINS_OPTS" {
+  cleanup $SUT_CONTAINER
+
   # running --help --version should return the version, not the help
   local version=$(grep 'ENV JENKINS_VERSION' Dockerfile | sed -e 's/.*:-\(.*\)}/\1/')
   # need the last line of output
@@ -66,8 +64,6 @@ SUT_DESCRIPTION=$(echo $SUT_IMAGE | sed -e 's/bats-jenkins-//g')
       bash -c "curl -fsSL --user \"admin:$(get_jenkins_password)\" $(get_jenkins_url)/systemInfo | sed 's/<\/tr>/<\/tr>\'$'\n/g' | grep '<td class=\"pane\">hudson.model.DirectoryBrowserSupport.CSP</td>' | sed -e '${sed_expr}'"
     assert 'Europe/Madrid' \
       bash -c "curl -fsSL --user \"admin:$(get_jenkins_password)\" $(get_jenkins_url)/systemInfo | sed 's/<\/tr>/<\/tr>\'$'\n/g' | grep '<td class=\"pane\">user.timezone</td>' | sed -e '${sed_expr}'"
-}
 
-@test "[${SUT_DESCRIPTION}] clean test containers" {
     cleanup $SUT_CONTAINER
 }

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -97,3 +97,9 @@ function unzip_manifest {
     local work=$2
     bash -c "docker run --rm -v $work:/var/jenkins_home --entrypoint unzip $SUT_IMAGE -p /var/jenkins_home/plugins/$plugin META-INF/MANIFEST.MF | tr -d '\r'"
 }
+
+function clean_work_directory {
+    local workdir=$1
+    local sut_image=$2
+    rm -rf "${workdir}/upgrade-plugins/work-${sut_image}"
+}


### PR DESCRIPTION
Unrevert the bats upgrade revert that sneaked in as a part of https://github.com/jenkinsci/docker/pull/1120

@timja, @dduportal, @saper