### PR TITLE
Revert "Use JDK 8u302 and JDK 11.0.12 on Alpine and Debian (#1170)"

### DIFF
--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-alpine
+FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-alpine
 
 RUN apk add --no-cache \
   bash \

--- a/11/debian/buster-slim/hotspot/Dockerfile
+++ b/11/debian/buster-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-debianslim-slim
+FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-debianslim-slim
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/11/debian/buster/hotspot/Dockerfile
+++ b/11/debian/buster/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-debian
+FROM adoptopenjdk/openjdk11:jdk-11.0.11_9-debian
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/8/alpine/hotspot/Dockerfile
+++ b/8/alpine/hotspot/Dockerfile
@@ -1,7 +1,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u302-b08-alpine
+FROM adoptopenjdk/openjdk8:jdk8u292-b10-alpine
 
 RUN apk add --no-cache \
   bash \

--- a/8/debian/buster-slim/hotspot/Dockerfile
+++ b/8/debian/buster-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:jdk8u302-b08-debianslim-slim
+FROM adoptopenjdk/openjdk8:jdk8u292-b10-debianslim-slim
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/8/debian/buster/hotspot/Dockerfile
+++ b/8/debian/buster/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk8:jdk8u302-b08-debian
+FROM adoptopenjdk/openjdk8:jdk8u292-b10-debian
 
 RUN apt-get update && \
     apt-get upgrade -y && \


### PR DESCRIPTION
We need to wait for Adoptium to deliver the Docker images and the tar.gz packages for aarch64.  Single Dockerfile for multiple platforms gives us consistency across platforms and means that we need the upstream release available for all the platforms we support.

This reverts commit 280afb7d564d80ffa3aee2c153acb62acf4aaaea.
