### PR TITLE
Remove s390x from rhel (upstream missing for it)

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -23,7 +23,6 @@ group "linux-arm64" {
 
 group "linux-s390x" {
   targets = [
-    "rhel_ubi8_jdk11",
     "debian_jdk11",
   ]
 }
@@ -247,7 +246,7 @@ target "rhel_ubi8_jdk11" {
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:rhel-ubi8-jdk11" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-rhel-ubi8-jdk11" : "",
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 }
 
 # TODO update windows publishing script to use this file


### PR DESCRIPTION
https://hub.docker.com/_/eclipse-temurin?tab=tags&page=1&ordering=last_updated&name=11.0.12_7-jdk-cento

![image](https://user-images.githubusercontent.com/21194782/130631513-138ffa73-ed15-496a-82ab-c63a73fdd4e8.png)
