### PR TITLE
Use Temurin build for `centos7_jdk8`

### DIFF
--- a/8/centos/centos7/hotspot/Dockerfile
+++ b/8/centos/centos7/hotspot/Dockerfile
@@ -1,3 +1,5 @@
+FROM eclipse-temurin:8u332-b09-jdk-centos7 as jre-build
+
 FROM centos:centos7.9.2009
 
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
@@ -5,13 +7,7 @@ ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
 ARG TARGETARCH
 ARG COMMIT_SHA
 
-RUN echo -e '[Adoptium]\n\
-name=Adoptium\n\
-baseurl=https://packages.adoptium.net/artifactory/rpm/centos/\$releasever/\$basearch\n\
-enabled=1\n\
-gpgcheck=1\n\
-gpgkey=https://packages.adoptium.net/artifactory/api/gpg/key/public' > /etc/yum.repos.d/adoptium.repo && \
-    yum update -y && yum install -y git curl temurin-8-jdk freetype fontconfig unzip which && \
+RUN yum install -y git curl freetype fontconfig unzip which && \
     yum clean all
 
 ARG TARGETARCH
@@ -103,6 +99,10 @@ EXPOSE ${http_port}
 EXPOSE ${agent_port}
 
 ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
+COPY --from=jre-build /opt/java/openjdk $JAVA_HOME
 
 USER ${user}
 


### PR DESCRIPTION
Consistent with https://github.com/jenkinsci/docker/blob/eefedd383a626acc51c0c9c8502f780d41737691/11/centos/centos7/hotspot/Dockerfile.