### PR TITLE
Prepare 2.346.3-2 LTS publication

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -176,7 +176,7 @@ fi
 versions=$(get-latest-versions)
 latest_lts_version="2.346.3-2"
 
-for version in ${versions}
+for version in ${versions} "2.346.3-2"
 do
     TOKEN=$(login-token)
 

--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -33,13 +33,13 @@ login-token() {
 }
 
 is-published() {
-    local JENKINS_VERSION="$1"
+    local MAIN_VERSION="$1"
     local LATEST_WEEKLY=$2
     local LATEST_LTS=$3
     local docker_bake_version_config
 
     ## Export values for docker bake (through the `make <target>` commands)
-    export JENKINS_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS
+    export MAIN_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS
 
     ## A given jenkins version is considered publish if, and only if, all the images associated with this tag, are published with the correct manifest.
     ## By "all images", we mean all the declinations but also all the CPU architectures.
@@ -108,25 +108,36 @@ publish() {
     local sha
     local build_opts=(--pull --push)
 
-    if [ "$dry_run" = true ]; then
-        build_opts=()
-    fi
+    local jenkins_version=${version%-*} # Remove eventual "-xxx" suffix
+    sha="$(curl --disable --fail --silent --show-error --location "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${jenkins_version}/jenkins-war-${jenkins_version}.war.sha256")"
 
-    sha="$(curl --disable --fail --silent --show-error --location "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${version}/jenkins-war-${version}.war.sha256")"
-
-    JENKINS_VERSION=$version
+    MAIN_VERSION=$version
     JENKINS_SHA=$sha
     LATEST_WEEKLY=$latest_weekly
     LATEST_LTS=$latest_lts
     COMMIT_SHA=$(git rev-parse HEAD)
-    export COMMIT_SHA JENKINS_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS
+    export COMMIT_SHA MAIN_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS
 
-    # Build and publish JDK8 images
+    if [ "$dry_run" = true ]; then
+        build_opts=()
+
+        echo "DEBUG: COMMIT_SHA=${COMMIT_SHA}"
+        echo "DEBUG: MAIN_VERSION=${MAIN_VERSION}"
+        echo "DEBUG: jenkins_version=${jenkins_version}"
+        echo "DEBUG: JENKINS_SHA=${JENKINS_SHA}"
+        echo "DEBUG: LATEST_WEEKLY=${LATEST_WEEKLY}"
+        echo "DEBUG: LATEST_LTS=${LATEST_LTS}"
+    fi
+
+    echo "===="
+    echo "INFO: Publishing the following tags:"
+    make show | jq -r '.target[].tags[]'
+    echo "===="
+
     docker buildx bake --file docker-bake.hcl "${build_opts[@]+"${build_opts[@]}"}" linux
 }
 
 # Process arguments
-
 dry_run=false
 debug=false
 start_after="1.0" # By default, we will publish anything missing (only the last 30 actually)
@@ -163,7 +174,7 @@ if [ "$dry_run" = true ]; then
 fi
 
 versions=$(get-latest-versions)
-latest_lts_version=$(echo "${versions}" | grep -E '[0-9]\.[0-9]+\.[0-9]' | tail -n 1 || echo "No LTS versions")
+latest_lts_version="2.346.3-2"
 
 for version in ${versions}
 do

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' require
 ## Check if a given image exists in the current manifest docker-bake.hcl
 check_image = make --silent list | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the platform 'linux/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
-bake_base_cli := docker buildx bake -f docker-bake.hcl --load
+bake_base_cli := docker buildx bake --file docker-bake.hcl --load
 
 check-reqs:
 ## Build requirements

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -47,7 +47,7 @@ variable "JENKINS_VERSION" {
 }
 
 variable "JENKINS_SHA" {
-  default = "1163c4554dc93439c5eef02b06a8d74f98ca920bbc012c2b8a089d414cfa8075"
+  default = "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89" # 2.346.3
 }
 
 variable "REGISTRY" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -38,9 +38,12 @@ group "linux-ppc64le" {
 }
 
 # ---- variables ----
+variable "MAIN_VERSION" {
+  default = "2.346.3-1"
+}
 
 variable "JENKINS_VERSION" {
-  default = "2.356"
+  default = _jenkins_version("${MAIN_VERSION}")
 }
 
 variable "JENKINS_SHA" {
@@ -73,10 +76,15 @@ variable "COMMIT_SHA" {
 
 # ----  user-defined functions ----
 
+# return the Jenkins version from a string that could have a "-XXX" suffix
+function "_jenkins_version" {
+  params = [main_version]
+  result = split("-", main_version)[0]
+}
 # return a tag prefixed by the Jenkins version
 function "_tag_jenkins_version" {
   params = [tag]
-  result = notequal(tag, "") ? "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}-${tag}" : "${REGISTRY}/${JENKINS_REPO}:${JENKINS_VERSION}"
+  result = notequal(tag, "") ? "${REGISTRY}/${JENKINS_REPO}:${MAIN_VERSION}-${tag}" : "${REGISTRY}/${JENKINS_REPO}:${MAIN_VERSION}"
 }
 
 # return a tag optionaly prefixed by the Jenkins version


### PR DESCRIPTION
Depends on #1451 #1450 #1449 #1448 .

This PR allows to publish a new tag for the LTS image without requiring a full Jenkins LTS release for #1441.

The new tag will be `2.346.3-2` and will also update the "non version" tags such as `lts-jdk11`, etc.


Tested the publication script in dry run:

```shell 
$ ./.ci/publish.sh -n     
Docker repository in Use:
* JENKINS_REPO: jenkins/jenkins
Dry run, will not publish images
Tag is already published: 2.346.1
Tag is already published: 2.346.2
Tag is already published: 2.346.3
WARNING: could not get a valid manifest at the URL https://index.docker.io/v2/jenkins/jenkins/manifests/2.346.3-2-almalinux.
  (For debugging purposes) manifest={"errors":[{"code":"MANIFEST_UNKNOWN","message":"manifest unknown","detail":"unknown tag=2.346.3-2-almalinux"}]}
2.346.3-2 not published yet
Version 2.346.3-2 higher than 1.0: publishing 2.346.3-2 latest_weekly:false latest_lts:true
DEBUG: COMMIT_SHA=7daeb5f3a914a491d4b843e7285a1451dc386fe9
DEBUG: MAIN_VERSION=2.346.3-2
DEBUG: jenkins_version=2.346.3
DEBUG: JENKINS_SHA=141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89
DEBUG: LATEST_WEEKLY=false
DEBUG: LATEST_LTS=true
====
INFO: Publishing the following tags:
docker.io/jenkins/jenkins:2.346.3-2-almalinux
docker.io/jenkins/jenkins:lts-almalinux
docker.io/jenkins/jenkins:2.346.3-2-alpine
docker.io/jenkins/jenkins:lts-alpine
docker.io/jenkins/jenkins:lts-alpine-jdk11
docker.io/jenkins/jenkins:2.346.3-2-lts-alpine
docker.io/jenkins/jenkins:2.346.3-2-alpine-jdk17-preview
docker.io/jenkins/jenkins:lts-alpine-jdk17-preview
docker.io/jenkins/jenkins:2.346.3-2-alpine-jdk17
docker.io/jenkins/jenkins:lts-alpine-jdk17
docker.io/jenkins/jenkins:2.346.3-2-alpine-jdk8
docker.io/jenkins/jenkins:lts-alpine-jdk8
docker.io/jenkins/jenkins:2.346.3-2-centos7
docker.io/jenkins/jenkins:2.346.3-2-lts-centos7
docker.io/jenkins/jenkins:lts-centos7
docker.io/jenkins/jenkins:lts-centos7-jdk11
docker.io/jenkins/jenkins:2.346.3-2-centos7-jdk8
docker.io/jenkins/jenkins:lts-centos7-jdk8
docker.io/jenkins/jenkins:2.346.3-2
docker.io/jenkins/jenkins:2.346.3-2-jdk11
docker.io/jenkins/jenkins:lts
docker.io/jenkins/jenkins:lts-jdk11
docker.io/jenkins/jenkins:2.346.3-2-lts
docker.io/jenkins/jenkins:2.346.3-2-lts-jdk11
docker.io/jenkins/jenkins:2.346.3-2-jdk17-preview
docker.io/jenkins/jenkins:lts-jdk17-preview
docker.io/jenkins/jenkins:2.346.3-2-lts-jdk17-preview
docker.io/jenkins/jenkins:2.346.3-2-jdk17
docker.io/jenkins/jenkins:lts-jdk17
docker.io/jenkins/jenkins:2.346.3-2-lts-jdk17
docker.io/jenkins/jenkins:2.346.3-2-jdk8
docker.io/jenkins/jenkins:lts-jdk8
docker.io/jenkins/jenkins:2.346.3-2-lts-jdk8
docker.io/jenkins/jenkins:2.346.3-2-slim
docker.io/jenkins/jenkins:lts-slim
docker.io/jenkins/jenkins:lts-slim-jdk11
docker.io/jenkins/jenkins:2.346.3-2-lts-slim
docker.io/jenkins/jenkins:2.346.3-2-slim-jdk17-preview
docker.io/jenkins/jenkins:lts-slim-jdk17-preview
docker.io/jenkins/jenkins:2.346.3-2-slim-jdk17
docker.io/jenkins/jenkins:lts-slim-jdk17
docker.io/jenkins/jenkins:2.346.3-2-slim-jdk8
docker.io/jenkins/jenkins:lts-slim-jdk8
docker.io/jenkins/jenkins:2.346.3-2-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:lts-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.346.3-2-lts-rhel-ubi8-jdk11
====
[+] Building 0.0s (0/0)                                                                                                                                          
{
  "group": {
    "default": {
      "targets": [
        "almalinux_jdk11",
        "alpine_jdk8",
        "alpine_jdk11",
        "alpine_jdk17",
        "centos7_jdk8",
        "centos7_jdk11",
        "debian_jdk8",
        "debian_jdk11",
        "debian_jdk17",
        "debian_slim_jdk8",
        "debian_slim_jdk11",
        "debian_slim_jdk17",
        "rhel_ubi8_jdk11"
      ]
    }
  },
  "target": {
    "almalinux_jdk11": {
      "context": ".",
      "dockerfile": "11/almalinux/almalinux8/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-almalinux",
        "docker.io/jenkins/jenkins:lts-almalinux"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    },
    "alpine_jdk11": {
      "context": ".",
      "dockerfile": "11/alpine/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-alpine",
        "docker.io/jenkins/jenkins:lts-alpine",
        "docker.io/jenkins/jenkins:lts-alpine-jdk11",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-alpine"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk17": {
      "context": ".",
      "dockerfile": "17/alpine/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-alpine-jdk17-preview",
        "docker.io/jenkins/jenkins:lts-alpine-jdk17-preview",
        "docker.io/jenkins/jenkins:2.346.3-2-alpine-jdk17",
        "docker.io/jenkins/jenkins:lts-alpine-jdk17"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "alpine_jdk8": {
      "context": ".",
      "dockerfile": "8/alpine/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-alpine-jdk8",
        "docker.io/jenkins/jenkins:lts-alpine-jdk8"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "centos7_jdk11": {
      "context": ".",
      "dockerfile": "11/centos/centos7/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-centos7",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-centos7",
        "docker.io/jenkins/jenkins:lts-centos7",
        "docker.io/jenkins/jenkins:lts-centos7-jdk11"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "centos7_jdk8": {
      "context": ".",
      "dockerfile": "8/centos/centos7/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-centos7-jdk8",
        "docker.io/jenkins/jenkins:lts-centos7-jdk8"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "debian_jdk11": {
      "context": ".",
      "dockerfile": "11/debian/bullseye/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2",
        "docker.io/jenkins/jenkins:2.346.3-2-jdk11",
        "docker.io/jenkins/jenkins:lts",
        "docker.io/jenkins/jenkins:lts-jdk11",
        "docker.io/jenkins/jenkins:2.346.3-2-lts",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-jdk11"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/s390x"
      ]
    },
    "debian_jdk17": {
      "context": ".",
      "dockerfile": "17/debian/bullseye/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-jdk17-preview",
        "docker.io/jenkins/jenkins:lts-jdk17-preview",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-jdk17-preview",
        "docker.io/jenkins/jenkins:2.346.3-2-jdk17",
        "docker.io/jenkins/jenkins:lts-jdk17",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-jdk17"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    },
    "debian_jdk8": {
      "context": ".",
      "dockerfile": "8/debian/bullseye/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-jdk8",
        "docker.io/jenkins/jenkins:lts-jdk8",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-jdk8"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "debian_slim_jdk11": {
      "context": ".",
      "dockerfile": "11/debian/bullseye-slim/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-slim",
        "docker.io/jenkins/jenkins:lts-slim",
        "docker.io/jenkins/jenkins:lts-slim-jdk11",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-slim"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "debian_slim_jdk17": {
      "context": ".",
      "dockerfile": "17/debian/bullseye-slim/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-slim-jdk17-preview",
        "docker.io/jenkins/jenkins:lts-slim-jdk17-preview",
        "docker.io/jenkins/jenkins:2.346.3-2-slim-jdk17",
        "docker.io/jenkins/jenkins:lts-slim-jdk17"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "debian_slim_jdk8": {
      "context": ".",
      "dockerfile": "8/debian/bullseye-slim/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-slim-jdk8",
        "docker.io/jenkins/jenkins:lts-slim-jdk8"
      ],
      "platforms": [
        "linux/amd64"
      ]
    },
    "rhel_ubi8_jdk11": {
      "context": ".",
      "dockerfile": "11/rhel/ubi8/hotspot/Dockerfile",
      "args": {
        "COMMIT_SHA": "7daeb5f3a914a491d4b843e7285a1451dc386fe9",
        "JENKINS_SHA": "141e8c5890a31a5cf37a970ce3e15273c1c74d8759e4a5873bb5511c50b47d89",
        "JENKINS_VERSION": "2.346.3",
        "PLUGIN_CLI_VERSION": "2.12.8"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.346.3-2-rhel-ubi8-jdk11",
        "docker.io/jenkins/jenkins:lts-rhel-ubi8-jdk11",
        "docker.io/jenkins/jenkins:2.346.3-2-lts-rhel-ubi8-jdk11"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64"
      ]
    }
  }
}
```