### PR TITLE
fix(jdk11): Alma and Rhel shouldn't use a Jammy image as the JDK source.

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,13 +1,23 @@
-FROM eclipse-temurin:11.0.20.1_1-jdk-jammy as jre-build
+ARG JAVA_VERSION=11.0.20.1_1
+FROM almalinux:8.8 as jre-build
+ARG JAVA_VERSION
 
-# Generate smaller java runtime without unneeded files
-# for now we include the full module path to maintain compatibility
-# while still saving space (approx 200mb from the full distribution)
-RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --no-man-pages \
-         --compress=2 \
-         --output /javaruntime
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -x \
+  && dnf -y upgrade-minimal --security \
+  && dnf install -y ca-certificates jq wget \
+  && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | awk -F'.' '{print $1}') \
+  && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | tr '_' '+' | jq "@uri" -jRr) \
+  && JAVA_VERSION_FILENAME=$(echo $JAVA_VERSION | tr '_' '+') \
+  && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
+  && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_"${JAVA_VERSION}".tar.gz -O /tmp/jdk.tar.gz \
+  && mkdir -p /opt/jdk-${JAVA_VERSION_FILENAME} \
+  && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-${JAVA_VERSION_FILENAME} --strip-components=1 \
+  && rm -f /tmp/jdk.tar.gz \
+  && export PATH=/opt/jdk-${JAVA_VERSION_FILENAME}/bin:$PATH \
+  && jlink --add-modules ALL-MODULE-PATH --no-man-pages --compress=2 --output /javaruntime \
+  && dnf clean all
 
 FROM almalinux:8.8
 

--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -7,15 +7,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
   && dnf -y upgrade-minimal --security \
   && dnf install -y ca-certificates jq wget \
-  && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | awk -F'.' '{print $1}') \
+  && JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION" | awk -F'.' '{print $1}') \
   && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | tr '_' '+' | jq "@uri" -jRr) \
-  && JAVA_VERSION_FILENAME=$(echo $JAVA_VERSION | tr '_' '+') \
+  && JAVA_VERSION_FILENAME=$(echo "$JAVA_VERSION" | tr '_' '+') \
   && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
   && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_"${JAVA_VERSION}".tar.gz -O /tmp/jdk.tar.gz \
-  && mkdir -p /opt/jdk-${JAVA_VERSION_FILENAME} \
-  && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-${JAVA_VERSION_FILENAME} --strip-components=1 \
+  && mkdir -p /opt/jdk-"${JAVA_VERSION_FILENAME}" \
+  && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-"${JAVA_VERSION_FILENAME}" --strip-components=1 \
   && rm -f /tmp/jdk.tar.gz \
-  && export PATH=/opt/jdk-${JAVA_VERSION_FILENAME}/bin:$PATH \
+  && export PATH=/opt/jdk-"${JAVA_VERSION_FILENAME}"/bin:$PATH \
   && jlink --add-modules ALL-MODULE-PATH --no-man-pages --compress=2 --output /javaruntime \
   && dnf clean all
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,13 +1,23 @@
-FROM eclipse-temurin:11.0.20.1_1-jdk-jammy as jre-build
+ARG JAVA_VERSION=11.0.20.1_1
+FROM registry.access.redhat.com/ubi8/ubi:8.8-1032.1692772289 as jre-build
+ARG JAVA_VERSION
 
-# Generate smaller java runtime without unneeded files
-# for now we include the full module path to maintain compatibility
-# while still saving space (approx 200mb from the full distribution)
-RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --no-man-pages \
-         --compress=2 \
-         --output /javaruntime
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN set -x \
+  && dnf -y upgrade-minimal --security \
+  && dnf install -y ca-certificates jq wget \
+  && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | awk -F'.' '{print $1}') \
+  && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | tr '_' '+' | jq "@uri" -jRr) \
+  && JAVA_VERSION_FILENAME=$(echo $JAVA_VERSION | tr '_' '+') \
+  && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
+  && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_"${JAVA_VERSION}".tar.gz -O /tmp/jdk.tar.gz \
+  && mkdir -p /opt/jdk-${JAVA_VERSION_FILENAME} \
+  && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-${JAVA_VERSION_FILENAME} --strip-components=1 \
+  && rm -f /tmp/jdk.tar.gz \
+  && export PATH=/opt/jdk-${JAVA_VERSION_FILENAME}/bin:$PATH \
+  && jlink --add-modules ALL-MODULE-PATH --no-man-pages --compress=2 --output /javaruntime \
+  && dnf clean all
 
 FROM registry.access.redhat.com/ubi8/ubi:8.8-1032.1692772289
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -7,15 +7,15 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN set -x \
   && dnf -y upgrade-minimal --security \
   && dnf install -y ca-certificates jq wget \
-  && JAVA_MAJOR_VERSION=$(echo $JAVA_VERSION | awk -F'.' '{print $1}') \
+  && JAVA_MAJOR_VERSION=$(echo "$JAVA_VERSION" | awk -F'.' '{print $1}') \
   && JAVA_VERSION_ENCODED=$(echo "$JAVA_VERSION" | tr '_' '+' | jq "@uri" -jRr) \
-  && JAVA_VERSION_FILENAME=$(echo $JAVA_VERSION | tr '_' '+') \
+  && JAVA_VERSION_FILENAME=$(echo "$JAVA_VERSION" | tr '_' '+') \
   && CONVERTED_ARCH=$(arch | sed -e 's/x86_64/x64/' -e 's/armv7l/arm/') \
   && wget --quiet https://github.com/adoptium/temurin"${JAVA_MAJOR_VERSION}"-binaries/releases/download/jdk-"${JAVA_VERSION_ENCODED}"/OpenJDK"${JAVA_MAJOR_VERSION}"U-jdk_"${CONVERTED_ARCH}"_linux_hotspot_"${JAVA_VERSION}".tar.gz -O /tmp/jdk.tar.gz \
-  && mkdir -p /opt/jdk-${JAVA_VERSION_FILENAME} \
-  && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-${JAVA_VERSION_FILENAME} --strip-components=1 \
+  && mkdir -p /opt/jdk-"${JAVA_VERSION_FILENAME}" \
+  && tar -xzf /tmp/jdk.tar.gz -C /opt/jdk-"${JAVA_VERSION_FILENAME}" --strip-components=1 \
   && rm -f /tmp/jdk.tar.gz \
-  && export PATH=/opt/jdk-${JAVA_VERSION_FILENAME}/bin:$PATH \
+  && export PATH=/opt/jdk-"${JAVA_VERSION_FILENAME}"/bin:$PATH \
   && jlink --add-modules ALL-MODULE-PATH --no-man-pages --compress=2 --output /javaruntime \
   && dnf clean all
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -142,6 +142,7 @@ target "almalinux_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    JAVA_VERSION = JAVA11_VERSION
   }
   tags = [
     tag(true, "almalinux"),
@@ -369,6 +370,7 @@ target "rhel_ubi8_jdk11" {
     JENKINS_SHA = JENKINS_SHA
     COMMIT_SHA = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    JAVA_VERSION = JAVA11_VERSION
   }
   tags = [
     tag(true, "rhel-ubi8-jdk11"),


### PR DESCRIPTION
@dduportal [commented](https://github.com/jenkinsci/docker/pull/1700#issuecomment-1723051290) on PR #1700 and suggested that we refrain from using Jammy as the source for Rhel and Alma Linux images (even if that works for us).

> Note: the UBI8 and Almalinux should not have a Temurin from an Ubuntu/Debian but from a RH-Linux-like base instead

I don't believe it's advisable to reintroduce CentOS 7, even if Temurin still [provides it](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=centos7), as its active support ended 3 years ago, and its security support will end in 9 months.

Temurin [supplies images for ubi9](https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=ubi) but not for ubi8.

I don't feel like doing a direct revert then.
Damiens's proposal (if I understood it correctly) was to use the same mechanism as @timja did for JDK21. This involves using the same Alma Linux/RHEL image for both the JRE build stage and the final image. Then, fetching the Temurin JDK binaries directly from the repository and utilizing `jlink` to ensure it functions with the current image while reducing its size.

### Testing done

```bash
docker buildx bake --file docker-bake.hcl almalinux_jdk11
docker buildx bake --file docker-bake.hcl rhel_ubi8_jdk11
```

### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
