### PR TITLE
Re-enable multi-arch

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -73,7 +73,6 @@ publish() {
     export LATEST_LTS=$latest_lts
     set -x
     docker buildx bake --file docker-bake.hcl \
-                 --set '*.platform=linux/amd64' \
                  "${build_opts[@]+"${build_opts[@]}"}" linux
     set +x
     if [ "$dry_run" = true ]; then

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,6 +126,7 @@ stage('Build') {
                     infra.withDockerCredentials {
                         sh '''
                             docker buildx create --use
+                            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
                             make publish
                             '''
                     }


### PR DESCRIPTION
It seems that on the AWS agents our current image works, but on the Azure agent we need to re-run the qemu restart command, 🤷 