### PR TITLE
fix(sync-plugin-manager): prevent it to open wrong PRs updating to `null`

### DIFF
--- a/.github/workflows/sync-plugin-manager.yml
+++ b/.github/workflows/sync-plugin-manager.yml
@@ -18,7 +18,7 @@ jobs:
         run: | 
           NEXT_VERSION=$(curl -sL  https://api.github.com/repos/jenkinsci/plugin-installation-manager-tool/releases/latest | jq -r ".tag_name")
           if [ -z "$NEXT_VERSION" ] || [ $NEXT_VERSION = "null" ]; then
-            echo "ERROR: Empty or 'null' latest plugin-installation-manager-tool returned by GitHub, abording."
+            echo "ERROR: Empty or 'null' latest plugin-installation-manager-tool version returned by GitHub API."
             exit 1
           fi
           echo "next-version=$NEXT_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/sync-plugin-manager.yml
+++ b/.github/workflows/sync-plugin-manager.yml
@@ -17,6 +17,10 @@ jobs:
         id: lts
         run: | 
           NEXT_VERSION=$(curl -sL  https://api.github.com/repos/jenkinsci/plugin-installation-manager-tool/releases/latest | jq -r ".tag_name")
+          if [ -z "$NEXT_VERSION" ] || [ $NEXT_VERSION = "null" ]; then
+            echo "ERROR: Empty or 'null' latest plugin-installation-manager-tool returned by GitHub, abording."
+            exit 1
+          fi
           echo "next-version=$NEXT_VERSION" >> $GITHUB_OUTPUT
 
       - name: Check if update is available


### PR DESCRIPTION
As seen in the logs of the last wrong PR (https://github.com/jenkinsci/docker/actions/runs/3727015964/jobs/6320829888), GitHub is sometime returning the value "null" instead of the latest release version.

This PR add a check on the NEXT_VERSION returned by GitHub, and abort the build if it's empty or equals to "null".

Fix #1418 #1462 #1516 #1532 

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
