### PR TITLE
Bump Debian from `bullseye-20220228` to `bullseye-20220509` in `17/debian/bullseye/hotspot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -58,6 +58,18 @@ updates:
 # Debian Linux
 
 - package-ecosystem: docker
+  directory: "17/debian/bullseye/hotspot"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  reviewers:
+  - MarkEWaite
+  - slide
+  labels:
+  - dependencies
+
+- package-ecosystem: docker
   directory: "11/debian/bullseye/hotspot"
   schedule:
     interval: weekly

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -6,7 +6,7 @@ RUN jlink \
   --compress=2 \
   --output /javaruntime
 
-FROM debian:bullseye-20220228
+FROM debian:bullseye-20220509
 
 RUN apt-get update && \
   apt-get install -y git curl gpg unzip libfreetype6 libfontconfig1 && \


### PR DESCRIPTION
Updates this old dependency and adds the relevant `Dockerfile` to our Dependabot configuration to get automatic updates in the future.