### PR TITLE
Remove AWS constraint on node selector

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ stage('Build') {
         def imageToBuild = i
 
         builds[imageToBuild] = {
-            nodeWithTimeout('docker && aws') {
+            nodeWithTimeout('docker') {
                 deleteDir()
 
                 stage('Checkout') {


### PR DESCRIPTION
It was only added because the azure images hadn't been updated yet, trusted CI doesn't have AWS setup