### PR TITLE
Remove `glibc` from `alpine_jdk11`

### DIFF
--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -19,6 +19,8 @@ RUN apk add --no-cache \
   curl \
   git \
   gnupg \
+  musl-locales \
+  musl-locales-lang \
   openssh-client \
   tini \
   ttf-dejavu \
@@ -44,42 +46,6 @@ RUN GIT_LFS_ARCHIVE="git-lfs-linux-${TARGETARCH}-v${GIT_LFS_VERSION}.tar.gz" \
     tar xzvf "/tmp/${GIT_LFS_ARCHIVE}" -C /tmp/git-lfs && \
     bash -x /tmp/git-lfs/install.sh && \
     rm -rf /tmp/git-lfs*
-
-# add glic required for java currently
-# copied from https://github.com/AdoptOpenJDK/openjdk-docker/blob/436253bad9e494ea0043da22fca197e6055a538a/11/jdk/alpine/Dockerfile.hotspot.releases.slim#L24-L46
-# inspired by https://blog.gilliard.lol/2018/11/05/alpine-jdk11-images.html
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
-    && GLIBC_VER="2.33-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
-    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
-    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -65,7 +65,7 @@ teardown() {
 }
 
 @test "[${SUT_DESCRIPTION}] has utf-8 locale" {
-  if [[ "${SUT_IMAGE}" == *"alpine"*  ]]; then
+  if [[ $IMAGE == 'alpine_jdk8' ]]; then
     run docker run --rm "${SUT_IMAGE}" /usr/glibc-compat/bin/locale charmap
   else
     run docker run --rm "${SUT_IMAGE}" locale charmap


### PR DESCRIPTION
[JDK-8247589](https://bugs.openjdk.java.net/browse/JDK-8247589) was backported to OpenJDK 11.0.16 upstream (slated for a July 19, 2022 GA) in https://github.com/openjdk/jdk11u-dev/pull/910, but it appears to have been backported to Adoptium/Temurin sooner than that in https://github.com/adoptium/jdk11u/pull/7 and is already shipping in Temurin 11.0.15. As a result it is no longer necessary to include `glibc`.

### Testing done

Built this Docker image. Verified that `java` is not linking against `glibc`:

```bash
$ ldd /opt/java/openjdk/bin/java
        /lib/ld-musl-x86_64.so.1 (0x7f1ec5295000)
        libjli.so => /opt/java/openjdk/bin/../lib/jli/libjli.so (0x7f1ec527e000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f1ec5295000)
        libz.so.1 => /lib/libz.so.1 (0x7f1ec5264000)
```

Installed Jenkins and verified there were no errors or stack traces printed in the console log. Then went to the script console and induced a crash:

```groovy
import java.lang.reflect.Field
import sun.misc.Unsafe

Field f = Unsafe.class.getDeclaredField("theUnsafe")
f.setAccessible(true)
Unsafe unsafe = (Unsafe) f.get(null)
unsafe.putAddress(0, 0)
```

Examining the resulting HotSpot error file, I see that `musl` is loaded in the process address space:

```bash
$ grep -i musl /tmp/hs_err_pid6.log
7fe98557e000-7fe985593000 r--p 00000000 00:52 50                         /lib/ld-musl-x86_64.so.1
7fe985593000-7fe9855db000 r-xp 00015000 00:52 50                         /lib/ld-musl-x86_64.so.1
7fe9855db000-7fe985611000 r--p 0005d000 00:52 50                         /lib/ld-musl-x86_64.so.1
7fe985611000-7fe985612000 r--p 00092000 00:52 50                         /lib/ld-musl-x86_64.so.1
7fe985612000-7fe985613000 rw-p 00093000 00:52 50                         /lib/ld-musl-x86_64.so.1
```

Additionally I see the following strings:

```
libc:musl - unknown musl - unknown
vm_info: OpenJDK 64-Bit Server VM (11.0.15+10) for linux-amd64-musl JRE (11.0.15+10), built on Apr 19 2022 22:14:51 by "" with gcc 10.3.1 20211027
```

The former indicates that https://github.com/adoptium/jdk11u/blob/982989d67b04ab2c4047c31acbf02e82b55c3072/src/hotspot/os/linux/os_linux.cpp#L626= must have been executed, which implies `MUSL_LIBC` must have been defined when compiling the software.