### PR TITLE
Remove ppc64le support

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -88,7 +88,6 @@ Planned supported architectures:
 * amd64
 * arm64
 * s390x
-* ppc64le
 
 == Debugging
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ export BUILDKIT_PROGRESS=plain
 export COMMIT_SHA=$(shell git rev-parse HEAD)
 
 current_arch := $(shell uname -m)
-export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (ppc64*|s390*|riscv*) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
+export ARCH ?= $(shell case $(current_arch) in (x86_64) echo "amd64" ;; (i386) echo "386";; (aarch64|arm64) echo "arm64" ;; (armv6*) echo "arm/v6";; (armv7*) echo "arm/v7";; (s390*|riscv*) echo $(current_arch);; (*) echo "UNKNOWN-CPU";; esac)
 
 all: hadolint shellcheck build test
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -29,10 +29,6 @@ group "linux-s390x" {
   ]
 }
 
-group "linux-ppc64le" {
-  targets = []
-}
-
 # ---- variables ----
 
 variable "JENKINS_VERSION" {


### PR DESCRIPTION
## Drop ppc64le support

IBM no longer provides the PowerPC agents that we use to test and verify PowerPC support.  Can't support an architecture that we can't test.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
