### PR TITLE
chore(dependencies): Dependabot monitors GitHub Actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -185,3 +185,12 @@ updates:
   - slide
   labels:
   - dependencies
+
+# GitHub actions
+
+- package-ecosystem: "github-actions"
+  target-branch: master
+  directory: "/"
+  schedule:
+    # Check for updates to GitHub Actions every week
+    interval: "weekly"


### PR DESCRIPTION
As I was trying my luck with PR #1711 , I saw the [log file](https://github.com/jenkinsci/docker/actions/runs/6220181363/job/16879674677?pr=1711#step:4:239) for the updatecli GitHub action saying:

> ERROR: something went wrong in target "setJDK17VersionDockerBake" : "⚠ Don't support resource kind: hcl"

It looks like we're not using the latest `updatecli` GitHub action.
That's because `dependabot` does not yet monitor our GitHub actions.

I just added a section for GitHub actions in `dependabot.yml`.

### Testing done

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
