### PR TITLE
Upgrade `shellcheck` from 0.7.2 to 0.8.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ check-reqs:
 	@$(call check_cli,jq)
 
 shellcheck:
-	$(ROOT_DIR)/tools/shellcheck -e SC1091 jenkins-support *.sh
+	$(ROOT_DIR)/tools/shellcheck -e SC1091 jenkins-support *.sh tests/test_helpers.bash tools/shellcheck .ci/publish.sh
 
 build: check-reqs
 	@set -x; $(bake_base_cli) --set '*.platform=linux/$(ARCH)' $(shell make --silent list)

--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -24,12 +24,14 @@ function retry {
 
     for ((i=0; i < attempts; i++)); do
         run "$@"
+        # shellcheck disable=SC2154
         if [ "$status" -eq 0 ]; then
             return 0
         fi
-        sleep $delay
+        sleep "${delay}"
     done
 
+    # shellcheck disable=SC2154
     echo "Command \"$*\" failed $attempts times. Status: $status. Output: $output" >&2
     false
 }
@@ -81,6 +83,7 @@ function get_jenkins_url {
     if [ -z "${DOCKER_HOST}" ]; then
         DOCKER_IP=localhost
     else
+        # shellcheck disable=SC2001
         DOCKER_IP=$(echo "$DOCKER_HOST" | sed -e 's|tcp://\(.*\):[0-9]*|\1|')
     fi
     echo "http://$DOCKER_IP:$(docker port "$(get_sut_container_name)" 8080 | cut -d: -f2)"

--- a/tools/shellcheck
+++ b/tools/shellcheck
@@ -3,4 +3,4 @@
 exec docker run --rm \
     -w "${PWD}" \
     -v "${PWD}:${PWD}" \
-    koalaman/shellcheck:v0.7.2 $@
+    koalaman/shellcheck:v0.8.0 "$@"


### PR DESCRIPTION
Upgrade `shellcheck` to the latest version and also run it on some additional shell scripts in the repository. Where the fixes were trivial I applied them, and where they were not trivial I ignored the check in order to at least prevent new violations from being introduced in the future.