### PR TITLE
Include x.yyy.z-lts tags in labeling

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -97,6 +97,7 @@ target "alpine_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-alpine",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:alpine" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-alpine" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts-alpine" : "",
   ]
   platforms = ["linux/amd64"]
 }
@@ -114,6 +115,7 @@ target "centos7_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos7",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:centos7" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-centos7" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts-centos7" : "",
   ]
   platforms = ["linux/amd64"]
 }
@@ -131,6 +133,7 @@ target "centos8_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-centos",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:centos" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-centos" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts-centos" : "",
   ]
   platforms = ["linux/amd64"]
 }
@@ -148,6 +151,7 @@ target "debian_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:latest" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts" : "",
   ]
   platforms = ["linux/amd64"]
 }
@@ -165,6 +169,7 @@ target "debian_jdk11" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-jdk11",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:jdk11" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-jdk11" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts-jdk11" : "",
   ]
   platforms = ["linux/amd64", "linux/arm64"]
 }
@@ -182,6 +187,7 @@ target "debian_slim_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-slim",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:slim" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-slim" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts-slim" : "",
   ]
   platforms = ["linux/amd64"]
 }


### PR DESCRIPTION
Fix https://github.com/jenkins-infra/release/issues/176

The 2.289.3 Docker image creation did not generate tags for:

* jenkins/jenkins:2.289.3-lts
* jenkins/jenkins:2.289.3-lts-alpine
* jenkins/jenkins:2.289.3-lts-centos
* jenkins/jenkins:2.289.3-lts-centos7
* jenkins/jenkins:2.289.3-lts-jdk11

This restores that behavior, though it may be temporary, since we're making other changes for the 2.302.1 release.
