### PR TITLE
Update windows Dockerfile default jenkins version

### DIFF
--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -40,7 +40,7 @@ RUN New-Item -ItemType Directory -Force -Path C:/ProgramData/Jenkins/Reference/i
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.356}
+ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=1163c4554dc93439c5eef02b06a8d74f98ca920bbc012c2b8a089d414cfa8075


### PR DESCRIPTION
Update default jenkins version.

Based on https://github.com/jenkinsci/docker/issues/1490 the windows docker version is lagging behind.
The current version provided (2.356) gives the following issues: 
![image](https://github.com/jenkinsci/docker/assets/26790846/27040040-a797-4ed3-b189-93e0988c6560)

So this is a quick fix to resolve the vulnerabilities in the current issue, before any work is done to actually fix the build process.


### Testing done

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
