### PR TITLE
Backport debian 20220822 updates to stable 2.346 line

### DIFF
--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20220801-slim
+FROM debian:bullseye-20220822-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -6,7 +6,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20220801
+FROM debian:bullseye-20220822
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/17/debian/bullseye-slim/hotspot/Dockerfile
+++ b/17/debian/bullseye-slim/hotspot/Dockerfile
@@ -8,7 +8,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM debian:bullseye-20220801-slim
+FROM debian:bullseye-20220822-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -6,7 +6,7 @@ RUN jlink \
   --compress=2 \
   --output /javaruntime
 
-FROM debian:bullseye-20220801
+FROM debian:bullseye-20220822
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/8/debian/bullseye-slim/hotspot/Dockerfile
+++ b/8/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8u345-b01-jdk-focal as jre-build
 
-FROM debian:bullseye-20220801-slim
+FROM debian:bullseye-20220822-slim
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/8/debian/bullseye/hotspot/Dockerfile
+++ b/8/debian/bullseye/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 FROM eclipse-temurin:8u345-b01-jdk-focal as jre-build
 
-FROM debian:bullseye-20220801
+FROM debian:bullseye-20220822
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This PR backports all the dependanbot commits which bumped the base debian OS image last week.

It also bumps the same version but for JDK8, which was ignored due to the dependabot setup