### PR TITLE
chore(publish.sh) Allow 2.391 container image to publish by fixing up a bug from #1564

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -67,6 +67,9 @@ is-published() {
             set -e
 
             test -n "${manifest}"
+            if test -z "${published_platforms}"; then
+                return 1
+            fi
             test "${published_platforms}" -eq "${platform_amount}"
         done
     done


### PR DESCRIPTION
## Allow container image 2.391 to publish

Build script is failing to publish with repeated messages that the test $x -eq $y is not evaluating an integer expression.

The $x in the expression is an empty string because 2.391 has not been published.  If the empty string, then the function can return immediately without any further tests.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Raised a help desk ticket to track the issue https://github.com/jenkins-infra/helpdesk/issues/3390