### PR TITLE
feat(centos): Uses Temurin's openJDK binary instead of the Docker image

### DIFF
--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -1,14 +1,3 @@
-FROM eclipse-temurin:11.0.19_7-jdk-centos7 as jre-build
-
-# Generate smaller java runtime without unneeded files
-# for now we include the full module path to maintain compatibility
-# while still saving space (approx 200mb from the full distribution)
-RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --no-man-pages \
-         --compress=2 \
-         --output /javaruntime
-
 FROM centos:centos7.9.2009
 
 RUN yum install -y \
@@ -19,7 +8,6 @@ RUN yum install -y \
     unzip \
     which \
   && yum clean all
-
 RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh -o /tmp/script.rpm.sh \
   && bash /tmp/script.rpm.sh \
   && rm -f /tmp/script.rpm.sh \
@@ -109,7 +97,51 @@ ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
-COPY --from=jre-build /javaruntime $JAVA_HOME
+ARG JAVA_VERSION 11.0.19+7
+ENV JAVA_VERSION $JAVA_VERSION
+
+RUN set -eux; \
+    ARCH="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')"; \
+    export JAVA_VERSION=$JAVA_VERSION; \
+    # Encode the Java version using sed because it's used in a URL \
+    ENCODED_JAVA_VERSION=$(echo $JAVA_VERSION | sed 's/+/%2B/g'); \
+    # Encode the Java version using sed because Temurin changed the '+' into '_' \
+    UNDERSCORED_JAVA_VERSION=$(echo "$JAVA_VERSION" | sed 's/\+/_/g'); \
+    case "${ARCH}" in \
+       aarch64|arm64) \
+         ESUM='0c7763a19b4af4ef5fbae831781b5184e988d6f131d264482399eeaf51b6e254'; \
+         BINARY_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${ENCODED_JAVA_VERSION}/OpenJDK11U-jdk_aarch64_linux_hotspot_${UNDERSCORED_JAVA_VERSION}.tar.gz"; \
+         ;; \
+       ppc64el|powerpc:common64) \
+         ESUM='1e3704c8e155f8f894953c2a6708a52e6f449bbf5a85450be6fbb2ec76581700'; \
+         BINARY_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${ENCODED_JAVA_VERSION}/OpenJDK11U-jdk_ppc64le_linux_hotspot_${UNDERSCORED_JAVA_VERSION}.tar.gz"; \
+         ;; \
+       amd64|i386:x86-64) \
+         ESUM='5f19fb28aea3e28fcc402b73ce72f62b602992d48769502effe81c52ca39a581'; \
+         BINARY_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${ENCODED_JAVA_VERSION}/OpenJDK11U-jdk_x64_linux_hotspot_${UNDERSCORED_JAVA_VERSION}.tar.gz"; \
+         ;; \
+       *) \
+         echo "Unsupported arch: ${ARCH}"; \
+         exit 1; \
+         ;; \
+    esac; \
+	  curl -L -o /tmp/openjdk.tar.gz "${BINARY_URL}"; \
+	  echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -; \
+	  mkdir -p "$JAVA_HOME"; \
+      mkdir -p "/tmp${JAVA_HOME}"; \
+	  tar --extract \
+	      --file /tmp/openjdk.tar.gz \
+	      --directory "/tmp$JAVA_HOME" \
+	      --strip-components 1 \
+	      --no-same-owner \
+	  ; \
+    rm -f /tmp/openjdk.tar.gz ${JAVA_HOME}/src.zip; \
+    rm -fr ${JAVA_HOME}; \
+    "/tmp/$JAVA_HOME/bin/jlink" \
+             --add-modules ALL-MODULE-PATH \
+             --no-man-pages \
+             --compress=2 \
+             --output ${JAVA_HOME}
 
 USER ${user}
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -73,6 +73,10 @@ variable "COMMIT_SHA" {
   default = ""
 }
 
+variable "JAVA_11_VERSION" {
+  default = "11.0.19+7"
+}
+
 # ----  user-defined functions ----
 
 # return a tag prefixed by the Jenkins version
@@ -163,6 +167,7 @@ target "centos7_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    JAVA_VERSION = JAVA_11_VERSION
   }
   tags = [
     tag(true, "centos7"),


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Following #1642, this draft PR proposes the download and build of the `x86-64` JRE for `Centos7` using `jlink`. The `JAVA_VERSION` has been defined in both `docker-bake.hcl` and `11/centos/centos7/hotspot/Dockerfile`.

The goal of this draft PR is to initiate a discussion regarding the advantages and disadvantages of using Temurin's binaries instead of relying on their Centos image, which can have a delay of up to 3 weeks. This delay becomes problematic when a CVE is detected.

I'm aware that we're only targeting x86_64, so we can simplify the code, and I also understand the need to find a better solution than using hardcoded checksums. This draft PR can serve as the basis for a `updatecli` task that tracks the Java 11 version provided by Temurin.

### Testing done

```bash
 make test-centos7_jdk11
WARNING: No blkio throttle.read_bps_device support
WARNING: No blkio throttle.write_bps_device support
WARNING: No blkio throttle.read_iops_device support
WARNING: No blkio throttle.write_iops_device support
git submodule update --init --recursive
mkdir -p target
WARNING: No blkio throttle.read_bps_device support
WARNING: No blkio throttle.write_bps_device support
WARNING: No blkio throttle.read_iops_device support
WARNING: No blkio throttle.write_iops_device support
+ make --silent show
+ jq -r .target | path(.. | select(.platforms[] | contains("linux/amd64"))?) | add
WARNING: No blkio throttle.read_bps_device support
WARNING: No blkio throttle.write_bps_device support
WARNING: No blkio throttle.read_iops_device support
WARNING: No blkio throttle.write_iops_device support
WARNING: No blkio throttle.read_bps_device support
WARNING: No blkio throttle.write_bps_device support
WARNING: No blkio throttle.read_iops_device support
WARNING: No blkio throttle.write_iops_device support
+ make --silent show
+ jq -r .target | path(.. | select(.platforms[] | contains("linux/amd64"))?) | add
+ docker buildx bake -f docker-bake.hcl --load --set *.platform=linux/amd64 centos7_jdk11
#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile: 30B 0.0s
#1 transferring dockerfile: 6.83kB 0.0s done
#1 DONE 0.1s

#2 [internal] load .dockerignore
#2 transferring context: 2B 0.1s done
#2 DONE 0.1s

#3 [internal] load metadata for docker.io/library/centos:centos7.9.2009
#3 DONE 0.7s

#4 [ 1/15] FROM docker.io/library/centos:centos7.9.2009@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4
#4 resolve docker.io/library/centos:centos7.9.2009@sha256:be65f488b7764ad3638f236b7b515b3678369a5124c47b8d32916d6487418ea4 0.0s done
#4 DONE 0.0s

#5 [internal] load build context
#5 transferring context: 177B 0.1s done
#5 DONE 0.1s

#6 [ 2/15] RUN yum install -y     curl     fontconfig     freetype     git     unzip     which   && yum clean all
#6 CACHED

#7 [ 4/15] RUN mkdir -p /var/jenkins_home   && chown 1000:1000 /var/jenkins_home   && groupadd -g 1000 jenkins   && useradd -N -d "/var/jenkins_home" -u 1000 -g 1000 -l -m -s /bin/bash jenkins
#7 CACHED

#8 [12/15] COPY jenkins-support /usr/local/bin/jenkins-support
#8 CACHED

#9 [14/15] COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
#9 CACHED

#10 [13/15] COPY jenkins.sh /usr/local/bin/jenkins.sh
#10 CACHED

#11 [11/15] RUN set -eux;     ARCH="$(objdump="$(command -v objdump)" && objdump --file-headers "$objdump" | awk -F '[:,]+[[:space:]]+' '$1 == "architecture" { print $2 }')";     export JAVA_VERSION=11.0.19+7;     ENCODED_JAVA_VERSION=$(echo 11.0.19+7 | sed 's/+/%2B/g');     UNDERSCORED_JAVA_VERSION=$(echo "11.0.19+7" | sed 's/\+/_/g');     case "${ARCH}" in        aarch64|arm64)          ESUM='0c7763a19b4af4ef5fbae831781b5184e988d6f131d264482399eeaf51b6e254';          BINARY_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${ENCODED_JAVA_VERSION}/OpenJDK11U-jdk_aarch64_linux_hotspot_${UNDERSCORED_JAVA_VERSION}.tar.gz";          ;;        ppc64el|powerpc:common64)          ESUM='1e3704c8e155f8f894953c2a6708a52e6f449bbf5a85450be6fbb2ec76581700';          BINARY_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${ENCODED_JAVA_VERSION}/OpenJDK11U-jdk_ppc64le_linux_hotspot_${UNDERSCORED_JAVA_VERSION}.tar.gz";          ;;        amd64|i386:x86-64)          ESUM='5f19fb28aea3e28fcc402b73ce72f62b602992d48769502effe81c52ca39a581';          BINARY_URL="https://github.com/adoptium/temurin11-binaries/releases/download/jdk-${ENCODED_JAVA_VERSION}/OpenJDK11U-jdk_x64_linux_hotspot_${UNDERSCORED_JAVA_VERSION}.tar.gz";          ;;        *)          echo "Unsupported arch: ${ARCH}";          exit 1;          ;;     esac;        curl -L -o /tmp/openjdk.tar.gz "${BINARY_URL}";   echo "${ESUM} */tmp/openjdk.tar.gz" | sha256sum -c -;    mkdir -p "/opt/java/openjdk";       mkdir -p "/tmp/opt/java/openjdk";           tar --extract               --file /tmp/openjdk.tar.gz         --directory "/tmp/opt/java/openjdk"             --strip-components 1            --no-same-owner     ;     rm -f /tmp/openjdk.tar.gz /opt/java/openjdk/src.zip;     rm -fr /opt/java/openjdk;     "/tmp//opt/java/openjdk/bin/jlink"              --add-modules ALL-MODULE-PATH              --no-man-pages              --compress=2
  --output /opt/java/openjdk
#11 CACHED

#12 [ 3/15] RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.rpm.sh -o /tmp/script.rpm.sh   && bash /tmp/script.rpm.sh   && rm -f /tmp/script.rpm.sh   && yum install -y     git-lfs   && yum clean all   && git lfs install
#12 CACHED

#13 [ 9/15] RUN chown -R jenkins "/var/jenkins_home" "/usr/share/jenkins/ref"
#13 CACHED

#14 [ 6/15] COPY tini_pub.gpg /var/jenkins_home/tini_pub.gpg
#14 CACHED

#15 [ 5/15] RUN mkdir -p /usr/share/jenkins/ref/init.groovy.d
#15 CACHED

#16 [ 7/15] RUN curl -fsSL "https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64" -o /sbin/tini   && curl -fsSL "https://github.com/krallin/tini/releases/download/v0.19.0/tini-static-amd64.asc" -o /sbin/tini.asc   && gpg --no-tty --import "/var/jenkins_home/tini_pub.gpg"   && gpg --verify /sbin/tini.asc   && rm -rf /sbin/tini.asc /root/.gnupg   && chmod +x /sbin/tini
#16 CACHED

#17 [10/15] RUN curl -fsSL https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/2.12.11/jenkins-plugin-manager-2.12.11.jar -o /opt/jenkins-plugin-manager.jar
#17 CACHED

#18 [ 8/15] RUN curl -fsSL https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/2.356/jenkins-war-2.356.war -o /usr/share/jenkins/jenkins.war   && echo "1163c4554dc93439c5eef02b06a8d74f98ca920bbc012c2b8a089d414cfa8075  /usr/share/jenkins/jenkins.war" >/tmp/jenkins_sha   && sha256sum -c --strict /tmp/jenkins_sha   && rm -f /tmp/jenkins_sha
#18 CACHED

#19 [15/15] COPY install-plugins.sh /usr/local/bin/install-plugins.sh
#19 CACHED

#20 exporting to docker image format
#20 exporting layers done
#20 exporting manifest sha256:c292509724adf13b185cdd13f0bea61ad7536e3b4531556eea31e7ae44324460 done
#20 exporting config sha256:aaa64e4e2e3766e734b8566b0d02017d8f29e6695603443bd4059fd66ee227db
#20 exporting config sha256:aaa64e4e2e3766e734b8566b0d02017d8f29e6695603443bd4059fd66ee227db done
#20 sending tarball
#20 sending tarball 5.4s done
#20 DONE 5.4s

#21 importing to docker
#21 DONE 0.2s
IMAGE=centos7_jdk11 bats/bin/bats /mnt/c/Support/users/jenkins/git/ci/docker/tests --jobs 24 | tee target/results-centos7_jdk11.tap
1..22
ok 1 [centos7_jdk11-functions] versionLT
ok 2 [centos7_jdk11-functions] permissions are propagated from override file
ok 3 [centos7_jdk11-plugins-cli] plugins are installed with jenkins-plugin-cli
ok 4 [centos7_jdk11-plugins-cli] plugins are installed with jenkins-plugin-cli with non-default REF
ok 5 [centos7_jdk11-plugins-cli] plugins are installed with jenkins-plugin-cli from a plugins file
ok 6 [centos7_jdk11-plugins-cli] plugins are getting upgraded but not downgraded
ok 7 [centos7_jdk11-plugins-cli] do not upgrade if plugin has been manually updated
ok 8 [centos7_jdk11-plugins-cli] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true
ok 9 [centos7_jdk11-plugins-cli] plugins are installed with jenkins-plugin-cli and no war
ok 10 [centos7_jdk11-plugins-cli] Use a custom jenkins.war
ok 11 [centos7_jdk11-plugins-cli] JAVA_OPTS environment variable is used with jenkins-plugin-cli
ok 12 [centos7_jdk11-runtime] test version in docker metadata
ok 13 [centos7_jdk11-runtime] test commit SHA in docker metadata is not empty
ok 14 [centos7_jdk11-runtime] test commit SHA in docker metadata
ok 15 [centos7_jdk11-runtime] test multiple JENKINS_OPTS
ok 16 [centos7_jdk11-runtime] test jenkins arguments
ok 17 [centos7_jdk11-runtime] timezones are handled correctly
ok 18 [centos7_jdk11-runtime] has utf-8 locale
ok 19 [centos7_jdk11-runtime] passes JAVA_OPTS as JVM options
ok 20 [centos7_jdk11-runtime] passes JENKINS_JAVA_OPTS as JVM options
ok 21 [centos7_jdk11-runtime] JENKINS_JAVA_OPTS overrides JAVA_OPTS
ok 22 [centos7_jdk11-runtime] ensure that 'ps' command is available
docker run --rm -v "/mnt/c/Support/users/jenkins/git/ci/docker":/usr/src/app -w /usr/src/app node:18-alpine \
        sh -c "npm install tap-xunit -g && cat target/results-centos7_jdk11.tap | tap-xunit --package='jenkinsci.docker.centos7_jdk11' > target/junit-results-centos7_jdk11.xml"

added 21 packages in 5s

1 package is looking for funding
  run `npm fund` for details
npm notice
npm notice New minor version of npm available! 9.5.1 -> 9.6.7
npm notice Changelog: <https://github.com/npm/cli/releases/tag/v9.6.7>
npm notice Run `npm install -g npm@9.6.7` to update!
npm notice
``` 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->
### Submitter checklist

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
