### PR TITLE
Add `alpine_jdk17`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,18 @@ updates:
 # Alpine Linux
 
 - package-ecosystem: docker
+  directory: "17/alpine/hotspot"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 2
+  target-branch: master
+  reviewers:
+  - MarkEWaite
+  - slide
+  labels:
+  - dependencies
+
+- package-ecosystem: docker
   directory: "11/alpine/hotspot"
   schedule:
     interval: weekly

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -19,6 +19,8 @@ RUN apk add --no-cache \
   curl \
   git \
   gnupg \
+  musl-locales \
+  musl-locales-lang \
   openssh-client \
   tini \
   ttf-dejavu \
@@ -44,42 +46,6 @@ RUN GIT_LFS_ARCHIVE="git-lfs-linux-${TARGETARCH}-v${GIT_LFS_VERSION}.tar.gz" \
     tar xzvf "/tmp/${GIT_LFS_ARCHIVE}" -C /tmp/git-lfs && \
     bash -x /tmp/git-lfs/install.sh && \
     rm -rf /tmp/git-lfs*
-
-# add glic required for java currently
-# copied from https://github.com/AdoptOpenJDK/openjdk-docker/blob/436253bad9e494ea0043da22fca197e6055a538a/11/jdk/alpine/Dockerfile.hotspot.releases.slim#L24-L46
-# inspired by https://blog.gilliard.lol/2018/11/05/alpine-jdk11-images.html
-RUN apk add --no-cache tzdata --virtual .build-deps curl binutils zstd \
-    && GLIBC_VER="2.33-r0" \
-    && ALPINE_GLIBC_REPO="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" \
-    && GCC_LIBS_URL="https://archive.archlinux.org/packages/g/gcc-libs/gcc-libs-10.1.0-2-x86_64.pkg.tar.zst" \
-    && GCC_LIBS_SHA256="f80320a03ff73e82271064e4f684cd58d7dbdb07aa06a2c4eea8e0f3c507c45c" \
-    && ZLIB_URL="https://archive.archlinux.org/packages/z/zlib/zlib-1%3A1.2.11-3-x86_64.pkg.tar.xz" \
-    && ZLIB_SHA256=17aede0b9f8baa789c5aa3f358fbf8c68a5f1228c5e6cba1a5dd34102ef4d4e5 \
-    && curl -LfsS https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub -o /etc/apk/keys/sgerrand.rsa.pub \
-    && SGERRAND_RSA_SHA256="823b54589c93b02497f1ba4dc622eaef9c813e6b0f0ebbb2f771e32adf9f4ef2" \
-    && echo "${SGERRAND_RSA_SHA256} */etc/apk/keys/sgerrand.rsa.pub" | sha256sum -c - \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-${GLIBC_VER}.apk > /tmp/glibc-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-${GLIBC_VER}.apk \
-    && curl -LfsS ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-bin-${GLIBC_VER}.apk > /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-bin-${GLIBC_VER}.apk \
-    && curl -Ls ${ALPINE_GLIBC_REPO}/${GLIBC_VER}/glibc-i18n-${GLIBC_VER}.apk > /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && apk add --no-cache /tmp/glibc-i18n-${GLIBC_VER}.apk \
-    && /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true \
-    && echo "export LANG=$LANG" > /etc/profile.d/locale.sh \
-    && curl -LfsS ${GCC_LIBS_URL} -o /tmp/gcc-libs.tar.zst \
-    && echo "${GCC_LIBS_SHA256} */tmp/gcc-libs.tar.zst" | sha256sum -c - \
-    && mkdir /tmp/gcc \
-    && zstd -d /tmp/gcc-libs.tar.zst --output-dir-flat /tmp \
-    && tar -xf /tmp/gcc-libs.tar -C /tmp/gcc \
-    && mv /tmp/gcc/usr/lib/libgcc* /tmp/gcc/usr/lib/libstdc++* /usr/glibc-compat/lib \
-    && strip /usr/glibc-compat/lib/libgcc_s.so.* /usr/glibc-compat/lib/libstdc++.so* \
-    && curl -LfsS ${ZLIB_URL} -o /tmp/libz.tar.xz \
-    && echo "${ZLIB_SHA256} */tmp/libz.tar.xz" | sha256sum -c - \
-    && mkdir /tmp/libz \
-    && tar -xf /tmp/libz.tar.xz -C /tmp/libz \
-    && mv /tmp/libz/usr/lib/libz.so* /usr/glibc-compat/lib \
-    && apk del --purge .build-deps glibc-i18n \
-    && rm -rf /tmp/*.apk /tmp/gcc /tmp/gcc-libs.tar* /tmp/libz /tmp/libz.tar.xz /var/cache/apk/*
 
 ARG user=jenkins
 ARG group=jenkins

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,0 +1,139 @@
+FROM eclipse-temurin:17.0.3_7-jdk-alpine AS jre-build
+
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+RUN apk add --no-cache binutils && rm -rf /var/cache/apk/*
+RUN jlink \
+         --add-modules ALL-MODULE-PATH \
+         --strip-debug \
+         --no-man-pages \
+         --no-header-files \
+         --compress=2 \
+         --output /javaruntime
+
+FROM alpine:3.15.4
+
+RUN apk add --no-cache \
+  bash \
+  coreutils \
+  curl \
+  git \
+  gnupg \
+  musl-locales \
+  musl-locales-lang \
+  openssh-client \
+  tini \
+  ttf-dejavu \
+  tzdata \
+  unzip
+
+ENV LANG C.UTF-8
+
+ARG TARGETARCH
+ARG COMMIT_SHA
+ARG GIT_LFS_VERSION=3.1.4
+
+# required for multi-arch support, revert to package cloud after:
+# https://github.com/git-lfs/git-lfs/issues/4546
+COPY git_lfs_pub.gpg /tmp/git_lfs_pub.gpg
+RUN GIT_LFS_ARCHIVE="git-lfs-linux-${TARGETARCH}-v${GIT_LFS_VERSION}.tar.gz" \
+    GIT_LFS_RELEASE_URL="https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/${GIT_LFS_ARCHIVE}"\
+    set -x; curl --fail --silent --location --show-error --output "/tmp/${GIT_LFS_ARCHIVE}" "${GIT_LFS_RELEASE_URL}" && \
+    curl --fail --silent --location --show-error --output "/tmp/git-lfs-sha256sums.asc" https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/sha256sums.asc && \
+    gpg --no-tty --import /tmp/git_lfs_pub.gpg && \
+    gpg -d /tmp/git-lfs-sha256sums.asc | grep "${GIT_LFS_ARCHIVE}" | (cd /tmp; sha256sum -c ) && \
+    mkdir -p /tmp/git-lfs && \
+    tar xzvf "/tmp/${GIT_LFS_ARCHIVE}" -C /tmp/git-lfs && \
+    bash -x /tmp/git-lfs/install.sh && \
+    rm -rf /tmp/git-lfs*
+
+ARG user=jenkins
+ARG group=jenkins
+ARG uid=1000
+ARG gid=1000
+ARG http_port=8080
+ARG agent_port=50000
+ARG JENKINS_HOME=/var/jenkins_home
+ARG REF=/usr/share/jenkins/ref
+
+ENV JENKINS_HOME $JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
+ENV REF $REF
+
+# Jenkins is run with user `jenkins`, uid = 1000
+# If you bind mount a volume from the host or a data container,
+# ensure you use the same uid
+RUN mkdir -p $JENKINS_HOME \
+  && chown ${uid}:${gid} $JENKINS_HOME \
+  && addgroup -g ${gid} ${group} \
+  && adduser -h "$JENKINS_HOME" -u ${uid} -G ${group} -s /bin/bash -D ${user}
+
+# Jenkins home directory is a volume, so configuration and build history
+# can be persisted and survive image upgrades
+VOLUME $JENKINS_HOME
+
+# $REF (defaults to `/usr/share/jenkins/ref/`) contains all reference configuration we want
+# to set on a fresh new installation. Use it to bundle additional plugins
+# or config file with your custom jenkins Docker image.
+RUN mkdir -p ${REF}/init.groovy.d
+
+# jenkins version being bundled in this docker image
+ARG JENKINS_VERSION
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.303}
+
+# jenkins.war checksum, download will be validated using it
+ARG JENKINS_SHA=4dfe49cd7422ec4317a7c7a7c083f40fa475a58a7747bd94187b2cf222006ac0
+
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
+
+# could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
+# see https://github.com/docker/docker/issues/8331
+RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
+  && echo "${JENKINS_SHA}  /usr/share/jenkins/jenkins.war" | sha256sum -c -
+
+ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
+ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
+RUN chown -R ${user} "$JENKINS_HOME" "$REF"
+
+ARG PLUGIN_CLI_VERSION=2.9.3
+ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${PLUGIN_CLI_VERSION}/jenkins-plugin-manager-${PLUGIN_CLI_VERSION}.jar
+RUN curl -fsSL ${PLUGIN_CLI_URL} -o /opt/jenkins-plugin-manager.jar
+
+# for main web interface:
+EXPOSE ${http_port}
+
+# will be used by attached agents:
+EXPOSE ${agent_port}
+
+ENV JENKINS_ENABLE_FUTURE_JAVA=true
+ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /javaruntime $JAVA_HOME
+
+USER ${user}
+
+COPY jenkins-support /usr/local/bin/jenkins-support
+COPY jenkins.sh /usr/local/bin/jenkins.sh
+COPY tini-shim.sh /bin/tini
+COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
+
+ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
+
+# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
+COPY install-plugins.sh /usr/local/bin/install-plugins.sh
+
+# metadata labels
+LABEL \
+    org.opencontainers.image.vendor="Jenkins project" \
+    org.opencontainers.image.title="Official Jenkins Docker image" \
+    org.opencontainers.image.description="The Jenkins Continuous Integration and Delivery server" \
+    org.opencontainers.image.version="${JENKINS_VERSION}" \
+    org.opencontainers.image.url="https://www.jenkins.io/" \
+    org.opencontainers.image.source="https://github.com/jenkinsci/docker" \
+    org.opencontainers.image.revision="${COMMIT_SHA}" \
+    org.opencontainers.image.licenses="MIT"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,6 +72,7 @@ stage('Build') {
         def images = [
                 'almalinux_jdk11',
                 'alpine_jdk11',
+                'alpine_jdk17',
                 'alpine_jdk8',
                 'centos7_jdk11',
                 'centos7_jdk8',

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -5,6 +5,7 @@ group "linux" {
     "almalinux_jdk11",
     "alpine_jdk8",
     "alpine_jdk11",
+    "alpine_jdk17",
     "centos7_jdk8",
     "centos7_jdk11",
     "debian_jdk8",
@@ -152,6 +153,24 @@ target "alpine_jdk11" {
     tag_lts(false, "lts-alpine"),
     tag_lts(false, "lts-alpine-jdk11"),
     tag_lts(true, "lts-alpine"),
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "alpine_jdk17" {
+  dockerfile = "17/alpine/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    GIT_LFS_VERSION = GIT_LFS_VERSION
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, "alpine-jdk17-preview"),
+    tag_weekly(false, "alpine-jdk17-preview"),
+    tag_lts(false, "lts-alpine-jdk17-preview")
   ]
   platforms = ["linux/amd64"]
 }

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -65,7 +65,7 @@ teardown() {
 }
 
 @test "[${SUT_DESCRIPTION}] has utf-8 locale" {
-  if [[ "${SUT_IMAGE}" == *"alpine"*  ]]; then
+  if [[ $IMAGE == 'alpine_jdk8' ]]; then
     run docker run --rm "${SUT_IMAGE}" /usr/glibc-compat/bin/locale charmap
   else
     run docker run --rm "${SUT_IMAGE}" locale charmap


### PR DESCRIPTION
Downstream of #1361 (new changes start in commit https://github.com/jenkinsci/docker/commit/ef8a718ee5afa008cf00a85430d74ce26a27662d). Adding a new Alpine JDK 17 image.

### Testing done

Built this Docker image. Verified that `java` is not linking against `glibc`:

```bash
$ ldd /opt/java/openjdk/bin/java
        /lib/ld-musl-x86_64.so.1 (0x7f242e4ab000)
        libjli.so => /opt/java/openjdk/bin/../lib/libjli.so (0x7f242e494000)
        libc.musl-x86_64.so.1 => /lib/ld-musl-x86_64.so.1 (0x7f242e4ab000)
        libz.so.1 => /lib/libz.so.1 (0x7f242e47a000)
```

Installed Jenkins and verified there were no errors or stack traces printed in the console log. Then went to the script console and induced a crash:

```groovy
import java.lang.reflect.Field
import sun.misc.Unsafe

Field f = Unsafe.class.getDeclaredField("theUnsafe")
f.setAccessible(true)
Unsafe unsafe = (Unsafe) f.get(null)
unsafe.putAddress(0, 0)
```

Examining the resulting HotSpot error file, I see that `musl` is loaded in the process address space:

```bash
$ grep -i musl /tmp/hs_err_pid7.log 
7f0ac4625000-7f0ac463a000 r--p 00000000 00:58 50                         /lib/ld-musl-x86_64.so.1
7f0ac463a000-7f0ac4682000 r-xp 00015000 00:58 50                         /lib/ld-musl-x86_64.so.1
7f0ac4682000-7f0ac46b8000 r--p 0005d000 00:58 50                         /lib/ld-musl-x86_64.so.1
7f0ac46b8000-7f0ac46b9000 r--p 00092000 00:58 50                         /lib/ld-musl-x86_64.so.1
7f0ac46b9000-7f0ac46ba000 rw-p 00093000 00:58 50                         /lib/ld-musl-x86_64.so.1
```

Additionally I see the following strings:

```
libc: musl - unknown musl - unknown 
vm_info: OpenJDK 64-Bit Server VM (17.0.3+7) for linux-amd64-musl JRE (17.0.3+7), built on Apr 19 2022 21:38:47 by "" with gcc 10.3.1 20211027
```

The former indicates that https://github.com/adoptium/jdk17u/blob/e158967986d978d54802cca6cb9b430a3c78b417/src/hotspot/os/linux/os_linux.cpp#L528= must have been executed, which implies `MUSL_LIBC` must have been defined when compiling the software.