### PR TITLE
Use JDK 11.0.13 and JDK 8u312

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.13_8-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM adoptopenjdk/openjdk11:jdk-11.0.12_7-alpine AS jre-build
+FROM adoptopenjdk/openjdk11:jdk-11.0.13_8-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.13_8-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.12_7-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.13_8-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.12_7-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.13_8-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.12_7-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.13_8-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/8/alpine/hotspot/Dockerfile
+++ b/8/alpine/hotspot/Dockerfile
@@ -1,7 +1,7 @@
 # FIXME(oleg_nenashev): This is not an official AdoptOpenJDK Docker Image.
 # There is no official Alpine images at the moment.
 # Needs upgrade when/if there is an official alpine image.
-FROM adoptopenjdk/openjdk8:jdk8u302-b08-alpine
+FROM adoptopenjdk/openjdk8:jdk8u312-b07-alpine
 
 RUN apk add --no-cache \
   bash \


### PR DESCRIPTION
# Use JDK 11.0.13 and JDK 8u312

Recently released by Adoptium and confirmed available on amd64, aarch64, and s390x.

The Docker image for 8u312 is currently only available for the adoptopenjdk/alpine image, not for the Ubuntu, Debian, or CentOS based images