### PR TITLE
Check for new plugin manager daily

### DIFF
--- a/.github/workflows/sync-plugin-manager.yml
+++ b/.github/workflows/sync-plugin-manager.yml
@@ -3,7 +3,7 @@ name: Sync Plugin manager Version
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "* 23 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Check daily for new plugin manager releases

Checking 4 times an hour seems too much.

Checking 4 times an hour was causing heavy use in my private fork

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
