### PR TITLE
Fix tests by using a newer default Jenkins version

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -42,11 +42,11 @@ group "linux-ppc64le" {
 # ---- variables ----
 
 variable "JENKINS_VERSION" {
-  default = "2.356"
+  default = "2.410"
 }
 
 variable "JENKINS_SHA" {
-  default = "1163c4554dc93439c5eef02b06a8d74f98ca920bbc012c2b8a089d414cfa8075"
+  default = "20e3436e1c05f1fa8c441d7fb41f2a797604194fd9f8e774acb74d47b6187e45"
 }
 
 variable "REGISTRY" {


### PR DESCRIPTION
## Fix tests by using a newer default Jenkins version

Tests fail now because one or more of the tested plugins require Jenkins 2.387.3 or newer.  Testing with Jenkins 2.356 is not as valuable as testing with a consistent version in all the locations.

Since 2.410 is used elsewhere in the file, let's use it as the default in docker-bake.hcl as well.

### Testing done

Confirmed I can duplicate the test failures locally with the commands:

```
make list
make build-almalinux_jdk11
make test-almalinux_jdk11
```

Confirmed that with this change the test failures are resolved:

```
make list
make build-almalinux_jdk11
make test-almalinux_jdk11
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
