### PR TITLE
install-plugins uses JENKINS_UC_DOWNLOAD if specified

### DIFF
--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -244,15 +244,20 @@ main() {
     echo "Registering preinstalled plugins..."
     installedPlugins="$(installedPlugins)"
 
-    # Get the update center URL based on the jenkins version
-    jenkinsVersion="$(jenkinsMajorMinorVersion)"
-    # shellcheck disable=SC2086
-    jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
-    if [ -n "${jenkinsUcJson}" ]; then
-        JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}
-        echo "Using version-specific update center: $JENKINS_UC_LATEST..."
-    else
+    # if download url specified skip checking JENKINS_UC_LATEST
+    if [ -n "${JENKINS_UC_DOWNLOAD:-""}" ]; then
         JENKINS_UC_LATEST=
+    else
+        # Get the update center URL based on the jenkins version
+        jenkinsVersion="$(jenkinsMajorMinorVersion)"
+        # shellcheck disable=SC2086
+        jenkinsUcJson=$(curl ${CURL_OPTIONS:--sSfL} -o /dev/null -w "%{url_effective}" "${JENKINS_UC}/update-center.json?version=${jenkinsVersion}")
+        if [ -n "${jenkinsUcJson}" ]; then
+            JENKINS_UC_LATEST=${jenkinsUcJson//update-center.json/}
+            echo "Using version-specific update center: $JENKINS_UC_LATEST..."
+        else
+            JENKINS_UC_LATEST=
+        fi
     fi
 
     echo "Downloading plugins..."


### PR DESCRIPTION
To speed up testing plugins I setup a local web server with the plugins I was using. So I tried to get JENKINS_UC_DOWNLOAD working. Due to the current logic, if you specify JENKINS_UC_DOWNLOAD, it doesn't ever get used as JENKINS_UC_LATEST will get set 1st and always used.

Taking this example Dockerfile;

```
FROM jenkins/jenkins:lts
ENV JENKINS_UC_DOWNLOAD https://updates.jenkins.io/download
RUN /usr/local/bin/install-plugins.sh  greenballs
```

The current version will download from `https://updates.jenkins.io/dynamic-2.319//latest/greenballs.hpi`

The patched version will download from `https://updates.jenkins.io/download/plugins/greenballs/latest/greenballs.hpi`

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
