### PR TITLE
Process test results with Node.js 18, not Node.js 12

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ test-%: prepare-test
 # Execute the test harness and write result to a TAP file
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:12-alpine \
+	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18-alpine \
 		sh -c "npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test


### PR DESCRIPTION
Node.js 18 is the current long term support release.

Intentionally continues the pattern of specifying a simplified Docker tag because minor version changes of Node.js are unlikely to harm this use case.

https://nodejs.org/en/about/releases/ describes the Node.js lifecycle.
