### PR TITLE
Remove dependabot checking of non-existing Dockerfiles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -116,30 +116,6 @@ updates:
   labels:
   - dependencies
 
-# Ubuntu Linux with OpenJ9
-
-- package-ecosystem: docker
-  directory: "11/ubuntu/focal/openj9"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - james-crowley
-  labels:
-  - dependencies
-
-- package-ecosystem: docker
-  directory: "8/ubuntu/focal/openj9"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  reviewers:
-  - james-crowley
-  labels:
-  - dependencies
-
 # RHEL UBI
 
 - package-ecosystem: docker


### PR DESCRIPTION
## Remove dependabot checks of Dockerfiles that don't exist

165c97452e8e7e2ca5097659b5853221c141a248 removed the generation of OpenJ9 unpublished images.  Also remove the dependabot checking of updates to those images.
