### PR TITLE
Use Eclipse Temurin on CentOS 7

### DIFF
--- a/8/centos/centos7/hotspot/Dockerfile
+++ b/8/centos/centos7/hotspot/Dockerfile
@@ -5,13 +5,13 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ARG TARGETARCH
 ARG COMMIT_SHA
 
-RUN echo -e '[AdoptOpenJDK]\n\
-name=AdoptOpenJDK\n\
-baseurl=https://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/centos/$releasever/$basearch\n\
+RUN echo -e '[Adoptium]\n\
+name=Adoptium\n\
+baseurl=https://packages.adoptium.net/artifactory/rpm/centos/\$releasever/\$basearch\n\
 enabled=1\n\
 gpgcheck=1\n\
-gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public' > /etc/yum.repos.d/adoptopenjdk.repo && \
-    yum update -y && yum install -y git curl adoptopenjdk-8-hotspot-8u292_b10-3 freetype fontconfig unzip which && \
+gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public' > /etc/yum.repos.d/adoptium.repo && \
+    yum update -y && yum install -y git curl temurin-8-jdk freetype fontconfig unzip which && \
     yum clean all
 
 ARG TARGETARCH


### PR DESCRIPTION
## Use Eclipse Temurin for CentOS 7

Switch from the AdoptOpenJDK executable for JDK 8 on CentOS 7 to the official Eclipse Temurin rpm file.

- Use Eclipse Temurin JDK 8 for CentOS 7 image, not AdoptOpenJDK 8

## Checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
