### PR TITLE
Restore headers and debug symbols

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -5,9 +5,7 @@ FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
 # while still saving space (approx 200mb from the full distribution)
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
-         --strip-debug \
          --no-man-pages \
-         --no-header-files \
          --compress=2 \
          --output /javaruntime
 

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -5,9 +5,7 @@ FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
 # while still saving space (approx 200mb from the full distribution)
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
-         --strip-debug \
          --no-man-pages \
-         --no-header-files \
          --compress=2 \
          --output /javaruntime
 

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -2,9 +2,7 @@ FROM eclipse-temurin:11.0.12_7-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
-         --strip-debug \
          --no-man-pages \
-         --no-header-files \
          --compress=2 \
          --output /javaruntime
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -5,9 +5,7 @@ FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
 # while still saving space (approx 200mb from the full distribution)
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
-         --strip-debug \
          --no-man-pages \
-         --no-header-files \
          --compress=2 \
          --output /javaruntime
 


### PR DESCRIPTION
#1185 implemented stripping of debug symbols and removal of header files. Without the header files, I can't install [`async-profiler`](https://github.com/jvm-profiling-tools/async-profiler), and without the debug symbols `async-profiler` (and GDB) [can't resolve stack frames within `libjvm.so`](https://github.com/jvm-profiling-tools/async-profiler#installing-debug-symbols). I have relied heavily on `async-profiler` and GDB over the years to help me debug problems on my production Jenkins controllers, most recently to root-cause an infrequent `SIGBUS` at `sun.awt.FcFontManager.getFontPathNative` or `sun.font.FreetypeFontScaler.initNativeScaler` (the problem ended up being that `jna.tmpdir` was set to a directory on NFS). I don't need the manual pages (I can always find those online), but please don't compromise debugging support for some small space savings.

Note that I left `--strip-debug` and `--no-header-files` in `11/debian/bullseye-slim/hotspot/Dockerfile`. I suppose if you are explicitly opting for the slim image then you probably don't mind a reduced set of functionality, including reduced debugging support.