### PR TITLE
Pass correct delim in jenkins.sh script

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -13,7 +13,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
 
   # read JAVA_OPTS and JENKINS_OPTS into arrays to avoid need for eval (and associated vulnerabilities)
   java_opts_array=()
-  while IFS= read -r -d '' item; do
+  while IFS= read -r -d ' ' item; do
     java_opts_array+=( "$item" )
   done < <([[ $JAVA_OPTS ]] && xargs printf '%s\0' <<<"$JAVA_OPTS")
 
@@ -30,7 +30,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
   fi
 
   jenkins_opts_array=( )
-  while IFS= read -r -d '' item; do
+  while IFS= read -r -d ' ' item; do
     jenkins_opts_array+=( "$item" )
   done < <([[ $JENKINS_OPTS ]] && xargs printf '%s\0' <<<"$JENKINS_OPTS")
 


### PR DESCRIPTION
I was trying to run docker alpine java 11 img with http2 support.
After some time i discovered that args passed to JAVA_OPTS and JENKINS_OPTS sent as whole string instead of array elements.
Simple echo in loop showed that this read doesn't split multiple args into separate values.
After adding space as delim it showed correct interpretation of my input args.

Now JENKINS_OPTS passed like this `--http2Port=8080 httpPort=-1` will be interpreted correctly.
There is no jira/github issue for this PR. I'm fixing my problems, but I think this could solve this issue https://github.com/jenkinsci/docker/issues/745.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
