### PR TITLE
Use Alma Linux 9 instead of Alma Linux 8

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @jenkinsci/team-docker-packaging
 */rhel/ubi*/ @olivergondza
-*/almalinux/almalinux8/ @saper
+*/almalinux/almalinux9/ @saper

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
 # AlmaLinux
 
 - package-ecosystem: docker
-  directory: "11/almalinux/almalinux8/hotspot"
+  directory: "11/almalinux/almalinux9/hotspot"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2

--- a/11/almalinux/almalinux9/hotspot/Dockerfile
+++ b/11/almalinux/almalinux9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.19_7-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.19_7-jdk-ubi9-minimal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/almalinux/almalinux9/hotspot/Dockerfile
+++ b/11/almalinux/almalinux9/hotspot/Dockerfile
@@ -9,7 +9,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM almalinux:8.7
+FROM almalinux:9.2-20230512
 
 ENV LANG C.UTF-8
 
@@ -66,10 +66,10 @@ RUN curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.356}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.401}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=1163c4554dc93439c5eef02b06a8d74f98ca920bbc012c2b8a089d414cfa8075
+ARG JENKINS_SHA=9f80ea9080c036a4bb7bd0d70a8863e13bdeea04bf7d6320d509bdcf888172b1
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -94,7 +94,7 @@ function "tag_lts" {
 # ---- targets ----
 
 target "almalinux_jdk11" {
-  dockerfile = "11/almalinux/almalinux8/hotspot/Dockerfile"
+  dockerfile = "11/almalinux/almalinux9/hotspot/Dockerfile"
   context = "."
   args = {
     JENKINS_VERSION = JENKINS_VERSION


### PR DESCRIPTION
## Use Alma Linux 9 instead of Alma Linux 8

Alma Linux 9.2 is the most recent Alma Linux release. It has a longer support life and is more likely to include important fixes.

Also incremented the default version of Jenkins that this script packages so that it matches with the next long term support baseline, 2.401.

### Testing done

Ran `make build-almalinux_jdk11` and `make test-almalinux_jdk11` and confirmed that build and test work as expected.  Since the UBI container image is already using UBI 9, this should be a safe change.

@saper I'd like a code review from you, since you're listed as CODEOWNER of the Alma Linux container image.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
