### PR TITLE
Added extra slash to remove slash from end of URL.

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -249,7 +249,7 @@ main() {
     # shellcheck disable=SC2086
     jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
     if [ -n "${jenkinsUcJson}" ]; then
-        JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}
+        JENKINS_UC_LATEST=${jenkinsUcJson///update-center.json/}
         echo "Using version-specific update center: $JENKINS_UC_LATEST..."
     else
         JENKINS_UC_LATEST=


### PR DESCRIPTION

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

The issue is with the JENKINS_UC_LATEST URL it is format in wrong way that makes download of plugin with error.

Example :
jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "https://updates.jenkins.io/update-center.json?version=2.303") 
JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json} gives https://updates.jenkins.io/dynamic-2.291/ which will fail to download plugins as now the url will be https://updates.jenkins.io/dynamic-2.291//latest/${plugin}.hpi"

so to overcome we can add one more slash as shown in commit and then the URL will look like https://updates.jenkins.io/dynamic-2.291/latest/${plugin}.hpi
