### PR TITLE
Use JDK from UBI 9 in UBI 9 container

### DIFF
--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.7_7-jdk-centos7 as jre-build
+FROM eclipse-temurin:17.0.7_7-jdk-ubi9-minimal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility


### PR DESCRIPTION
## Use Eclipse Temurin from UBI 9 for ubi9 container

Eclipse Temurin centos7 image is not the best choice for UBI 9 container image.

### Testing done

Automated tests pass.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
