### PR TITLE
Pass JENKINS_JAVA_OPTS as JVM parameters as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,11 +83,13 @@ If you connect agents using web sockets (since Jenkins 2.217), the TCP agent por
 # Passing JVM parameters
 
 You might need to customize the JVM running Jenkins, typically to adjust [system properties](https://www.jenkins.io/doc/book/managing/system-properties/) or tweak heap memory settings.
-Use the `JAVA_OPTS` environment variable for this purpose :
+Use the `JAVA_OPTS` or `JENKINS_JAVA_OPTS` environment variables for this purpose :
 
 ```
-docker run --name myjenkins -p 8080:8080 -p 50000:50000 --env JAVA_OPTS=-Dhudson.footerURL=http://mycompany.com jenkins/jenkins:lts-jdk11
+docker run --name myjenkins -p 8080:8080 -p 50000:50000 --env JENKINS_JAVA_OPTS=-Dhudson.footerURL=http://mycompany.com jenkins/jenkins:lts-jdk11
 ```
+
+JVM options specifically for the Jenkins controller should be set through `JENKINS_JAVA_OPTS`, as other tools might also respond to the `JAVA_OPTS` environment variable.
 
 # Configuring logging
 
@@ -141,10 +143,10 @@ or as a parameter to docker,
 docker run --name myjenkins -p 8080:8080 -p 50001:50001 --env JENKINS_SLAVE_AGENT_PORT=50001 jenkins/jenkins:lts-jdk11
 ```
 
-**Note**: This environment variable will be used to set the port adding the
-[system property][https://www.jenkins.io/doc/book/managing/system-properties/] `jenkins.model.Jenkins.slaveAgentPort` to **JAVA_OPTS**.
+**Note**: This environment variable will be used to set the
+[system property](https://www.jenkins.io/doc/book/managing/system-properties/) `jenkins.model.Jenkins.slaveAgentPort`.
 
-> If this property is already set in **JAVA_OPTS**, then the value of
+> If this property is already set in **JAVA_OPTS** or **JENKINS_JAVA_OPTS**, then the value of
 `JENKINS_SLAVE_AGENT_PORT` will be ignored.
 
 # Installing more tools

--- a/jenkins.ps1
+++ b/jenkins.ps1
@@ -18,10 +18,10 @@ Get-ChildItem -Recurse -File -Path 'C:/ProgramData/Jenkins/Reference' | ForEach-
 if(($args.Count -eq 0) -or ($args[0] -match "^--.*")) {
 
   # read JAVA_OPTS and JENKINS_OPTS into arrays to avoid need for eval (and associated vulnerabilities)
-  $java_opts_array = $env:JAVA_OPTS -split ' '
+  $java_opts_array = ($env:JAVA_OPTS -split ' ') + ($env:JENKINS_JAVA_OPTS -split ' ')
 
   $agent_port_property='jenkins.model.Jenkins.slaveAgentPort'
-  if(![System.String]::IsNullOrWhiteSpace($env:JENKINS_AGENT_PORT) -and ($env:JAVA_OPTS -notmatch "$agent_port_property")) {
+  if(![System.String]::IsNullOrWhiteSpace($env:JENKINS_AGENT_PORT) -and !($java_opts_array -match "$agent_port_property")) {
     $java_opts_array += "-D`"$agent_port_property=$env:JENKINS_AGENT_PORT`""
   }
 

--- a/tests/runtime.Tests.ps1
+++ b/tests/runtime.Tests.ps1
@@ -63,45 +63,74 @@ Describe "[$TEST_TAG] test jenkins arguments" {
   }
 }
 
-Describe "[$TEST_TAG] create test container" {
-  It 'start container' {
-    $cmd = @"
-docker --% run -d -e JAVA_OPTS="-Duser.timezone=Europe/Madrid -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';\"" --name $SUT_CONTAINER -P $SUT_IMAGE
-"@
-    Invoke-Expression $cmd
-    $lastExitCode | Should -Be 0
-  }
-}
+Describe "[$TEST_TAG] passing JVM parameters" {
+  BeforeAll {
+    $tzSetting = '-Duser.timezone=Europe/Madrid'
+    $tzRegex = [regex]::Escape("Europe/Madrid")
 
-Describe "[$TEST_TAG] test container is running" {
-  It 'is running' {
-    # give time to eventually fail to initialize
-    Start-Sleep -Seconds 5
-    Retry-Command -RetryCount 3 -Delay 1 -ScriptBlock { docker inspect -f "{{.State.Running}}" $SUT_CONTAINER ; if($lastExitCode -ne 0) { throw('Docker inspect failed') } } -Verbose | Should -BeTrue
-  }
-}
+    $cspSetting = @'
+-Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';\"
+'@
+    $cspRegex = [regex]::Escape("default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;")
 
-Describe "[$TEST_TAG] Jenkins is initialized" {
-  It 'is initialized' {
-    # it takes a while for jenkins to be up enough
-    Retry-Command -RetryCount 30 -Delay 5 -ScriptBlock { Test-Url $SUT_CONTAINER "/api/json" } -Verbose | Should -BeTrue
-  }
-}
+    function Start-With-Opts() {
+      Param (
+        [string] $JAVA_OPTS,
+        [string] $JENKINS_JAVA_OPTS
+      )
 
-Describe "[$TEST_TAG] JAVA_OPTS are set" {
-  It 'CSP value' {
-    $content = (Get-JenkinsWebpage $SUT_CONTAINER "/systemInfo").Replace("</tr>","</tr>`n").Replace("<wbr>", "").Split("`n") | Select-String -Pattern '<td class="pane">hudson.model.DirectoryBrowserSupport.CSP</td>' 
-    $content | Should -Match ([regex]::Escape("default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;"))
+      $cmd = "docker --% run -d --name $SUT_CONTAINER -P"
+      if ($JAVA_OPTS.length -gt 0) {
+        $cmd += " -e JAVA_OPTS=`"$JAVA_OPTS`""
+      }
+      if ($JENKINS_JAVA_OPTS.length -gt 0) {
+        $cmd += " -e JENKINS_JAVA_OPTS=`"$JENKINS_JAVA_OPTS`""
+      }
+      $cmd += " $SUT_IMAGE"
+
+      Invoke-Expression $cmd
+      $lastExitCode | Should -Be 0
+
+      # give time to eventually fail to initialize
+      Start-Sleep -Seconds 5
+      Retry-Command -RetryCount 3 -Delay 1 -ScriptBlock { docker inspect -f "{{.State.Running}}" $SUT_CONTAINER ; if($lastExitCode -ne 0) { throw('Docker inspect failed') } } -Verbose | Should -BeTrue
+
+      # it takes a while for jenkins to be up enough
+      Retry-Command -RetryCount 30 -Delay 5 -ScriptBlock { Test-Url $SUT_CONTAINER "/api/json" } -Verbose | Should -BeTrue
+    }
+
+    function Get-Csp-Value() {
+      return (Get-JenkinsWebpage $SUT_CONTAINER "/systemInfo").Replace("</tr>","</tr>`n").Replace("<wbr>", "").Split("`n") | Select-String -Pattern '<td class="pane">hudson.model.DirectoryBrowserSupport.CSP</td>' 
+    }
+
+    function Get-Timezone-Value() {
+      return (Get-JenkinsWebpage $SUT_CONTAINER "/systemInfo").Replace("</tr>","</tr>`n").Replace("<wbr>", "").Split("`n") | Select-String -Pattern '<td class="pane">user.timezone</td>' 
+    }
   }
 
-  It 'Timezone set' {
-    $content = (Get-JenkinsWebpage $SUT_CONTAINER "/systemInfo").Replace("</tr>","</tr>`n").Replace("<wbr>", "").Split("`n") | Select-String -Pattern '<td class="pane">user.timezone</td>' 
-    $content | Should -Match ([regex]::Escape("Europe/Madrid"))
-  }
-}
+  It 'passes JAVA_OPTS' {
+    Start-With-Opts -JAVA_OPTS "$tzSetting $cspSetting"
 
-Describe "[$TEST_TAG] cleanup container" {
-  It 'cleanup' {
+    Get-Csp-Value | Should -Match $cspRegex
+    Get-Timezone-Value | Should -Match $tzRegex
+  }
+
+  It 'passes JENKINS_JAVA_OPTS' {
+    Start-With-Opts -JENKINS_JAVA_OPTS "$tzSetting $cspSetting"
+
+    Get-Csp-Value | Should -Match $cspRegex
+    Get-Timezone-Value | Should -Match $tzRegex
+  }
+
+  It 'JENKINS_JAVA_OPTS overrides JAVA_OPTS' {
+    Start-With-Opts -JAVA_OPTS "$tzSetting -Dhudson.model.DirectoryBrowserSupport.CSP=\`"default-src 'self';\`"" -JENKINS_JAVA_OPTS "$cspSetting"
+
+    Get-Csp-Value | Should -Match $cspRegex
+    Get-Timezone-Value | Should -Match $tzRegex
+  }
+
+  AfterEach {
     Cleanup $SUT_CONTAINER | Out-Null
   }
 }
+


### PR DESCRIPTION
JAVA_OPTS is used by other tools as well (e.g. gradle).
This adds a dedicated variable to set JVM parameters for the Jenkins controller only.

Added/adopted the linux and windows tests as well. I also felt like re-structuring the runtime tests a bit, especially on the PowerShell part.

Updated documentation as well.

Fixes #1288
Fixes #822

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

