### PR TITLE
Adapt to jenkinsci/jenkins#6356

### DIFF
--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -103,7 +103,6 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
-ENV JENKINS_ENABLE_FUTURE_JAVA=true
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -37,18 +37,7 @@ if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then
     jenkins_opts_array+=( "$item" )
   done < <([[ $JENKINS_OPTS ]] && xargs printf '%s\0' <<<"$JENKINS_OPTS")
 
-  FUTURE_OPTS=""
-  if [[ "$JENKINS_ENABLE_FUTURE_JAVA" ]] ; then
-    FUTURE_OPTS="--add-opens java.base/java.lang=ALL-UNNAMED
-        --add-opens=java.base/java.io=ALL-UNNAMED
-        --add-opens java.base/java.util=ALL-UNNAMED
-        --add-opens java.base/java.util.concurrent=ALL-UNNAMED
-        "
-  fi
-
-  # --add-opens won't get expanded properly with quotes around it
-  # shellcheck disable=SC2086
-  exec java -Duser.home="$JENKINS_HOME" ${FUTURE_OPTS} "${java_opts_array[@]}" -jar ${JENKINS_WAR} "${jenkins_opts_array[@]}" "$@"
+  exec java -Duser.home="$JENKINS_HOME" "${java_opts_array[@]}" -jar ${JENKINS_WAR} "${jenkins_opts_array[@]}" "$@"
 fi
 
 # As argument is not jenkins, assume user wants to run a different process, for example a `bash` shell to explore this image


### PR DESCRIPTION
Adapts to jenkinsci/jenkins#6356 (first delivered in 2.339), where `--add-opens` is no longer required when running on Java 17. Note that the core change was not backported to LTS, so this PR should not be merged to a branch of `jenkinsci/docker` that is used for LTS releases.