### PR TITLE
feat(alpine): Pin Alpine version to 3.18.0

### DIFF
--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,6 @@
-FROM eclipse-temurin:11.0.19_7-jdk-alpine AS jre-build
+ARG JAVA_VERSION="11.0.19_7"
+ARG ALPINE_TAG=3.18.0
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
@@ -11,7 +13,7 @@ RUN jlink \
          --compress=2 \
          --output /javaruntime
 
-FROM alpine:3.18.0
+FROM alpine:"${ALPINE_TAG}" AS build
 
 RUN apk add --no-cache \
     bash \

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,18 +1,28 @@
-FROM eclipse-temurin:17.0.7_7-jdk-alpine AS jre-build
+ARG JAVA_VERSION="17.0.7_7"
+ARG ALPINE_TAG=3.18.0
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
-RUN apk add --no-cache binutils \
-  && jlink \
-         --add-modules ALL-MODULE-PATH \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
+RUN if [ "$TARGETPLATFORM" != 'linux/arm/v7' ]; then \
+    case "$(jlink --version 2>&1)" in \
+      # jlink version 11 has less features than JDK17+
+      "11."*) strip_java_debug_flags="--strip-debug" ;; \
+      *) strip_java_debug_flags="--strip-java-debug-attributes" ;; \
+    esac; \
+    jlink \
+      --add-modules ALL-MODULE-PATH \
+      "$strip_java_debug_flags" \
+      --no-man-pages \
+      --no-header-files \
+      --compress=2 \
+      --output /javaruntime; \
+  else \
+    cp -r /opt/java/openjdk /javaruntime; \
+  fi
 
-FROM alpine:3.18.0
+FROM alpine:"${ALPINE_TAG}" AS build
 
 RUN apk add --no-cache \
     bash \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,6 +77,21 @@ variable "COMMIT_SHA" {
   default = ""
 }
 
+variable "ALPINE_FULL_TAG" {
+  default = "3.18.0"
+}
+
+variable "ALPINE_SHORT_TAG" {
+  default = regex_replace(ALPINE_FULL_TAG, "\\.\\d+$", "")
+}
+
+variable "JAVA11_VERSION" {
+  default = "11.0.19_7"
+}
+
+variable "JAVA17_VERSION" {
+  default = "17.0.7_7"
+}
 # ----  user-defined functions ----
 
 # return a tag prefixed by the Jenkins version
@@ -142,14 +157,17 @@ target "alpine_jdk11" {
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
     RELEASE_LINE = release_line()
+    ALPINE_TAG = ALPINE_FULL_TAG
+    JAVA_VERSION = JAVA11_VERSION
   }
   tags = [
     tag(true, "alpine"),
     tag_weekly(false, "alpine"),
     tag_weekly(false, "alpine-jdk11"),
+    tag_weekly(false, "alpine${ALPINE_SHORT_TAG}-jdk11"),
     tag_lts(false, "lts-alpine"),
     tag_lts(false, "lts-alpine-jdk11"),
-    tag_lts(true, "lts-alpine"),
+    tag_lts(true, "lts-alpine")
   ]
   platforms = ["linux/amd64"]
 }
@@ -163,10 +181,13 @@ target "alpine_jdk17" {
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
     RELEASE_LINE = release_line()
+    ALPINE_TAG = ALPINE_FULL_TAG
+    JAVA_VERSION = JAVA17_VERSION
   }
   tags = [
     tag(true, "alpine-jdk17"),
     tag_weekly(false, "alpine-jdk17"),
+    tag_weekly(false, "alpine${ALPINE_SHORT_TAG}-jdk17"),
     tag_lts(false, "lts-alpine-jdk17")
   ]
   platforms = ["linux/amd64"]


### PR DESCRIPTION
In the hope of using dependabot to keep Alpine up to date, I'm proposing to fix first of all the Alpine version we use, as well as the Java 11 and 17 versions we use for Alpine.
I've already done the same for [`ssh-agent`](https://github.com/jenkinsci/docker-ssh-agent/pull/252).

### Testing done

```bash
docker buildx bake alpine_jdk11 --load
``` 

and 

```bash
docker buildx bake alpine_jdk17 --load
``` 
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
