### PR TITLE
Add a rhel ubi8 build for Openshift Container Platform. (#881)

### DIFF
--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -44,7 +44,7 @@ ENV REF $REF
 # ensure you use the same uid
 RUN mkdir -p $JENKINS_HOME \
   && chown ${uid}:${gid} $JENKINS_HOME \
-  && groupadd -g ${gid} ${group} \
+  && (getent group ${gid} || groupadd -g ${gid} ${group}) \
   && useradd -N -d "$JENKINS_HOME" -u ${uid} -g ${gid} -m -s /bin/bash ${user}
 
 # Jenkins home directory is a volume, so configuration and build history

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,7 +12,8 @@ group "linux" {
     "debian_jdk17",
     "debian_slim_jdk8",
     "debian_slim_jdk11",
-    "rhel_ubi8_jdk11"
+    "rhel_ubi8_jdk11",
+    "rhel_ocp_ubi8_jdk11"
   ]
 }
 
@@ -293,6 +294,24 @@ target "rhel_ubi8_jdk11" {
     tag_lts(true, "lts-rhel-ubi8-jdk11")
   ]
   platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "rhel_ocp_ubi8_jdk11" {
+  dockerfile = "11/rhel/ubi8/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    uid = 1001
+    gid = 0
+  }
+  tags = [
+    tag(true, "rhel-ocp-ubi8-jdk11"),
+    tag_weekly(false, "rhel-ocp-ubi8-jdk11"),
+    tag_lts(false, "lts-rhel-ocp-ubi8-jdk11")
+  ]
+  platforms = ["linux/amd64"]
 }
 
 target "debian_jdk17" {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->

On one hand this PR tries to add a build variant based on rhel ubi8 image with uid=1001 and gid=0 to run rootless on Openshift Container Platform. On the other hand this PR shows how to add a custom build variant with different uid/gid as discussed in issue #881.

Since gid=0 is already present on the base container, I needed to add a check for the groupadd call.
