### PR TITLE
workaround(publish.sh) Only check the last 3 Jenkins versions for publication

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -98,7 +98,7 @@ is-published() {
 }
 
 get-latest-versions() {
-    curl --disable --fail --silent --show-error --location https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml | grep '<version>.*</version>' | grep -E -o '[0-9]+(\.[0-9]+)+' | sort-versions | uniq | tail -n 30
+    curl --disable --fail --silent --show-error --location https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml | grep '<version>.*</version>' | grep -E -o '[0-9]+(\.[0-9]+)+' | sort-versions | uniq | tail -n 3
 }
 
 publish() {


### PR DESCRIPTION
The PR https://github.com/jenkinsci/docker/pull/1549 introduced a new image definition: ubi-9.
Alas, our publication process is fragile and broke following this change.

This PR is a a workaround on the publication script to avoid breakage (in short term).

It only checks the past 3 Jenkins versions instead of the past 30: that should avoid the 1 hour timeout that is blocking the recent `2.389` publication.


In details: the script (for Linux container images) checks for the past 30 Jenkins version if they are published or not. If not, then it's rebuilt and published.
But the function in charge of checking if "pusblished" relies on the output of `make --silent show`, e.g. directly from the conten t of the `docker-bake.hcl` file.
Since #1549 and until this PR is merged, the publication process checks for `ubi9` tag for each of these 30 versions, which of coure did not exist, leading to a full (and costly) rebuild of all.


Long term, we might want to propose a new delivery system: this "script" is painful, breaks often (and [does not work for Windows](https://github.com/jenkinsci/docker/issues/1490) images).
We should not try to rebuild a given tag.

PS: since the latest LTS `2.375.2` was rebuilt and redeployed, we'll have to communicate to users