### PR TITLE
Use JDK 17.0.8.1 instead of 17.0.8

### DIFF
--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="17.0.8_7"
+ARG JAVA_VERSION="17.0.8.1_1"
 ARG ALPINE_TAG=3.18.3
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 

--- a/17/debian/bookworm-slim/hotspot/Dockerfile
+++ b/17/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="17.0.8_7"
+ARG JAVA_VERSION="17.0.8.1_1"
 ARG BOOKWORM_TAG=20230904
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/17/debian/bookworm/hotspot/Dockerfile
+++ b/17/debian/bookworm/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION="17.0.8_7"
+ARG JAVA_VERSION="17.0.8.1_1"
 ARG BOOKWORM_TAG=20230904
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -93,7 +93,7 @@ variable "JAVA11_VERSION" {
 }
 
 variable "JAVA17_VERSION" {
-  default = "17.0.8_7"
+  default = "17.0.8.1_1"
 }
 
 # not passed through currently as inconsistent versions are published (2023-08-14)


### PR DESCRIPTION
## Use JDK 17.0.8.1 instead of 17.0.8

Use the most recent patch release of Java 17.0.8

### Testing done

Automated tests pass on Ubuntu 22.04 with latest Docker Desktop.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
