### PR TITLE
Use Eclipse Temurin 11.0.16 and 17.0.4

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jdk-alpine AS jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.15_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.16_8-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM eclipse-temurin:11.0.15_10-jdk-windowsservercore-1809
+FROM eclipse-temurin:11.0.16_8-jdk-windowsservercore-1809
 # hadolint shell=powershell
 
 ARG user=jenkins

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.3_7-jdk-alpine AS jre-build
+FROM eclipse-temurin:17.0.4_8-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/17/debian/bullseye-slim/hotspot/Dockerfile
+++ b/17/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.3_7-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.4_8-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.3_7-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.4_8-jdk-focal as jre-build
 
 RUN jlink \
   --add-modules ALL-MODULE-PATH \


### PR DESCRIPTION
## Use Eclipse Temurin JDK 11.0.16 and JDK 17.0.4

- Use JDK 11.0.16 instead of JDK 11.0.15
- Use JDK 17.0.4 instead of JDK 17.0.3

Eclipse Temurin JDK 11.0.16_8 is the most recent release of JDK 11. Available for all our platforms per https://adoptium.net/temurin/releases/?version=11

Eclipse Temurin JDK 17.0.4_8 is the most recent release of JDK 17. Available for all our platforms per https://adoptium.net/temurin/releases/?version=17

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
