### PR TITLE
Add a Security Policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,7 +350,7 @@ If you wish to contribute fixes to this repository, please refer to the [dedicat
 
 # Security
 
-For information related to the security of the Docker image, please refer to the [dedicated documentation](README.md).
+For information related to the security of this Docker image, please refer to the [dedicated documentation](SECURITY.md).
 
 # Questions?
 

--- a/README.md
+++ b/README.md
@@ -348,6 +348,10 @@ Then plugins will be upgraded if the version provided by the docker image is new
 
 If you wish to contribute fixes to this repository, please refer to the [dedicated documentation](HACKING.adoc).
 
+### Security
+
+For information related to the security of the Docker image, please refer to the [dedicated documentation](README.md).
+
 ## Questions?
 
 We're on Gitter, https://gitter.im/jenkinsci/docker

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+The Jenkins project takes security seriously.
+We make every possible effort to ensure users can adequately secure their automation infrastructure.
+
+## Docker Image Publication
+
+When an image is published, the latest image and the latest available packages are used.
+
+We rely on the base image provider for the security of the system libraries.
+
+## Reporting Security Vulnerabilities
+
+Before reporting a vulnerability, here are some instructions.
+
+If the finding is coming from a Software Composition Analysis (SCA) scanner:
+- The scan must have been done on the latest version of the image.
+- The package should have a fixed version provided in the base image that is not yet included in our image.
+
+If the finding is coming from a manual audit:
+- Please follow the process about [Reporting Security Vulnerabilities](https://jenkins.io/security/reporting/).
+
+We will reject reports coming from scanners without additional explanations.
+
+## Vulnerability Management
+
+Once the report is considered legit, a new image is published with the latest packages.
+In the case the adjustment has to be done in the building process (e.g. in the Dockerfile), the correction will be prioritized and applied as soon as possible.
+
+By default we do not plan to publish advisories for vulnerabilities at the Docker level. 
+There may be exceptions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -24,7 +24,7 @@ We will reject reports coming from scanners without additional explanations.
 
 ## Vulnerability Management
 
-Once the report is considered legit, a new image is published with the latest packages.
+Once the report is considered legitimate, a new image is published with the latest packages.
 In the case the adjustment has to be done in the building process (e.g. in the Dockerfile), the correction will be prioritized and applied as soon as possible.
 
 By default we do not plan to publish advisories for vulnerabilities at the Docker level. 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,24 +3,37 @@
 The Jenkins project takes security seriously.
 We make every possible effort to ensure users can adequately secure their automation infrastructure.
 
+You can find more information in the [general Security Policy](https://github.com/jenkinsci/.github/blob/master/SECURITY.md), this policy is specific to our Docker images.
+
 ## Docker Image Publication
 
 When an image is published, the latest image and the latest available packages are used.
 
 We rely on the base image provider for the security of the system libraries.
+The default base image is Debian but multiple other variants are proposed, that could potentially better fit your needs.
 
 ## Reporting Security Vulnerabilities
 
-Before reporting a vulnerability, here are some instructions.
+If you have identified a security vulnerability and would like to report it, please be aware of those requirements.
 
-If the finding is coming from a Software Composition Analysis (SCA) scanner:
+
+For findings from a **Software Composition Analysis (SCA) scanner report**, all of the following points must be satisfied:
 - The scan must have been done on the latest version of the image.
+Vulnerabilities are discovered in a continuous way, so it is expected that past releases could contain some.
 - The package should have a fixed version provided in the base image that is not yet included in our image.
+We rely on the base image provider to propose the corrections.
+- The correction should have existed at the time the image was created.
+Normally our update workflow ensures that the latest available versions are used.
 
-If the finding is coming from a manual audit:
-- Please follow the process about [Reporting Security Vulnerabilities](https://jenkins.io/security/reporting/).
+The objective is to reduce the number of reports we receive that are not relevant to the security of the project.
 
-We will reject reports coming from scanners without additional explanations.
+
+For findings from a **manual audit**, the report must contain either reproduction steps or a sufficiently well described proof to demonstrate the impact.
+
+
+Once the report is ready, please follow the process about [Reporting Security Vulnerabilities](https://jenkins.io/security/reporting/).
+
+We will reject reports that are not satisfying those requirements.
 
 ## Vulnerability Management
 


### PR DESCRIPTION
After some discussions with @dduportal, I would like to propose this addition to set expectations about the security management of the Docker images.

Depending on the outcome, this could be re-used in other Docker repositories (like docker-inbound-agent).

Also, a link to this document could be added to https://hub.docker.com/r/jenkins/jenkins to increase visibility.

Additional context for the discovery of the information. When you are on https://www.jenkins.io/download/, if you click on "Docker", you're redirected to https://hub.docker.com/r/jenkins/jenkins, which contains a link to the README.md of this repository.

If you think about a better place for this, please don't hesitate :-)

----

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [n/a] Link to relevant issues in GitHub or Jira
- [n/a] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

Required reviewers:
- @dduportal 

Some potentially interested reviewers:
- @daniel-beck 
- @MarkEWaite 
- @gounthar 
