### PR TITLE
Avoid dependabot PR's changing Alma Linux major version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,6 +41,10 @@ updates:
   - slide
   labels:
   - dependencies
+  ignore:
+  # Ignore proposals to update to Alma Linux 9 or later
+  - dependency-name: "almalinux"
+    update-types: ["version-update:semver-major"]
 
 # CentOS Linux
 


### PR DESCRIPTION
## Prevent Alma Linux major version upgrade by dependabot

https://github.blog/changelog/2021-05-21-dependabot-version-updates-can-now-ignore-major-minor-patch-releases/ shows the technique to allow minor version pull requests but to not propose major version pull requests.

Avoid pull requests like:

* https://github.com/jenkinsci/docker/pull/1627
* https://github.com/MarkEWaite/docker-lfs/pull/148

<!-- Please describe your pull request here. -->

### Testing done

Technique works in https://github.com/jenkinsci/copyartifact-plugin/blob/8077a4bdf3f2623758c0c74fb4d856f1f67f38fe/.github/dependabot.yml#L17

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
