### PR TITLE
Use `ExitLifecycle` when running in a container

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -22,6 +22,11 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     java_opts_array+=( "-D${agent_port_property}=${JENKINS_SLAVE_AGENT_PORT}" )
   fi
 
+  readonly lifecycle_property='hudson.lifecycle'
+  if [[ "${JAVA_OPTS:-}" != *"${lifecycle_property}"* ]]; then
+    java_opts_array+=( "-D${lifecycle_property}=hudson.lifecycle.ExitLifecycle" )
+  fi
+
   if [[ "$DEBUG" ]] ; then
     java_opts_array+=( \
       '-Xdebug' \


### PR DESCRIPTION
When running in a container, the default `UnixLifecycle` (with all its fragile low-level systems logic) is unnecessary. The container orchestrator effectively functions as the service manager, so allow the process to exit and be restarted by the container orchestrator rather than trying to do this ourselves in `UnixLifecycle`. Similar changes should be made to the non-container-based packaging, but this is a start.

I tested this by running Jenkins in Docker with this change and applying a Docker restart policy of `always` to the container. (I assume Kubernetes has its own equivalent for this, but I don't use Kubernetes.) I verified that by default `-Dhudson.lifecycle=hudson.lifecycle.ExitLifecycle` was set and that after going to `/safeRestart` the process exited and Docker restarted the container automatically, resulting in the same behavior as with `UnixLifecycle`. I also verified that when manually adjusting `JAVA_OPTS` to override `-Dhudson.lifecycle` that my overridden choice was respected.

Fixes https://github.com/jenkinsci/helm-charts/issues/529