### PR TITLE
Enable multi-arch publishing

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -73,7 +73,6 @@ publish() {
     export LATEST_LTS=$latest_lts
     set -x
     docker buildx bake --file docker-bake.hcl \
-                 --set '*.platform=linux/amd64' \
                  "${build_opts[@]+"${build_opts[@]}"}" linux
     set +x
     if [ "$dry_run" = true ]; then


### PR DESCRIPTION
Relates to https://github.com/jenkinsci/docker/issues/1139

Requires https://github.com/jenkinsci/docker/pull/1156 https://github.com/jenkins-infra/packer-images/pull/75 and updating of Azure templates to latest packer image on trusted.ci

Shall we give this a try for weekly release next week?

cc @dduportal