### PR TITLE
Revert "Force 2.289.3 to be published (#1164)"

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -126,8 +126,7 @@ latest_lts_version=$(echo "${versions}" | grep -E '[0-9]\.[0-9]+\.[0-9]' | tail 
 
 for version in $versions; do
     TOKEN=$(login-token)
-    # Temporary hack to publish 2.289.3 even though some variants are already published
-    if is-published "$version$variant" && [ "$version" != "2.289.3" ] ; then
+    if is-published "$version$variant"; then
         echo "Tag is already published: $version$variant"
     else
         echo "$version$variant not published yet"


### PR DESCRIPTION
## Revert the 2.289.3 temporary change

Tags are published as expected.  Other rework can be done at a more reasonable pace and a more reasonable time.

This reverts commit e2dff829de6aa7dc84736b87f6921ad5dce3bb1f.
