### PR TITLE
chore(updatecli): update jdk21 manifests

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -29,11 +29,16 @@ function get_jdk_download_url() {
       ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
-    21*)
-      # JDK version (21+35-ea-beta)
+    21*-ea-beta)
+      # JDK preview version (21+35-ea-beta)
+      jdk_version="${jdk_version//-ea-beta}"
       ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35-ea-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_ea_21-0-35.tar.gz
       urlEncodedJDKVersion="${jdk_version//+/%2B}"
       echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${urlEncodedJDKVersion}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-$(echo ${jdk_version} | cut -d '+' -f 2 | cut -d '-' -f 1)"
+      return 0;;
+    21*)
+      ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version}/OpenJDK21U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
     *)
       echo "ERROR: unsupported JDK version (${jdk_version}).";
@@ -51,8 +56,10 @@ case "${1}" in
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   19.*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
-  21*+*)
+  21*+*-ea-beta)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
+  21*+*)
+    platforms=("x64_linux" "x64_windows" "aarch64_linux");;
   *)
     echo "ERROR: unsupported JDK version (${1}).";
     exit 1;;

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -30,11 +30,13 @@ function get_jdk_download_url() {
       echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
     21*-ea-beta)
-      # JDK preview version (21+35-ea-beta)
+      # JDK preview version (21+35-ea-beta, 21.0.1+12-ea-beta)
       jdk_version="${jdk_version//-ea-beta}"
       ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21%2B35-ea-beta/OpenJDK21U-jdk_aarch64_linux_hotspot_ea_21-0-35.tar.gz
-      urlEncodedJDKVersion="${jdk_version//+/%2B}"
-      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${urlEncodedJDKVersion}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-$(echo ${jdk_version} | cut -d '+' -f 2 | cut -d '-' -f 1)"
+      ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12-ea-beta/OpenJDK21U-jdk_x64_linux_hotspot_ea_21-0-1-12.tar.gz
+      dashJDKVersion="${jdk_version//+/-}"
+      completeDashJDKVersion="${dashJDKVersion//./-}"
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version//+/%2B}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-${completeDashJDKVersion}"
       return 0;;
     21*)
       ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names

--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -36,7 +36,7 @@ function get_jdk_download_url() {
       ##    https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.1%2B12-ea-beta/OpenJDK21U-jdk_x64_linux_hotspot_ea_21-0-1-12.tar.gz
       dashJDKVersion="${jdk_version//+/-}"
       completeDashJDKVersion="${dashJDKVersion//./-}"
-      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version//+/%2B}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_21-0-${completeDashJDKVersion}"
+      echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version//+/%2B}-ea-beta/OpenJDK21U-jdk_${platform}_hotspot_ea_${completeDashJDKVersion}"
       return 0;;
     21*)
       ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names

--- a/updatecli/updatecli.d/jdk21-preview.yaml
+++ b/updatecli/updatecli.d/jdk21-preview.yaml
@@ -1,5 +1,5 @@
 ---
-name: Bump JDK21 version for all Linux images
+name: Bump JDK21 preview version (EA) for all Linux images
 
 scms:
   default:
@@ -23,14 +23,14 @@ scms:
       branch: "main"
 
 sources:
-  getLatestJDK21EAVersion:
-    name: Get the latest Adoptium JDK21 version
+  getLatestJDK21PreviewVersion:
+    name: Get the latest Adoptium JDK21 preview version (EA)
     kind: gittag
     scmid: temurin21-binaries
     spec:
       versionfilter:
         kind: regex
-        pattern: "\\d$"
+        pattern: ".*-ea-.*"
     transformers:
       - trimprefix: "jdk-"
 
@@ -41,55 +41,37 @@ conditions:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
 
 targets:
-  setJDK21VersionDockerBake:
-    name: "Bump JDK21 version for Linux images in the docker-bake.hcl file"
+  setJDK21PreviewVersionDockerBake:
+    name: "Bump JDK21 preview version (EA) for Linux images in the docker-bake.hcl file"
     kind: hcl
     spec:
       file: docker-bake.hcl
-      path: variable.JAVA21_VERSION.default
+      path: variable.JAVA21_PREVIEW_VERSION.default
+    transformers:
+      - trimsuffix: "-ea-beta"
     scmid: default
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
-  setJDK21VersionAlpine:
-    name: "Bump JDK21 version for Linux images in the Alpine Linux Dockerfile"
+  setJDK21PreviewVersionDebian:
+    name: "Bump JDK21 preview version (EA) for Linux images in the Debian Dockerfile"
     kind: dockerfile
     spec:
-      file: 21/alpine/hotspot/Dockerfile
+      file: 21/debian/bookworm/hotspot/preview/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
     transformers:
-      - replacer:
-          from: "+"
-          to: "_"
-  setJDK21VersionDebian:
-    name: "Bump JDK21 version for Linux images in the Debian Dockerfile"
+      - trimsuffix: "-ea-beta"
+  setJDK21PreviewVersionDebianSlim:
+    name: "Bump JDK21 preview version (EA) for Linux images in the Debian Slim Dockerfile"
     kind: dockerfile
     spec:
-      file: 21/debian/bookworm/hotspot/Dockerfile
+      file: 21/debian/bookworm-slim/hotspot/preview/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
     transformers:
-      - replacer:
-          from: "+"
-          to: "_"
-  setJDK21VersionDebianSlim:
-    name: "Bump JDK21 version for Linux images in the Debian Slim Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "JAVA_VERSION"
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
-  setJDK21VersionRhel:
-    name: "Bump JDK21 version for Linux images in the Rhel Dockerfile"
+      - trimsuffix: "-ea-beta"
+  setJDK21PreviewVersionRhel:
+    name: "Bump JDK21 preview version (EA) for Linux images in the Rhel Dockerfile"
     kind: dockerfile
     spec:
       file: 21/rhel/ubi9/hotspot/Dockerfile
@@ -97,15 +79,13 @@ targets:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
     transformers:
-      - replacer:
-          from: "+"
-          to: "_"
+      - trimsuffix: "-ea-beta"
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK21 version to {{ source "getLatestJDK21EAVersion" }}
+    title: Bump JDK21 preview version (EA) to {{ source "getLatestJDK21PreviewVersion" }}
     spec:
       labels:
         - dependencies
-        - jdk21
+        - jdk21-preview

--- a/updatecli/updatecli.d/jdk21-preview.yaml
+++ b/updatecli/updatecli.d/jdk21-preview.yaml
@@ -33,12 +33,15 @@ sources:
         pattern: ".*-ea-.*"
     transformers:
       - trimprefix: "jdk-"
+      - trimsuffix: "-ea-beta"
 
 conditions:
   checkIfReleaseIsAvailable:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+    transformers:
+      - addsuffix: "-ea-beta"
 
 targets:
   setJDK21PreviewVersionDockerBake:
@@ -47,8 +50,6 @@ targets:
     spec:
       file: docker-bake.hcl
       path: variable.JAVA21_PREVIEW_VERSION.default
-    transformers:
-      - trimsuffix: "-ea-beta"
     scmid: default
   setJDK21PreviewVersionDebian:
     name: "Bump JDK21 preview version (EA) for Linux images in the Debian Dockerfile"
@@ -58,8 +59,6 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
-    transformers:
-      - trimsuffix: "-ea-beta"
   setJDK21PreviewVersionDebianSlim:
     name: "Bump JDK21 preview version (EA) for Linux images in the Debian Slim Dockerfile"
     kind: dockerfile
@@ -68,8 +67,6 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
-    transformers:
-      - trimsuffix: "-ea-beta"
   setJDK21PreviewVersionRhel:
     name: "Bump JDK21 preview version (EA) for Linux images in the Rhel Dockerfile"
     kind: dockerfile
@@ -78,8 +75,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
-    transformers:
-      - trimsuffix: "-ea-beta"
+
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -33,12 +33,19 @@ sources:
         pattern: "\\d$"
     transformers:
       - trimprefix: "jdk-"
+      - replacer:
+          from: "+"
+          to: "_"
 
 conditions:
   checkIfReleaseIsAvailable:
     kind: shell
     spec:
       command: bash ./updatecli/scripts/check-jdk.sh # source input value passed as argument
+    transformers:
+      - replacer:
+          from: "_"
+          to: "+"
 
 targets:
   setJDK21VersionDockerBake:
@@ -48,10 +55,6 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA21_VERSION.default
     scmid: default
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
   setJDK21VersionAlpine:
     name: "Bump JDK21 version for Linux images in the Alpine Linux Dockerfile"
     kind: dockerfile
@@ -60,10 +63,6 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
   setJDK21VersionDebian:
     name: "Bump JDK21 version for Linux images in the Debian Dockerfile"
     kind: dockerfile
@@ -72,10 +71,6 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
   setJDK21VersionDebianSlim:
     name: "Bump JDK21 version for Linux images in the Debian Slim Dockerfile"
     kind: dockerfile
@@ -84,10 +79,7 @@ targets:
       instruction:
         keyword: "ARG"
         matcher: "JAVA_VERSION"
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
+
 actions:
   default:
     kind: github/pullrequest

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -23,7 +23,7 @@ scms:
       branch: "main"
 
 sources:
-  getLatestJDK21EAVersion:
+  getLatestJDK21Version:
     name: Get the latest Adoptium JDK21 version
     kind: gittag
     scmid: temurin21-binaries
@@ -88,23 +88,11 @@ targets:
       - replacer:
           from: "+"
           to: "_"
-  setJDK21VersionRhel:
-    name: "Bump JDK21 version for Linux images in the Rhel Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/rhel/ubi9/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "JAVA_VERSION"
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump JDK21 version to {{ source "getLatestJDK21EAVersion" }}
+    title: Bump JDK21 version to {{ source "getLatestJDK21Version" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
This PR introduces a new updatecli manifest to distinctively track Eclipse Temuring preview images (EA versions), and fixes the existing one to use a "+" in the source version, but target a "_" version as used in the docker-bake file and in the Dockerfiles where official GA temurin images are already used.

Follow-up of #1738 

Closes #1739 

### Testing done

https://github.com/jenkinsci/docker/actions/runs/6587768678/job/17898685768

<details><summary>Logs extract:</summary>

```
########################################################
# BUMP JDK21 PREVIEW VERSION (EA) FOR ALL LINUX IMAGES #
########################################################


SOURCES
=======

getLatestJDK21PreviewVersion
----------------------------
Searching for version matching pattern ".*-ea-.*"
✔ Git tag "jdk-21.0.1+12-ea-beta" found matching pattern ".*-ea-.*" of kind "regex"


CONDITIONS:
===========

checkIfReleaseIsAvailable
-------------------------
The shell 🐚 command "/bin/sh /tmp/updatecli/bin/e178f4342f912570a17f53f2079a8f8a53445ca928f785971065f2d450977844.sh" ran successfully with the following output:
----
OK: all JDK URL for version=21.0.1+12-ea-beta are available.
----
✔ shell condition of type "console/output", passing


TARGETS
========

setJDK21PreviewVersionDockerBake
--------------------------------

**Dry Run enabled**

⚠ - path "variable.JAVA21_PREVIEW_VERSION.default" updated from "21+35" to "21.0.1+12" in file "docker-bake.hcl"

setJDK21PreviewVersionRhel
--------------------------

----
✔ shell condition of type "console/output", passing


TARGETS
========

setJDK21VersionDebianSlim
-------------------------

**Dry Run enabled**

✔ The line #2, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is correctly set to "ARG JAVA_VERSION=21_35".
✔ - 

setJDK21VersionDebian
---------------------

**Dry Run enabled**

✔ The line #2, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is correctly set to "ARG JAVA_VERSION=21_35".
✔ - 

setJDK21VersionAlpine
---------------------

**Dry Run enabled**

✔ The line #2, matched by the keyword "ARG" and the matcher "JAVA_VERSION", is correctly set to "ARG JAVA_VERSION=21_35".
✔ - 

setJDK21VersionDockerBake
-------------------------

**Dry Run enabled**

✔ - path "variable.JAVA21_VERSION.default" already set to "21_35", from file "docker-bake.hcl", 

```

</details>

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
