### PR TITLE
chore: add ksalerno as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 * @jenkinsci/team-docker-packaging
 */rhel/ubi*/ @olivergondza
 */almalinux/almalinux8/ @saper
+*/debian/bullseye/hotspot @ksalerno99
+*/rhel/ubi9/hotspot @ksalerno99


### PR DESCRIPTION
As per https://github.com/jenkinsci/docker/issues/1559#issuecomment-1453514549, @ksalerno99 stepped-in to help to add the `ppc64le` architecture on this image (and also Docker agents).

This PR adds as a (co-) code owner for the debian and ubi9 images for which he worked with.

Many thanks for the contributions and help!


@jenkinsci/team-docker-packaging I need your +1 here before merging.

Once merged, i'll take care of adding @ksalerno99 in the repository as contributor (and also @saper) to fix the "CODEOWNER" issues (ref. https://github.com/jenkinsci/docker/pull/1629#pullrequestreview-1426934543), and then propagate to `jenkinsci/docker-*agent` repositories as well.