### PR TITLE
chore(dependencies): Preliminary work to integrate updatecli. Uses a JAVA_VERSION arg for Windows and RHEL 9.

### DIFF
--- a/11/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/11/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -1,5 +1,6 @@
 # escape=`
-FROM eclipse-temurin:11.0.20.1_1-jdk-windowsservercore-1809
+ARG JAVA_VERSION=11.0.20.1_1
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-windowsservercore-1809
 # hadolint shell=powershell
 
 ARG user=jenkins

--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,5 @@
-FROM eclipse-temurin:17.0.8.1_1-jdk-ubi9-minimal as jre-build
+ARG JAVA_VERSION=17.0.8.1_1
+FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-ubi9-minimal as jre-build
 
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility


### PR DESCRIPTION
As Damien noted [here](https://github.com/jenkinsci/docker/pull/1720#issuecomment-1732624795) and [there](https://github.com/jenkinsci/docker/pull/1711#pullrequestreview-1640947559), I forgot to add an `ARG` instruction in the Windows and RHEL9 Dockerfiles in PR #1710 . 😊 

[It was done](https://github.com/jenkinsci/docker/pull/1711/files#diff-2a69f081ba192d08536c4ce27308de21931caedf22e474bd7d8118070d152a21R1) in #1711 though. 🤷 

I have not been rigorous enough on this set of PRs. 😊 
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- ~~Link to relevant issues in GitHub or Jira~~
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- ~~Ensure you have provided tests - that demonstrates feature works or fixes the issue~~