### PR TITLE
Use Git LFS 3.1.2 instead of 3.0.2

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -62,7 +62,7 @@ variable "LATEST_LTS" {
 }
 
 variable "GIT_LFS_VERSION" {
-  default = "3.0.2"
+  default = "3.1.2"
 }
 
 variable "PLUGIN_CLI_VERSION" {


### PR DESCRIPTION
## Use git lfs 3.1.2 instead of 3.0.2

Only need to change docker-bake.hcl because it provides the arguments to docker bake

* https://github.com/git-lfs/git-lfs/releases/tag/v3.1.2
* https://github.com/git-lfs/git-lfs/releases/tag/v3.1.1

v3.1.2 changelog:

This is a bugfix release which fixes a bug in git lfs install and some issues in our CI release processes, including one that prevented arm64 packages for Debian 11 from being uploaded.

Bugs

* lfs: add old hook content to the list of old hooks #4878 (@bk2204)

Misc

* Revert "Merge pull request #4795 from bk2204/actions-checkout-v2" #4877 (@bk2204)
* .github/workflows: install packagecloud gem #4873 (@bk2204)

v3.1.1 changelog:

This is a bugfix release which fixes a syntax error in the release workflow.

Misc

* .github: fix syntax error in release workflow #4866 (@bk2204)

No changelog for v3.1.0, tag only due to issues in git LFS release process

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~
