### PR TITLE
Fix(stable-2.346) remove hacks to allow publishing all JDKs for 2.346.x LTS line

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -123,16 +123,6 @@ publish() {
 
     # Build and publish JDK8 images
     docker buildx bake --file docker-bake.hcl "${build_opts[@]+"${build_opts[@]}"}" linux
-
-    # Republish 'jdk17-preview' images from their 'jdk17' counterpart
-    for jdk17preview_image in $(make show | jq -r '.target[].tags[]' | grep 'jdk17-preview$' | sort | uniq)
-    do
-        # Remove the "-preview" prefix
-        jdk17_image="${jdk17preview_image/"-preview"/}"
-        echo "Copying ${jdk17_image} to ${jdk17preview_image}..."
-        docker run --rm --platform=linux/amd64 quay.io/skopeo/stable:latest \
-            copy docker://"${jdk17_image}" docker://"${jdk17preview_image}"
-    done
 }
 
 # Process arguments

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -122,7 +122,7 @@ publish() {
     export COMMIT_SHA JENKINS_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS
 
     # Build and publish JDK8 images
-    docker buildx bake --file docker-bake.hcl "${build_opts[@]+"${build_opts[@]}"}" linux_jdk8
+    docker buildx bake --file docker-bake.hcl "${build_opts[@]+"${build_opts[@]}"}" linux
 
     # Republish 'jdk17-preview' images from their 'jdk17' counterpart
     for jdk17preview_image in $(make show | jq -r '.target[].tags[]' | grep 'jdk17-preview$' | sort | uniq)

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20220527-slim
+FROM debian:bullseye-20220801-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -6,7 +6,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20220527
+FROM debian:bullseye-20220801
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/8/alpine/hotspot/Dockerfile
+++ b/8/alpine/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8u345-b01-jdk-alpine as jre-build
 
-FROM alpine:3.16.0
+FROM alpine:3.16.2
 
 RUN apk add --no-cache \
     bash \

--- a/8/debian/bullseye-slim/hotspot/Dockerfile
+++ b/8/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8u345-b01-jdk-focal as jre-build
 
-FROM debian:bullseye-20220527-slim
+FROM debian:bullseye-20220801-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/8/debian/bullseye/hotspot/Dockerfile
+++ b/8/debian/bullseye/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8u345-b01-jdk-focal as jre-build
 
-FROM debian:bullseye-20220527
+FROM debian:bullseye-20220801
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,10 +70,20 @@ stage('Build') {
 
     if (!infra.isTrusted()) {
         def images = [
-                'alpine_jdk8',
-                'centos7_jdk8',
-                'debian_jdk8',
-                'debian_slim_jdk8',
+            'almalinux_jdk11',
+            'alpine_jdk11',
+            'alpine_jdk17',
+            'alpine_jdk8',
+            'centos7_jdk11',
+            'centos7_jdk8',
+            'debian_jdk11',
+            'debian_jdk17',
+            'debian_jdk8',
+            'debian_slim_jdk11',
+            'debian_slim_jdk17',
+            'debian_slim_jdk8',
+            'debian_slim_jdk8',
+            'rhel_ubi8_jdk11',
         ]
         for (i in images) {
             def imageToBuild = i

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -165,7 +165,10 @@ target "alpine_jdk17" {
   tags = [
     tag(true, "alpine-jdk17-preview"),
     tag_weekly(false, "alpine-jdk17-preview"),
-    tag_lts(false, "lts-alpine-jdk17-preview")
+    tag_lts(false, "lts-alpine-jdk17-preview"),
+    tag(true, "alpine-jdk17"),
+    tag_weekly(false, "alpine-jdk17"),
+    tag_lts(false, "lts-alpine-jdk17")
   ]
   platforms = ["linux/amd64"]
 }
@@ -262,7 +265,12 @@ target "debian_jdk17" {
     tag_weekly(false, "latest-jdk17-preview"),
     tag_weekly(false, "jdk17-preview"),
     tag_lts(false, "lts-jdk17-preview"),
-    tag_lts(true, "lts-jdk17-preview")
+    tag_lts(true, "lts-jdk17-preview"),
+    tag(true, "jdk17"),
+    tag_weekly(false, "latest-jdk17"),
+    tag_weekly(false, "jdk17"),
+    tag_lts(false, "lts-jdk17"),
+    tag_lts(true, "lts-jdk17")
   ]
   platforms = ["linux/amd64", "linux/arm64"]
 }
@@ -317,6 +325,9 @@ target "debian_slim_jdk17" {
     tag(true, "slim-jdk17-preview"),
     tag_weekly(false, "slim-jdk17-preview"),
     tag_lts(false, "lts-slim-jdk17-preview"),
+    tag(true, "slim-jdk17"),
+    tag_weekly(false, "slim-jdk17"),
+    tag_lts(false, "lts-slim-jdk17"),
   ]
   platforms = ["linux/amd64"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,13 +2,19 @@
 
 group "linux" {
   targets = [
+    "almalinux_jdk11",
     "alpine_jdk8",
+    "alpine_jdk11",
     "alpine_jdk17",
     "centos7_jdk8",
+    "centos7_jdk11",
     "debian_jdk8",
+    "debian_jdk11",
     "debian_jdk17",
     "debian_slim_jdk8",
+    "debian_slim_jdk11",
     "debian_slim_jdk17",
+    "rhel_ubi8_jdk11"
   ]
 }
 
@@ -23,7 +29,16 @@ group "linux_jdk8" {
 
 group "linux-arm64" {
   targets = [
+    "almalinux_jdk11",
+    "debian_jdk11",
     "debian_jdk17",
+    "rhel_ubi8_jdk11",
+  ]
+}
+
+group "linux-s390x" {
+  targets = [
+    "debian_jdk11",
   ]
 }
 
@@ -93,6 +108,23 @@ function "tag_lts" {
 
 # ---- targets ----
 
+target "almalinux_jdk11" {
+  dockerfile = "11/almalinux/almalinux8/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, "almalinux"),
+    tag_weekly(false, "almalinux"),
+    tag_lts(false, "lts-almalinux")
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
 target "alpine_jdk8" {
   dockerfile = "8/alpine/hotspot/Dockerfile"
   context = "."
@@ -106,6 +138,26 @@ target "alpine_jdk8" {
     tag(true, "alpine-jdk8"),
     tag_weekly(false, "alpine-jdk8"),
     tag_lts(false, "lts-alpine-jdk8")
+  ]
+  platforms = ["linux/amd64"]
+}
+
+target "alpine_jdk11" {
+  dockerfile = "11/alpine/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, "alpine"),
+    tag_weekly(false, "alpine"),
+    tag_weekly(false, "alpine-jdk11"),
+    tag_lts(false, "lts-alpine"),
+    tag_lts(false, "lts-alpine-jdk11"),
+    tag_lts(true, "lts-alpine"),
   ]
   platforms = ["linux/amd64"]
 }
@@ -144,6 +196,26 @@ target "centos7_jdk8" {
   platforms = ["linux/amd64"]
 }
 
+target "centos7_jdk11" {
+  dockerfile = "11/centos/centos7/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, "centos7"),
+    tag_weekly(false, "centos7"),
+    tag_weekly(false, "centos7-jdk11"),
+    tag_lts(true, "lts-centos7"),
+    tag_lts(false, "lts-centos7"),
+    tag_lts(false, "lts-centos7-jdk11")
+  ]
+  platforms = ["linux/amd64"]
+}
+
 target "debian_jdk8" {
   dockerfile = "8/debian/bullseye/hotspot/Dockerfile"
   context = "."
@@ -160,6 +232,29 @@ target "debian_jdk8" {
     tag_lts(true, "lts-jdk8")
   ]
   platforms = ["linux/amd64"]
+}
+
+target "debian_jdk11" {
+  dockerfile = "11/debian/bullseye/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, ""),
+    tag(true, "jdk11"),
+    tag_weekly(false, "latest"),
+    tag_weekly(false, "latest-jdk11"),
+    tag_weekly(false, "jdk11"),
+    tag_lts(false, "lts"),
+    tag_lts(false, "lts-jdk11"),
+    tag_lts(true, "lts"),
+    tag_lts(true, "lts-jdk11")
+  ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/s390x"]
 }
 
 target "debian_jdk17" {
@@ -198,6 +293,26 @@ target "debian_slim_jdk8" {
   platforms = ["linux/amd64"]
 }
 
+target "debian_slim_jdk11" {
+  dockerfile = "11/debian/bullseye-slim/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, "slim"),
+    tag_weekly(false, "slim"),
+    tag_weekly(false, "slim-jdk11"),
+    tag_lts(false, "lts-slim"),
+    tag_lts(false, "lts-slim-jdk11"),
+    tag_lts(true, "lts-slim"),
+  ]
+  platforms = ["linux/amd64"]
+}
+
 target "debian_slim_jdk17" {
   dockerfile = "17/debian/bullseye-slim/hotspot/Dockerfile"
   context = "."
@@ -213,4 +328,22 @@ target "debian_slim_jdk17" {
     tag_lts(false, "lts-slim-jdk17-preview"),
   ]
   platforms = ["linux/amd64"]
+}
+
+target "rhel_ubi8_jdk11" {
+  dockerfile = "11/rhel/ubi8/hotspot/Dockerfile"
+  context = "."
+  args = {
+    JENKINS_VERSION = JENKINS_VERSION
+    JENKINS_SHA = JENKINS_SHA
+    COMMIT_SHA = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+  }
+  tags = [
+    tag(true, "rhel-ubi8-jdk11"),
+    tag_weekly(false, "rhel-ubi8-jdk11"),
+    tag_lts(false, "lts-rhel-ubi8-jdk11"),
+    tag_lts(true, "lts-rhel-ubi8-jdk11")
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -123,7 +123,6 @@ target "alpine_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
-    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
   }
   tags = [
     tag(true, "alpine-jdk8"),
@@ -180,7 +179,6 @@ target "centos7_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
-    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
   }
   tags = [
     tag(true, "centos7-jdk8"),
@@ -217,7 +215,6 @@ target "debian_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
-    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
   }
   tags = [
     tag(true, "jdk8"),
@@ -282,7 +279,6 @@ target "debian_slim_jdk8" {
     JENKINS_VERSION = JENKINS_VERSION
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
-    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
   }
   tags = [
     tag(true, "slim-jdk8"),

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -18,15 +18,6 @@ group "linux" {
   ]
 }
 
-group "linux_jdk8" {
-  targets = [
-    "alpine_jdk8",
-    "centos7_jdk8",
-    "debian_jdk8",
-    "debian_slim_jdk8",
-  ]
-}
-
 group "linux-arm64" {
   targets = [
     "almalinux_jdk11",

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -40,11 +40,11 @@ group "linux-ppc64le" {
 # ---- variables ----
 
 variable "JENKINS_VERSION" {
-  default = "2.303"
+  default = "2.356"
 }
 
 variable "JENKINS_SHA" {
-  default = "4dfe49cd7422ec4317a7c7a7c083f40fa475a58a7747bd94187b2cf222006ac0"
+  default = "1163c4554dc93439c5eef02b06a8d74f98ca920bbc012c2b8a089d414cfa8075"
 }
 
 variable "REGISTRY" {

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -89,20 +89,27 @@ start-jenkins-with-jvm-opts() {
 }
 
 get-csp-value() {
-  local sed_expr='s/<wbr>//g;s/<td class="pane">.*<\/td><td class.*normal">//g;s/<t.>//g;s/<\/t.>//g'
-  bash -c "curl -fsSL --user \"admin:$(get_jenkins_password)\" $(get_jenkins_url)/systemInfo | sed 's/<\/tr>/<\/tr>\'$'\n/g' | grep '<td class=\"pane\">hudson.model.DirectoryBrowserSupport.CSP</td>' | sed -e '${sed_expr}'"
+  runInScriptConsole "System.getProperty('hudson.model.DirectoryBrowserSupport.CSP')"
 }
 
 get-timezone-value() {
-  local sed_expr='s/<wbr>//g;s/<td class="pane">.*<\/td><td class.*normal">//g;s/<t.>//g;s/<\/t.>//g'
-  bash -c "curl -fsSL --user \"admin:$(get_jenkins_password)\" $(get_jenkins_url)/systemInfo | sed 's/<\/tr>/<\/tr>\'$'\n/g' | grep '<td class=\"pane\">user.timezone</td>' | sed -e '${sed_expr}'"
+  runInScriptConsole "System.getProperty('user.timezone')"
+}
+
+runInScriptConsole() {
+  SERVER="$(get_jenkins_url)"
+  COOKIEJAR="$(mktemp)"
+  PASSWORD="$(get_jenkins_password)"
+  CRUMB=$(curl -u "admin:$PASSWORD" --cookie-jar "$COOKIEJAR" "$SERVER/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,%22:%22,//crumb)")
+
+  bash -c "curl -fssL -X POST -u \"admin:$PASSWORD\" --cookie \"$COOKIEJAR\" -H \"$CRUMB\" \"$SERVER\"/scriptText -d script=\"$1\" | sed -e 's/Result: //'"
 }
 
 @test "[${SUT_DESCRIPTION}] passes JAVA_OPTS as JVM options" {
   start-jenkins-with-jvm-opts --env JAVA_OPTS="-Duser.timezone=Europe/Madrid -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';\""
 
   # JAVA_OPTS are used
-  assert 'default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;' get-csp-value
+  assert "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';" get-csp-value
   assert 'Europe/Madrid' get-timezone-value
 }
 
@@ -110,7 +117,7 @@ get-timezone-value() {
   start-jenkins-with-jvm-opts --env JENKINS_JAVA_OPTS="-Duser.timezone=Europe/Madrid -Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';\""
 
   # JENKINS_JAVA_OPTS are used
-  assert 'default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;' get-csp-value
+  assert "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';" get-csp-value
   assert 'Europe/Madrid' get-timezone-value
 }
 
@@ -120,6 +127,6 @@ get-timezone-value() {
     --env JENKINS_JAVA_OPTS="-Dhudson.model.DirectoryBrowserSupport.CSP=\"default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';\""
 
   # JAVA_OPTS and JENKINS_JAVA_OPTS are used
-  assert 'default-src &#039;self&#039;; script-src &#039;self&#039; &#039;unsafe-inline&#039; &#039;unsafe-eval&#039;; style-src &#039;self&#039; &#039;unsafe-inline&#039;;' get-csp-value
+  assert "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline';" get-csp-value
   assert 'Europe/Madrid' get-timezone-value
 }


### PR DESCRIPTION
Note: as preliminary to this PR, I've manually republished the missing `jdk17-prevoew` images manually as the publish script seems to have failed for some.

This PR removes most of the short hacks that were added to this branch to fix the missing JDK8 images for 2.346.2 and 2.346.3.

It's caused by #1441, setting the ground to allow publishing futur LTS image releases for this line.


It introduces the following changes:

- Add back the JDK11 and JDK17 builds (reverts https://github.com/dduportal/docker/commit/dc26917942c7cce09afffc8633b580161bd85c92)
- Add back the JDK11 and JDK17 publications (reverts https://github.com/dduportal/docker/commit/e6b995f4436f71bfa3d50ee5724988d528189b9c)
- Ensure that all JDK17 images are now built and published with both `jdk17` and `jdk17-preview` (and removes the hack in publish script that was skopeo-copying images).
- Cherry pick https://github.com/jenkinsci/docker/pull/1409 and https://github.com/jenkinsci/docker/pull/1411 for fixing tests
- Cleanup the docker-bake to stop passing (unused) build args to JKD8 (which now have a fixed version of the jenkins-plugin-cli that should never be upgraded anymore as the next version dropped the JDK8 support)
- Cherry pick missing base OS updates