### PR TITLE
Improve release drafter configuration definition

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,15 +1,13 @@
 # https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 _extends: .github
-# We are using 3-digit LTS versioning here
-version-template: $MAJOR.$MINOR.$PATCH
-tag-template: jenkins-docker-packaging-$NEXT_PATCH_VERSION
-name-template: Jenkins Docker Image $NEXT_PATCH_VERSION
+# We are using 2-digit weekly versioning here
+version-template: $MAJOR.$MINOR
+tag-template: $NEXT_MINOR_VERSION
+name-template: $NEXT_MINOR_VERSION
 template: |
   <!-- Optional: add a release summary here -->
-  ## 📦 Jenkins Core updates  
-  
-  * Update to Jenkins $NEXT_PATCH_VERSION ([changelog](https://jenkins.io/changelog-stable/#v$NEXT_PATCH_VERSION)) 
-  
+  ## 📦 Jenkins Core updates
+
+  * Update to Jenkins $NEXT_MINOR_VERSION ([changelog](https://jenkins.io/changelog-stable/#v$NEXT_MINOR_VERSION))
+
   $CHANGES
-  
-  **NOTE:** This is an experimental changelog. See [this page](https://github.com/jenkinsci/docker/blob/master/CHANGELOG.md) for more info


### PR DESCRIPTION
## Improve release drafter configuration definition

Use weekly release format as the default for the releases.  LTS releases will need edits to provide them.  If we decide to create a separate branch for LTS releases, then the release drafter configuration on that branch could be adjusted to propose LTS version numbers.

### Testing done

Use a release drafter configuration that prefers weekly rather than LTS releases.

### Submitter checklist

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
