### PR TITLE
chore(dependencies): Modernize Temurin image imports

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.20_8-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.20_8-jdk-jammy as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/debian/bookworm-slim/hotspot/Dockerfile
+++ b/11/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_VERSION="11.0.20_8"
 ARG BOOKWORM_TAG=20230904
-FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal as jre-build
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/debian/bookworm/hotspot/Dockerfile
+++ b/11/debian/bookworm/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_VERSION="11.0.20_8"
 ARG BOOKWORM_TAG=20230904
-FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal as jre-build
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.20.1_1-jdk-centos7 as jre-build
+FROM eclipse-temurin:11.0.20_8-jdk-jammy as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/17/debian/bookworm-slim/hotspot/Dockerfile
+++ b/17/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_VERSION="17.0.8_7"
 ARG BOOKWORM_TAG=20230904
-FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal as jre-build
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \
          --add-modules ALL-MODULE-PATH \

--- a/17/debian/bookworm/hotspot/Dockerfile
+++ b/17/debian/bookworm/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG JAVA_VERSION="17.0.8_7"
 ARG BOOKWORM_TAG=20230904
-FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-focal as jre-build
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \
   --add-modules ALL-MODULE-PATH \


### PR DESCRIPTION
In today's Platform SIG meeting, @MarkEWaite responded to a comment I had written about the changelogs for the latest container images. Specifically, there was an update to the Centos7 Temurin image.

During the meeting, he clarified that we were still using a Temurin Centos7 image as the JDK binary base for some of our images, even though they don't run on Centos7.

So, I decided to take the initiative to remove references to Centos7 wherever possible and proceeded with the switch to Jammy instead of Focal in other places..

By the way, I don't get why [Dependabot](https://github.com/jenkinsci/docker/blob/master/.github/dependabot.yml#L142) hasn't updated [the `FROM` for `ubi8`](https://github.com/jenkinsci/docker/pull/1700/files#diff-0683004823fea71706896965544e63b342031ceb9ab47dc9ea71ff2baf4782edL1) yet.

### Testing done

```bash
make build-almalinux_jdk11
make build-rhel_ubi8_jdk11
make build-debian_jdk11
make build-debian_slim_jdk11
make build-debian_jdk17
make build-debian_slim_jdk17
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
