### PR TITLE
Switch to eclipse temurin, build via jlink, switch to bullseye

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,16 +1,18 @@
+FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
 FROM almalinux:8.4
 
 ARG TARGETARCH
 
-RUN echo -e '[AdoptOpenJDK]\n\
-name=AdoptOpenJDK\n\
-baseurl=https://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/centos/$releasever/$basearch\n\
-enabled=1\n\
-gpgcheck=1\n\
-gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public' > /etc/yum.repos.d/adoptopenjdk.repo && \
-    dnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs update -y && \
-    dnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
-	adoptopenjdk-11-hotspot-11.0.11+9-3 \
+RUN dnf --setopt=install_weak_deps=0 --setopt=tsflags=nodocs install -y \
 	fontconfig \
 	freetype \
 	git-lfs \
@@ -88,6 +90,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,5 +1,8 @@
 FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,14 +1,18 @@
+FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
 FROM centos:centos7.9.2009
 
 ARG TARGETARCH
 
-RUN echo -e '[AdoptOpenJDK]\n\
-name=AdoptOpenJDK\n\
-baseurl=https://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/centos/$releasever/$basearch\n\
-enabled=1\n\
-gpgcheck=1\n\
-gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public' > /etc/yum.repos.d/adoptopenjdk.repo && \
-    yum update -y && yum install -y git curl adoptopenjdk-11-hotspot-11.0.11+9-3 freetype fontconfig unzip which && \
+RUN yum install -y git curl freetype fontconfig unzip which && \
     yum clean all
 
 ARG TARGETARCH
@@ -99,6 +103,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,5 +1,8 @@
 FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,8 +1,17 @@
-FROM adoptopenjdk/openjdk8:jdk8u302-b08-debian
+FROM eclipse-temurin:11.0.12_7-jdk-focal as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 procps wget && \
+    apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
@@ -93,6 +102,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20210816-slim
 
 RUN apt-get update && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye
+FROM debian:bullseye-20210816
 
 RUN apt-get update && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -1,7 +1,16 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-debianslim-slim
+FROM eclipse-temurin:11.0.12_7-jdk-focal as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM debian:bullseye
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \
     rm -rf /var/lib/apt/lists/*
 
@@ -93,6 +102,11 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV JENKINS_ENABLE_FUTURE_JAVA=true
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,16 +1,18 @@
+FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
 FROM registry.access.redhat.com/ubi8/ubi:8.4-209
 
 ARG TARGETARCH
 
-RUN echo -e '[AdoptOpenJDK]\n\
-name=AdoptOpenJDK\n\
-baseurl=https://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/rhel/$releasever/$basearch\n\
-enabled=1\n\
-gpgcheck=1\n\
-gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public' > /etc/yum.repos.d/adoptopenjdk.repo \
-    && dnf update --disableplugin=subscription-manager --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y  \
-    && dnf install --disableplugin=subscription-manager --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y \
-        adoptopenjdk-11-hotspot-11.0.11+9-3 \
+RUN dnf install --disableplugin=subscription-manager --setopt=install_weak_deps=0 --setopt=tsflags=nodocs -y \
         git \
         git-lfs \
         curl \
@@ -91,6 +93,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,5 +1,8 @@
 FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \

--- a/8/debian/bullseye-slim/hotspot/Dockerfile
+++ b/8/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,13 +1,5 @@
 FROM eclipse-temurin:8u302-b08-jdk-focal as jre-build
 
-RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
-
 FROM debian:bullseye-20210816-slim
 
 RUN apt-get update && \
@@ -105,7 +97,7 @@ ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
+COPY --from=jre-build /opt/java/openjdk $JAVA_HOME
 
 USER ${user}
 

--- a/8/debian/bullseye-slim/hotspot/Dockerfile
+++ b/8/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,7 +1,16 @@
-FROM adoptopenjdk/openjdk8:jdk8u302-b08-debianslim-slim
+FROM eclipse-temurin:8u302-b08-jdk-focal as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM debian:bullseye-slim
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \
     rm -rf /var/lib/apt/lists/*
 
@@ -93,6 +102,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/8/debian/bullseye-slim/hotspot/Dockerfile
+++ b/8/debian/bullseye-slim/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-slim
+FROM debian:bullseye-20210816-slim
 
 RUN apt-get update && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \

--- a/8/debian/bullseye/hotspot/Dockerfile
+++ b/8/debian/bullseye/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye
+FROM debian:bullseye-20210816
 
 RUN apt-get update && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 procps wget && \

--- a/8/debian/bullseye/hotspot/Dockerfile
+++ b/8/debian/bullseye/hotspot/Dockerfile
@@ -1,8 +1,17 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-debian
+FROM eclipse-temurin:8u302-b08-jdk-focal as jre-build
+
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM debian:bullseye
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
-    apt-get install -y git curl gpg unzip && \
+    apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 procps wget && \
     rm -rf /var/lib/apt/lists/*
 
 ARG TARGETARCH
@@ -93,7 +102,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-ENV JENKINS_ENABLE_FUTURE_JAVA=true
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}
 

--- a/8/debian/bullseye/hotspot/Dockerfile
+++ b/8/debian/bullseye/hotspot/Dockerfile
@@ -1,13 +1,5 @@
 FROM eclipse-temurin:8u302-b08-jdk-focal as jre-build
 
-RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
-
 FROM debian:bullseye-20210816
 
 RUN apt-get update && \
@@ -105,7 +97,7 @@ ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
+COPY --from=jre-build /opt/java/openjdk $JAVA_HOME
 
 USER ${user}
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -161,7 +161,7 @@ target "centos7_jdk11" {
 }
 
 target "debian_jdk8" {
-  dockerfile = "8/debian/buster/hotspot/Dockerfile"
+  dockerfile = "8/debian/bullseye/hotspot/Dockerfile"
   context = "."
   args = {
     JENKINS_VERSION = JENKINS_VERSION
@@ -178,7 +178,7 @@ target "debian_jdk8" {
 }
 
 target "debian_jdk11" {
-  dockerfile = "11/debian/buster/hotspot/Dockerfile"
+  dockerfile = "11/debian/bullseye/hotspot/Dockerfile"
   context = "."
   args = {
     JENKINS_VERSION = JENKINS_VERSION
@@ -199,7 +199,7 @@ target "debian_jdk11" {
 }
 
 target "debian_slim_jdk8" {
-  dockerfile = "8/debian/buster-slim/hotspot/Dockerfile"
+  dockerfile = "8/debian/bullseye-slim/hotspot/Dockerfile"
   context = "."
   args = {
     JENKINS_VERSION = JENKINS_VERSION
@@ -216,7 +216,7 @@ target "debian_slim_jdk8" {
 }
 
 target "debian_slim_jdk11" {
-  dockerfile = "11/debian/buster-slim/hotspot/Dockerfile"
+  dockerfile = "11/debian/bullseye-slim/hotspot/Dockerfile"
   context = "."
   args = {
     JENKINS_VERSION = JENKINS_VERSION


### PR DESCRIPTION
AdoptOpenJDK official images are now deprecated and not receiving any updates since August 1st 2021:
https://hub.docker.com/_/adoptopenjdk

eclipse temurin is the replacement, but it's only currently offering ubuntu and centos7 images, with the intention that it's one APT based and one rpm based package manager. https://github.com/docker-library/official-images/pull/10662#issuecomment-897889255

The expectation is that you use a multi-stage build with `jlink` and copy it to your image.
This appears to be saving 200MB or so by building our own java run time which takes ~11 seconds.

So far I've tested the debian image starts and you can run a pipeline

I've also included the switch to `bullseye` in this.

I removed the `apt upgrade -y` and equivalent as that's an anti-pattern with docker, you're supposed to get updates from the base image otherwise you're bloating your image. Happy to discuss and revert if needed

eclipse temurin have said they intend to publish alpine but at a later date so I've left that alone in this PR

