### PR TITLE
Use newest JDK's and base operating systems

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.13_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.14_9-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.13_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.14_9-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.13_8-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.14_9-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.13_8-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.14_9-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.13_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.14_9-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -9,7 +9,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM registry.access.redhat.com/ubi8/ubi:8.4-213
+FROM registry.access.redhat.com/ubi8/ubi:8.5-226
 
 ENV LANG C.UTF-8
 

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -6,7 +6,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20210927
+FROM debian:bullseye-20220125
 
 RUN apt-get update && \
     apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17_35-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.2_8-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/8/debian/bullseye-slim/hotspot/Dockerfile
+++ b/8/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8u312-b07-jdk-focal as jre-build
+FROM eclipse-temurin:8u322-b06-jdk-focal as jre-build
 
 FROM debian:bullseye-20220125-slim
 

--- a/8/debian/bullseye/hotspot/Dockerfile
+++ b/8/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8u312-b07-jdk-focal as jre-build
+FROM eclipse-temurin:8u322-b06-jdk-focal as jre-build
 
 FROM debian:bullseye-20220125
 


### PR DESCRIPTION
## Use newest JDKs and base operating systems

Update JDK versions

- Use JDK 11.0.14, not 11.0.13
- Use JDK 8u322, not 8u312
- Use JDK 17.0.2, not 17.0

Update operating system versions

- Use ubi 8.5-226, not 8.4-213
- Use Debian bullseye 2022-01-25, not 2021-09-27

Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Caveats:

* Does not fix the centos7 image that is still using an outdated Java version (8u292) over a CentOS 7 image that has not been updated in 5 months