### PR TITLE
Fix jenkins-plugin-cli JAVA_OPTS handling

### DIFF
--- a/jenkins-plugin-cli.sh
+++ b/jenkins-plugin-cli.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-exec /bin/bash -c "java $JAVA_OPTS -jar /opt/jenkins-plugin-manager.jar $*"
+eval exec java "$JAVA_OPTS" -jar /opt/jenkins-plugin-manager.jar "$*"

--- a/jenkins-plugin-cli.sh
+++ b/jenkins-plugin-cli.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-eval exec java "$JAVA_OPTS" -jar /opt/jenkins-plugin-manager.jar "$*"
+# read JAVA_OPTS into array to avoid need for eval (and associated vulnerabilities)
+java_opts_array=()
+while IFS= read -r -d '' item; do
+	java_opts_array+=( "$item" )
+done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
+
+exec java "${java_opts_array[@]}" -jar /opt/jenkins-plugin-manager.jar "$@"


### PR DESCRIPTION
The jenkins-plugin-cli.sh helper script does not evaluate correctly when there
are JAVA_OPTS set. JAVA_OPTS needs to be double quoted to prevent word
splitting and globbing. Take the example where JAVA_OPTS sets a proxy and uses
`*`:

```
❯ JAVA_OPTS="-Dhttp.nonProxyHosts=127.0.*,localhost" ./jenkins-plugin-cli.sh --plugins foo
+ exec /bin/bash -c 'java -Dhttp.nonProxyHosts=127.0.*,localhost -jar /opt/jenkins-plugin-manager.jar --plugins foo'
```
The proxy option is not properly quoted when interpreted by the bash command.

By using eval we can resolve the variables and maintain proper word splitting
and globbing behavior.

```
❯ JAVA_OPTS="-Dhttp.nonProxyHosts=127.0.*,localhost" ./jenkins-plugin-cli.sh --plugins foo
+ eval exec java '-Dhttp.nonProxyHosts=127.0.*,localhost' -jar /opt/jenkins-plugin-manager.jar '--plugins foo'
++ exec java '-Dhttp.nonProxyHosts=127.0.*,localhost' -jar /opt/jenkins-plugin-manager.jar --plugins foo
```

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
