### PR TITLE
Use JDK 17.0.4.1 instead of JDK 17.0.4

### DIFF
--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4_8-jdk-alpine AS jre-build
+FROM eclipse-temurin:17.0.4.1_1-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/17/debian/bullseye-slim/hotspot/Dockerfile
+++ b/17/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4_8-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.4.1_1-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.4_8-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.4.1_1-jdk-focal as jre-build
 
 RUN jlink \
   --add-modules ALL-MODULE-PATH \


### PR DESCRIPTION
Backports https://github.com/jenkinsci/docker/pull/1447 , working on https://github.com/jenkinsci/docker/issues/1441.

This PR ensures that JDK-8292260 is fixed on the LTS 2.346 JDK17 line

----

From https://www.jenkins.io/doc/upgrade-guide/2.346/#upgrading-to-jenkins-lts-2-346-3

OpenJDK 11.0.16/17.0.4 and the C2 JIT compiler

OpenJDK 11.0.16 and 17.0.4 are susceptible to JDK-8292260, a regression in
the C2 JIT compiler which may cause the JVM to crash unpredictably. The
OpenJDK project has released fixes in 11.0.16.1 and 17.0.4.1.

OpenJDK 11.0.16/17.0.4 and the metaspace

The version of OpenJDK in the official Docker image has been upgraded from
11.0.15 to 11.0.16 and from 17.0.3 to 17.0.4. This exposes a metaspace
memory leak in Pipeline: Groovy 2692.v76b_089ccd026 and earlier and in
Script Security 1172.v35f6a_0b_8207e and earlier. After upgrading Jenkins
to 2.346.3, upgrade Pipeline: Groovy to 2705.v0449852ee36f or later and
upgrade Script Security to 1175.v4b_d517d6db_f0 or later. It is generally
recommended to upgrade all plugins after upgrading Jenkins core.

(cherry picked from commit 954da19c99f9e7f6bee968dcd0d9b4d48fbab669)

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
