### PR TITLE
Tag lts-jdk8 with ${JENKINS_VERSION}

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -177,6 +177,7 @@ target "debian_jdk8" {
     "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-jdk8",
     equal(LATEST_WEEKLY, "true") ? "${REGISTRY}/${JENKINS_REPO}:latest-jdk8" : "",
     equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:lts-jdk8" : "",
+    equal(LATEST_LTS, "true") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-lts-jdk8" : "",
   ]
   platforms = ["linux/amd64"]
 }


### PR DESCRIPTION
add a versioned tag to the lts-jdk8 image
in addition to lts-jdk11 (which is now default anyway)

Fixes https://github.com/jenkinsci/docker/issues/1265

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
