### PR TITLE
chore(Windows): log the list of tag(s) to be built

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -44,6 +44,9 @@ Get-ChildItem -Recurse -Include windows -Directory | ForEach-Object {
     }
 }
 
+Write-Host "= PREPARE: List of $Organization/$Repository images and tags to be processed:"
+ConvertTo-Json $builds
+
 if(![System.String]::IsNullOrWhiteSpace($Build) -and $builds.ContainsKey($Build)) {
     foreach($tag in $builds[$Build]['Tags']) {
         Write-Host "Building $Build => tag=$tag"


### PR DESCRIPTION
This PR adds to the build logs a listing of the Windows tags that will be built, like what has been added to https://github.com/jenkinsci/docker-agent and https://github.com/jenkinsci/docker-inbound-agent build process.

Output:
```
= PREPARE: List of jenkins4eval/jenkins images and tags to be processed:
 {
     "jdk11-hotspot-windowsservercore-2019":  {
                                                  "Folder":  "11\\windows\\windowsservercore-2019\\hotspot",
                                                  "Tags":  [
                                                               "jdk11-hotspot-windowsservercore-2019"
                                                           ]
                                              }
 }
```
### Testing done
`pwsh make.ps1` and CI build.
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
