### PR TITLE
Use Java 11.0.20.1 instead of 11.0.20

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11.0.20_8-jdk-jammy as jre-build
+FROM eclipse-temurin:11.0.20.1_1-jdk-jammy as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="11.0.20_8"
+ARG JAVA_VERSION="11.0.20.1_1"
 ARG ALPINE_TAG=3.18.3
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 

--- a/11/debian/bookworm-slim/hotspot/Dockerfile
+++ b/11/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="11.0.20_8"
+ARG JAVA_VERSION="11.0.20.1_1"
 ARG BOOKWORM_TAG=20230904
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/11/debian/bookworm/hotspot/Dockerfile
+++ b/11/debian/bookworm/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="11.0.20_8"
+ARG JAVA_VERSION="11.0.20.1_1"
 ARG BOOKWORM_TAG=20230904
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-FROM eclipse-temurin:11.0.20_8-jdk-windowsservercore-1809
+FROM eclipse-temurin:11.0.20.1_1-jdk-windowsservercore-1809
 # hadolint shell=powershell
 
 ARG user=jenkins

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -89,7 +89,7 @@ variable "ALPINE_SHORT_TAG" {
 }
 
 variable "JAVA11_VERSION" {
-  default = "11.0.20_8"
+  default = "11.0.20.1_1"
 }
 
 variable "JAVA17_VERSION" {


### PR DESCRIPTION
## Use Java 11.0.20.1 instead of 11.0.20

- chore(deps): bump eclipse-temurin in /11/almalinux/almalinux8/hotspot
- Use Java 11.0.20.1_1, not 11.0.20_8

Includes 

### Testing done

Automated tests run successfully (with `make run`) on my Ubuntu 22.04 computer with latest Docker Desktop installed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
