### PR TITLE
Use ubi8:8.7 instead of ubi8:8.6

### DIFF
--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -9,7 +9,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM registry.access.redhat.com/ubi8/ubi:8.6-943.1665521450
+FROM registry.access.redhat.com/ubi8/ubi:8.7-1054
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
## Use ubi8/ubi:8.7 instead of 8.6

The 8.7 container was updated a week ago. The 8.6 version we were delivering was last updated over 3 months ago.

https://catalog.redhat.com/software/containers/ubi8/ubi/5c359854d70cc534b3a3784e

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
