### PR TITLE
Remove docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-master:
-  build: .
-  environment:
-    JAVA_OPTS: "-Djava.awt.headless=true"
-  ports:
-    - "50000:50000"
-    - "8080:8080"
-  volumes:
-    - /var/jenkins_home


### PR DESCRIPTION
## Remove docker-compose file

Issue #1250 reports that `docker-compose` with the sample compose file fails on Windows.  There is no mention of the docker-compose.yml file anywhere else in the repository and no explanation of the file contents.  It was added in 2015 without any further documentation.

This fixes #1250 by removing the file.

The example seems to still work on my Linux computer, but it runs an outdated version of Jenkins weekly, provides no hints that would guide the user to maintain their Jenkins image, and does not provide any example that would configure the Docker image as code.

Reverts 06dd4e6ec47a4f13f6736d5237afe37c64bab127
