### PR TITLE
Download from repo.jenkins-ci.org, not get.jenkins.io

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -72,11 +72,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -73,11 +73,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/11/centos/centos7/hotspot/Dockerfile
+++ b/11/centos/centos7/hotspot/Dockerfile
@@ -81,11 +81,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/11/debian/bullseye-slim/hotspot/Dockerfile
+++ b/11/debian/bullseye-slim/hotspot/Dockerfile
@@ -78,11 +78,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/11/debian/bullseye/hotspot/Dockerfile
+++ b/11/debian/bullseye/hotspot/Dockerfile
@@ -76,11 +76,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, usually either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -74,11 +74,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -45,11 +45,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -82,11 +82,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/17/debian/bullseye-slim/hotspot/Dockerfile
+++ b/17/debian/bullseye-slim/hotspot/Dockerfile
@@ -78,11 +78,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/17/debian/bullseye/hotspot/Dockerfile
+++ b/17/debian/bullseye/hotspot/Dockerfile
@@ -76,11 +76,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -73,11 +73,8 @@ ENV JENKINS_VERSION ${JENKINS_VERSION:-2.410}
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45
 
-# Download directory, either `war` for weekly or `war-stable` for LTS
-ARG RELEASE_LINE
-
-# Can be used to customize jenkins.war download location
-ARG JENKINS_URL=https://get.jenkins.io/${RELEASE_LINE}/${JENKINS_VERSION}/jenkins.war
+# Can be used to customize where jenkins.war get downloaded from
+ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war
 
 # could use ADD but this one does not check Last-Modified header neither does it allow to control checksum
 # see https://github.com/docker/docker/issues/8331

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -41,10 +41,6 @@ group "linux-ppc64le" {
 
 # ---- variables ----
 
-variable "RELEASE_LINE" {
-  default = "war"
-}
-
 variable "JENKINS_VERSION" {
   default = "2.356"
 }
@@ -123,16 +119,6 @@ function "tag_lts" {
   result =  equal(LATEST_LTS, "true") ? tag(prepend_jenkins_version, tag) : ""
 }
 
-# return release line based on Jenkins version
-function "release_line" {
-  # If there is more than one sequence of digits with a trailing literal '.', this is LTS
-  # 2.407 has only one sequence of digits with a trailing literal '.'
-  # 2.401.1 has two sequences of digits with a trailing literal '.'
-  # https://developer.hashicorp.com/terraform/language/functions/regexall describes the technique
-  params = []
-  result = length(regexall("[0-9]+[.]", JENKINS_VERSION)) < 2 ? "war" : "war-stable"
-}
-
 # ---- targets ----
 
 target "almalinux_jdk11" {
@@ -143,7 +129,6 @@ target "almalinux_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
   }
   tags = [
     tag(true, "almalinux"),
@@ -161,7 +146,6 @@ target "alpine_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
     ALPINE_TAG = ALPINE_FULL_TAG
     JAVA_VERSION = JAVA11_VERSION
   }
@@ -185,7 +169,6 @@ target "alpine_jdk17" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
     ALPINE_TAG = ALPINE_FULL_TAG
     JAVA_VERSION = JAVA17_VERSION
   }
@@ -206,7 +189,6 @@ target "centos7_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
   }
   tags = [
     tag(true, "centos7"),
@@ -227,7 +209,6 @@ target "debian_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
     JAVA_VERSION = JAVA11_VERSION
     BULLSEYE_TAG = BULLSEYE_TAG
   }
@@ -253,7 +234,6 @@ target "debian_jdk17" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
     JAVA_VERSION = JAVA17_VERSION
     BULLSEYE_TAG = BULLSEYE_TAG
   }
@@ -275,7 +255,6 @@ target "debian_slim_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
     JAVA_VERSION = JAVA11_VERSION
     BULLSEYE_TAG = BULLSEYE_TAG
   }
@@ -298,7 +277,6 @@ target "debian_slim_jdk17" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
     JAVA_VERSION = JAVA17_VERSION
     BULLSEYE_TAG = BULLSEYE_TAG
   }
@@ -318,7 +296,6 @@ target "rhel_ubi8_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
   }
   tags = [
     tag(true, "rhel-ubi8-jdk11"),
@@ -337,7 +314,6 @@ target "rhel_ubi9_jdk17" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    RELEASE_LINE = release_line()
   }
   tags = [
     tag(true, "rhel-ubi9-jdk17"),

--- a/make.ps1
+++ b/make.ps1
@@ -19,20 +19,6 @@ if(![String]::IsNullOrWhiteSpace($env:DOCKERHUB_ORGANISATION)) {
     $Organization = $env:DOCKERHUB_ORGANISATION
 }
 
-# Set RELEASE_LINE to either `war` for weekly or `war-stable` for LTS
-if(-not [System.String]::IsNullOrWhiteSpace($JenkinsVersion)) {
-    if([regex]::Matches($JenkinsVersion, "[0-9]+[.]").count -lt 2) {
-        # Building the weekly version
-        $AdditionalArgs = $AdditionalArgs + ' --build-arg RELEASE_LINE=war'
-    } else {
-        # Building the LTS version
-        $AdditionalArgs = $AdditionalArgs + ' --build-arg RELEASE_LINE=war-stable'
-    }
-} else {
-    # Building the weekly version
-    $AdditionalArgs = $AdditionalArgs + ' --build-arg RELEASE_LINE=war'
-} 
-
 # this is the jdk version that will be used for the 'bare tag' images, e.g., jdk11-windowsservercore-1809 -> windowsserver-1809
 $defaultBuild = '11'
 $defaultJvm = 'hotspot'

--- a/tests/test_helpers.psm1
+++ b/tests/test_helpers.psm1
@@ -113,15 +113,9 @@ function Build-Docker {
     $FOLDER = $FOLDER.Trim()
 
     if(-not [System.String]::IsNullOrWhiteSpace($env:JENKINS_VERSION)) {
-        if([regex]::Matches($env:JENKINS_VERSION, "[0-9]+[.]").count -lt 2) {
-            # Building the weekly version
-            return (Run-Program 'docker.exe' "build --build-arg JENKINS_VERSION=$env:JENKINS_VERSION --build-arg JENKINS_SHA=$env:JENKINS_SHA --build-arg RELEASE_LINE=war $args $FOLDER")
-        } else {
-            # Building the LTS version
-            return (Run-Program 'docker.exe' "build --build-arg JENKINS_VERSION=$env:JENKINS_VERSION --build-arg JENKINS_SHA=$env:JENKINS_SHA --build-arg RELEASE_LINE=war-stable $args $FOLDER")
-        }
+        return (Run-Program 'docker.exe' "build --build-arg JENKINS_VERSION=$env:JENKINS_VERSION --build-arg JENKINS_SHA=$env:JENKINS_SHA $args $FOLDER")
     } 
-    return (Run-Program 'docker.exe' "build --build-arg RELEASE_LINE=war $args $FOLDER")
+    return (Run-Program 'docker.exe' "build $args $FOLDER")
 }
 
 function Build-DockerChild($tag, $dir) {


### PR DESCRIPTION
## Download from repo.jenkins-ci.org, not get.jenkins.io

The parallel build processes are much better served if the container images can be created as soon as a release is published to the official repository, repo.jenkins-ci.org, instead of waiting for the image to be available on the mirrors.  The bandwidth used for container image creation is small and the benefits of parallel creation of container images are great.

Fixes https://github.com/jenkinsci/docker/issues/1671

Reverts PR https://github.com/jenkinsci/docker/pull/1648

Commits reverted include:

* a9f4d3126ecd - Provide RELEASE_LINE in all Windows test paths
* 3dfbe262cfd1 - Add RELEASE_LINE always in make.ps1
* 4a9dbf1f7f77 - Set RELEASE_LINE in Windows make.ps1
* a7b2df536759 - Limit RELEASE_LINE to use at build time
* 81e26f5d1af7 - Calculate RELEASE_LINE inside docker-bake.hcl
* 6f74cba3e589 - Export the RELEASE_LINE just like others
* 9b014edf320a - Identify release line based on Jenkins version
* d41891c6da16 - Use RELEASE_LINE instead of DOWNLOAD_DIR
* 7e57eb817225 - Include DOWNLOAD_DIR in build scripts

### Testing done

`make build-alpine_jdk11 && make test-alpine_jdk11` passes on my Debian Linux system

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
