### PR TITLE
Use JDK 11.0.19 and JDK 17.0.7

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk-alpine AS jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk-focal as jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.18_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM eclipse-temurin:11.0.18_10-jdk-windowsservercore-1809
+FROM eclipse-temurin:11.0.19_7-jdk-windowsservercore-1809
 # hadolint shell=powershell
 
 ARG user=jenkins

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.6_10-jdk-alpine AS jre-build
+FROM eclipse-temurin:17.0.7_7-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/17/debian/bullseye-slim/hotspot/Dockerfile
+++ b/17/debian/bullseye-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.6_10-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.7_7-jdk-focal as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.6_10-jdk-focal as jre-build
+FROM eclipse-temurin:17.0.7_7-jdk-focal as jre-build
 
 RUN jlink \
   --add-modules ALL-MODULE-PATH \

--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.6_10-jdk-centos7 as jre-build
+FROM eclipse-temurin:17.0.7_7-jdk-centos7 as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility


### PR DESCRIPTION
## Use JDK 11.0.19 and JDK 17.0.7

- Use JDK 11.0.19_7, not JDK 11.0.18_10
- Use JDK 17.0.7_7, not JDK 17.0.6_10

Released by the OpenJDK project April 2023.  Container images delivered by Eclipse Temurin.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
