### PR TITLE
Use JDK 11.0.16.1 instead of JDK 11.0.16

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.16.1_1-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk-alpine AS jre-build
+FROM eclipse-temurin:11.0.16.1_1-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.16.1_1-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.16.1_1-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.16.1_1-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.16_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.16.1_1-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM eclipse-temurin:11.0.16_8-jdk-windowsservercore-1809
+FROM eclipse-temurin:11.0.16.1_1-jdk-windowsservercore-1809
 # hadolint shell=powershell
 
 ARG user=jenkins


### PR DESCRIPTION
Backports #1446 , working on #1441.

This PR ensures that JDK-8292260 is fixed on the LTS 2.346 JDK11 line

----

From https://www.jenkins.io/doc/upgrade-guide/2.346/#upgrading-to-jenkins-lts-2-346-3

OpenJDK 11.0.16 and 17.0.4 are susceptible to JDK-8292260, a regression in
the C2 JIT compiler which may cause the JVM to crash unpredictably. The
OpenJDK project has released fixes in 11.0.16.1 and 17.0.4.1.

The version of OpenJDK in the official Docker image has been upgraded from
11.0.15 to 11.0.16 and from 17.0.3 to 17.0.4. This exposes a metaspace
memory leak in Pipeline: Groovy 2692.v76b_089ccd026 and earlier and in
Script Security 1172.v35f6a_0b_8207e and earlier. After upgrading Jenkins
to 2.346.3, upgrade Pipeline: Groovy to 2705.v0449852ee36f or later and
upgrade Script Security to 1175.v4b_d517d6db_f0 or later. It is generally
recommended to upgrade all plugins after upgrading Jenkins core.

OpenJDK 11.0.16 contains a fix for JDK-8230305; i.e., container awareness
for cgroups v2.

Previously, there would be no container detection when running OpenJDK
11.0.15 on cgroups v2, and the limits from the container host would
be used. As of OpenJDK 11.0.16, OpenJDK detects container limits via
cgroups v2. These limits affect, for example, the garbage collection (GC)
algorithm selected by the JVM, the default size of the heap, the sizes of
thread pools, and how default parallelism is determined for ForkJoinPool.

(cherry picked from commit 4e1de38a5efef6adbc0159a851197ccf051e3c23)

