### PR TITLE
feat(platforms): Adds s390x, ppc64le and armv7 architectures

### DIFF
--- a/21/debian/bookworm-slim/hotspot/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/Dockerfile
@@ -19,11 +19,17 @@ RUN set -x; apt-get update \
 
 ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
 
-RUN jlink \
-  --add-modules ALL-MODULE-PATH \
-  --no-man-pages \
-  --compress=zip-6 \
-  --output /javaruntime
+RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
+      jlink \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --compress=zip-6 \
+        --output /javaruntime; \
+    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
+    # Because jlink fails with the error "jmods: Value too large for defined data type" error.
+    else  \
+      cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+    fi
 
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim
 

--- a/21/debian/bookworm-slim/hotspot/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
-ARG BOOKWORM_TAG=20230725
+ARG BOOKWORM_TAG=20230904
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
-ARG BUILD_NUMBER=34
+ARG BUILD_NUMBER=35
 ARG JAVA_VERSION=21+${BUILD_NUMBER}
 ARG TARGETPLATFORM
 
@@ -12,7 +12,7 @@ RUN set -x; apt-get update \
     jq \
     wget \
   && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | jq "@uri" -jRr) \
-  && CONVERTED_ARCH=$(arch | sed 's/x86_64/x64/') \
+  && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
   && wget --quiet https://github.com/adoptium/temurin21-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"-ea-beta/OpenJDK21U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_ea_21-0-"${BUILD_NUMBER}".tar.gz -O /tmp/jdk.tar.gz \
   && tar -xzf /tmp/jdk.tar.gz -C /opt/ \
   && rm -f /tmp/jdk.tar.gz

--- a/21/debian/bookworm/hotspot/Dockerfile
+++ b/21/debian/bookworm/hotspot/Dockerfile
@@ -19,11 +19,17 @@ RUN set -x; apt-get update \
 
 ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
 
-RUN jlink \
-  --add-modules ALL-MODULE-PATH \
-  --no-man-pages \
-  --compress=zip-6 \
-  --output /javaruntime
+RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
+      jlink \
+        --add-modules ALL-MODULE-PATH \
+        --no-man-pages \
+        --compress=zip-6 \
+        --output /javaruntime; \
+    # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
+    # Because jlink fails with the error "jmods: Value too large for defined data type" error.
+    else  \
+      cp -r "/opt/jdk-${JAVA_VERSION}" /javaruntime; \
+    fi
 
 FROM debian:bookworm-"${BOOKWORM_TAG}"
 

--- a/21/debian/bookworm/hotspot/Dockerfile
+++ b/21/debian/bookworm/hotspot/Dockerfile
@@ -1,6 +1,6 @@
-ARG BOOKWORM_TAG=20230725
+ARG BOOKWORM_TAG=20230904
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
-ARG BUILD_NUMBER=34
+ARG BUILD_NUMBER=35
 ARG JAVA_VERSION=21+${BUILD_NUMBER}
 ARG TARGETPLATFORM
 
@@ -12,7 +12,7 @@ RUN set -x; apt-get update \
     jq \
     wget \
   && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | jq "@uri" -jRr) \
-  && CONVERTED_ARCH=$(arch | sed 's/x86_64/x64/') \
+  && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
   && wget --quiet https://github.com/adoptium/temurin21-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"-ea-beta/OpenJDK21U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_ea_21-0-"${BUILD_NUMBER}".tar.gz -O /tmp/jdk.tar.gz \
   && tar -xzf /tmp/jdk.tar.gz -C /opt/ \
   && rm -f /tmp/jdk.tar.gz

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -298,7 +298,7 @@ target "debian_jdk21" {
     tag_lts(false, "lts-jdk21-preview"),
     tag_lts(true, "lts-jdk21-preview")
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x", "linux/arm/v7"]
 }
 
 target "debian_slim_jdk11" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -358,7 +358,7 @@ target "debian_slim_jdk21" {
     tag_weekly(false, "slim-jdk21-preview"),
     tag_lts(false, "lts-slim-jdk21-preview"),
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x", "linux/arm/v7"]
 }
 
 target "rhel_ubi8_jdk11" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -298,7 +298,7 @@ target "debian_jdk21" {
     tag_lts(false, "lts-jdk21-preview"),
     tag_lts(true, "lts-jdk21-preview")
   ]
-  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 }
 
 target "debian_slim_jdk11" {
@@ -358,7 +358,7 @@ target "debian_slim_jdk21" {
     tag_weekly(false, "slim-jdk21-preview"),
     tag_lts(false, "lts-slim-jdk21-preview"),
   ]
-  platforms = ["linux/amd64", "linux/arm64"]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le", "linux/s390x"]
 }
 
 target "rhel_ubi8_jdk11" {


### PR DESCRIPTION
After discussing with @ksalerno99 yesterday during the [Platform SIG meeting](https://www.jenkins.io/sigs/platform/), I considered that adding support for a few platforms for JDK21 would be beneficial.

I then propose to add `"linux/s390x"`, `"linux/ppc64le"` and `"linux/arm/v7"` as new target platforms for our JDK21 preview images.

I have also updated the `bookworm` tag and the JDK build number, as they are not yet tracked with updatecli.

### Testing done

```bash
docker buildx bake --file docker-bake.hcl debian_slim_jdk21
docker buildx bake --file docker-bake.hcl debian_jdk21
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- ~~Link to relevant pull requests, esp. upstream and downstream changes~~
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
