### PR TITLE
chore(updatecli): Fix the Debian manifest by removing the "bullseye-" prefix

### DIFF
--- a/updatecli/updatecli.d/bullseye.yaml
+++ b/updatecli/updatecli.d/bullseye.yaml
@@ -17,6 +17,8 @@ sources:
   bullseyeLatestVersion:
     kind: dockerimage
     name: "Get the latest Debian Bullseye Linux version"
+    transformers:
+      - trimprefix: "bullseye-"
     spec:
       image: "debian"
       tagFilter: "bullseye-*"
@@ -27,6 +29,8 @@ sources:
   bullseyeSlimLatestVersion:
     kind: dockerimage
     name: "Get the latest Debian Bullseye Linux version"
+    transformers:
+      - trimprefix: "bullseye-"
     spec:
       image: "debian"
       tagFilter: "bullseye-*"


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

I'm sorry for the obvious mistake I should have spotted before asking the review of #1658 .
This led to the erroneous PR #1661 .

### Testing done


```bash
updatecli diff --config updatecli/updatecli.d/bullseye.yaml --values updatecli/values.github-action.yaml


+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/bullseye.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



################################
# BUMP DEBIAN BULLSEYE VERSION #
################################


SOURCES
=======

bullseyeLatestVersion
---------------------

Searching for version matching pattern "bullseye-\\d+$"
✔ Docker Image Tag "bullseye-20230612" found matching pattern "bullseye-\\d+$"

bullseyeSlimLatestVersion
-------------------------

Searching for version matching pattern "bullseye-\\d+-slim$"
✔ Docker Image Tag "bullseye-20230612-slim" found matching pattern "bullseye-\\d+-slim$"


CONDITIONS:
===========

testDockerfileArgJDK11Slim
--------------------------
✔ Line "ARG BULLSEYE_TAG=\"20230612\"" found, matching the keyword "ARG" and the matcher "BULLSEYE_TAG".
✔ key map["keyword":"ARG" "matcher":"BULLSEYE_TAG"] found in Dockerfile "11/debian/bullseye-slim/hotspot/Dockerfile"

testDockerfileArgJDK17
----------------------
✔ Line "ARG BULLSEYE_TAG=\"20230612\"" found, matching the keyword "ARG" and the matcher "BULLSEYE_TAG".
✔ key map["keyword":"ARG" "matcher":"BULLSEYE_TAG"] found in Dockerfile "17/debian/bullseye/hotspot/Dockerfile"

testDockerfileArgJDK11
----------------------
✔ Line "ARG BULLSEYE_TAG=\"20230612\"" found, matching the keyword "ARG" and the matcher "BULLSEYE_TAG".
✔ key map["keyword":"ARG" "matcher":"BULLSEYE_TAG"] found in Dockerfile "11/debian/bullseye/hotspot/Dockerfile"

testVersionInBakeFile
---------------------
✔ Content of the file "docker-bake.hcl" matched the pattern "(.*BULLSEYE_TAG.*)"
✔ condition on file ["docker-bake.hcl"] passed

testDockerfileArgJDK17Slim
--------------------------
✔ Line "ARG BULLSEYE_TAG=\"20230612\"" found, matching the keyword "ARG" and the matcher "BULLSEYE_TAG".
✔ key map["keyword":"ARG" "matcher":"BULLSEYE_TAG"] found in Dockerfile "17/debian/bullseye-slim/hotspot/Dockerfile"


TARGETS
========

updateDockerfileJDK17Slim
-------------------------

**Dry Run enabled**

⚠ The line #2, matched by the keyword "ARG" and the matcher "BULLSEYE_TAG", is changed from "ARG BULLSEYE_TAG=\"20230612\"" to "ARG BULLSEYE_TAG=20230612".
⚠ - changed lines [2] of file "/tmp/updatecli/github/jenkinsci/docker/17/debian/bullseye-slim/hotspot/Dockerfile"

updateDockerfileJDK11Slim
-------------------------

**Dry Run enabled**

⚠ The line #2, matched by the keyword "ARG" and the matcher "BULLSEYE_TAG", is changed from "ARG BULLSEYE_TAG=\"20230612\"" to "ARG BULLSEYE_TAG=20230612".
⚠ - changed lines [2] of file "/tmp/updatecli/github/jenkinsci/docker/11/debian/bullseye-slim/hotspot/Dockerfile"

updateDockerfileJDK17
---------------------

**Dry Run enabled**

⚠ The line #2, matched by the keyword "ARG" and the matcher "BULLSEYE_TAG", is changed from "ARG BULLSEYE_TAG=\"20230612\"" to "ARG BULLSEYE_TAG=20230612".
⚠ - changed lines [2] of file "/tmp/updatecli/github/jenkinsci/docker/17/debian/bullseye/hotspot/Dockerfile"

updateDockerfileJDK11
---------------------

**Dry Run enabled**

⚠ The line #2, matched by the keyword "ARG" and the matcher "BULLSEYE_TAG", is changed from "ARG BULLSEYE_TAG=\"20230612\"" to "ARG BULLSEYE_TAG=20230612".
⚠ - changed lines [2] of file "/tmp/updatecli/github/jenkinsci/docker/11/debian/bullseye/hotspot/Dockerfile"

updateDockerBake
----------------

**Dry Run enabled**

✔ - all contents from 'file' and 'files' combined already up to date


ACTIONS
========

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

REPORTS:


⚠ Bump Debian Bullseye version:
        Source:
                ✔ [bullseyeLatestVersion] Get the latest Debian Bullseye Linux version
                ✔ [bullseyeSlimLatestVersion] Get the latest Debian Bullseye Linux version
        Condition:
                ✔ [testDockerfileArgJDK11] Does the Dockerfile have an ARG instruction for the Debian Bullseye Linux version?
                ✔ [testDockerfileArgJDK11Slim] Does the Dockerfile have an ARG instruction for the Debian Bullseye Linux version?
                ✔ [testDockerfileArgJDK17] Does the Dockerfile have an ARG instruction for the Debian Bullseye Linux version?
                ✔ [testDockerfileArgJDK17Slim] Does the Dockerfile have an ARG instruction for the Debian Bullseye Linux version?
                ✔ [testVersionInBakeFile] Does the bake file have variable BULLSEYE_TAG
        Target:
                ✔ [updateDockerBake] Update the value of the base image (ARG BULLSEYE_TAG) in the docker-bake.hcl
                ⚠ [updateDockerfileJDK11] Update the value of the base image (ARG BULLSEYE_TAG) in the Dockerfile
                ⚠ [updateDockerfileJDK11Slim] Update the value of the base image (ARG BULLSEYE_TAG) in the Dockerfile
                ⚠ [updateDockerfileJDK17] Update the value of the base image (ARG BULLSEYE_TAG) in the Dockerfile
                ⚠ [updateDockerfileJDK17Slim] Update the value of the base image (ARG BULLSEYE_TAG) in the Dockerfile


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
