### PR TITLE
Pull hadolint image from the docker hub

### DIFF
--- a/tools/hadolint
+++ b/tools/hadolint
@@ -3,4 +3,4 @@
 exec docker run --rm \
 	-w "${PWD}" \
 	-v "${PWD}:${PWD}" \
-	ghcr.io/hadolint/hadolint:v2.10.0-debian hadolint "$@"
+	hadolint/hadolint:v2.10.0-debian hadolint "$@"


### PR DESCRIPTION
Is there a particular reason to use GH packages over pulling images straight from the docker hub? If no, this PR is a drop-in replacement, which also gets a rid of the need to authenticate yourself in order to pull images from GH packages.