### PR TITLE
fix: add additional tags for default Java images

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -191,6 +191,8 @@ target "alpine_jdk17" {
   }
   tags = [
     tag(true, "alpine"),
+    tag(true, "alpine-jdk17"),
+    tag(false, "alpine-jdk17"),
     tag_weekly(false, "alpine"),
     tag_weekly(false, "alpine-jdk17"),
     tag_weekly(false, "alpine${ALPINE_SHORT_TAG}-jdk17"),
@@ -277,6 +279,7 @@ target "debian_jdk17" {
   tags = [
     tag(true, ""),
     tag(true, "jdk17"),
+    tag(false, "jdk17"),
     tag_weekly(false, "latest"),
     tag_weekly(false, "latest-jdk17"),
     tag_weekly(false, "jdk17"),
@@ -364,6 +367,8 @@ target "debian_slim_jdk17" {
   }
   tags = [
     tag(true, "slim"),
+    tag(true, "slim-jdk17"),
+    tag(false, "slim-jdk17"),
     tag_weekly(false, "slim"),
     tag_weekly(false, "slim-jdk17"),
     tag_lts(false, "lts-slim"),


### PR DESCRIPTION
This PR adds additional tags containing the default Java version (currently: "-jdk17").

Fixes https://github.com/jenkinsci/docker/issues/1754

### Testing done

Ran `docker buildx bake --print -f docker-bake.hcl linux | jq -r '.target.[].tags[]' | sort` before and after, with and without `LATEST_WEEKLY=true` or `LATEST_LTS=true` to compare tags:

<details><summary>Comparisons:</summary>

## Default tags
### Before:
```
docker.io/jenkins/jenkins:2.419
docker.io/jenkins/jenkins:2.419-almalinux
docker.io/jenkins/jenkins:2.419-alpine
docker.io/jenkins/jenkins:2.419-alpine-jdk11
docker.io/jenkins/jenkins:2.419-alpine-jdk21
docker.io/jenkins/jenkins:2.419-centos7
docker.io/jenkins/jenkins:2.419-jdk11
docker.io/jenkins/jenkins:2.419-jdk21
docker.io/jenkins/jenkins:2.419-jdk21-preview
docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-slim
docker.io/jenkins/jenkins:2.419-slim-jdk11
docker.io/jenkins/jenkins:2.419-slim-jdk17
docker.io/jenkins/jenkins:2.419-slim-jdk21
docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
```
### After:
```
docker.io/jenkins/jenkins:2.419
docker.io/jenkins/jenkins:2.419-almalinux
docker.io/jenkins/jenkins:2.419-alpine
docker.io/jenkins/jenkins:2.419-alpine-jdk11
docker.io/jenkins/jenkins:2.419-alpine-jdk17
docker.io/jenkins/jenkins:2.419-alpine-jdk21
docker.io/jenkins/jenkins:2.419-centos7
docker.io/jenkins/jenkins:2.419-jdk11
docker.io/jenkins/jenkins:2.419-jdk17
docker.io/jenkins/jenkins:2.419-jdk21
docker.io/jenkins/jenkins:2.419-jdk21-preview
docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-slim
docker.io/jenkins/jenkins:2.419-slim-jdk11
docker.io/jenkins/jenkins:2.419-slim-jdk17
docker.io/jenkins/jenkins:2.419-slim-jdk21
docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
docker.io/jenkins/jenkins:alpine-jdk17
docker.io/jenkins/jenkins:jdk17
docker.io/jenkins/jenkins:slim-jdk17
```
### Diff with default tags before/after:
```diff
@@ -2,9 +2,11 @@
 docker.io/jenkins/jenkins:2.419-almalinux
 docker.io/jenkins/jenkins:2.419-alpine
 docker.io/jenkins/jenkins:2.419-alpine-jdk11
+docker.io/jenkins/jenkins:2.419-alpine-jdk17
 docker.io/jenkins/jenkins:2.419-alpine-jdk21
 docker.io/jenkins/jenkins:2.419-centos7
 docker.io/jenkins/jenkins:2.419-jdk11
+docker.io/jenkins/jenkins:2.419-jdk17
 docker.io/jenkins/jenkins:2.419-jdk21
 docker.io/jenkins/jenkins:2.419-jdk21-preview
 docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
@@ -15,3 +17,6 @@
 docker.io/jenkins/jenkins:2.419-slim-jdk17
 docker.io/jenkins/jenkins:2.419-slim-jdk21
 docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
+docker.io/jenkins/jenkins:alpine-jdk17
+docker.io/jenkins/jenkins:jdk17
+docker.io/jenkins/jenkins:slim-jdk17
```

## With `LATEST_WEEKLY=true`
### Before:
```
docker.io/jenkins/jenkins:2.419
docker.io/jenkins/jenkins:2.419-almalinux
docker.io/jenkins/jenkins:2.419-alpine
docker.io/jenkins/jenkins:2.419-alpine-jdk11
docker.io/jenkins/jenkins:2.419-alpine-jdk21
docker.io/jenkins/jenkins:2.419-centos7
docker.io/jenkins/jenkins:2.419-jdk11
docker.io/jenkins/jenkins:2.419-jdk17
docker.io/jenkins/jenkins:2.419-jdk21
docker.io/jenkins/jenkins:2.419-jdk21-preview
docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-slim
docker.io/jenkins/jenkins:2.419-slim-jdk11
docker.io/jenkins/jenkins:2.419-slim-jdk21
docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
docker.io/jenkins/jenkins:almalinux
docker.io/jenkins/jenkins:alpine
docker.io/jenkins/jenkins:alpine-jdk11
docker.io/jenkins/jenkins:alpine-jdk17
docker.io/jenkins/jenkins:alpine-jdk21
docker.io/jenkins/jenkins:alpine3.18-jdk11
docker.io/jenkins/jenkins:alpine3.18-jdk17
docker.io/jenkins/jenkins:alpine3.18-jdk21
docker.io/jenkins/jenkins:centos7
docker.io/jenkins/jenkins:centos7-jdk11
docker.io/jenkins/jenkins:jdk11
docker.io/jenkins/jenkins:jdk17
docker.io/jenkins/jenkins:jdk21
docker.io/jenkins/jenkins:jdk21-preview
docker.io/jenkins/jenkins:latest
docker.io/jenkins/jenkins:latest-jdk11
docker.io/jenkins/jenkins:latest-jdk17
docker.io/jenkins/jenkins:latest-jdk21
docker.io/jenkins/jenkins:latest-jdk21-preview
docker.io/jenkins/jenkins:rhel-ubi8-jdk11
docker.io/jenkins/jenkins:rhel-ubi9-jdk17
docker.io/jenkins/jenkins:rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:slim
docker.io/jenkins/jenkins:slim-jdk11
docker.io/jenkins/jenkins:slim-jdk17
docker.io/jenkins/jenkins:slim-jdk21
docker.io/jenkins/jenkins:slim-jdk21-preview
```
### After:
```
docker.io/jenkins/jenkins:2.419
docker.io/jenkins/jenkins:2.419-almalinux
docker.io/jenkins/jenkins:2.419-alpine
docker.io/jenkins/jenkins:2.419-alpine-jdk11
docker.io/jenkins/jenkins:2.419-alpine-jdk17
docker.io/jenkins/jenkins:2.419-alpine-jdk21
docker.io/jenkins/jenkins:2.419-centos7
docker.io/jenkins/jenkins:2.419-jdk11
docker.io/jenkins/jenkins:2.419-jdk17
docker.io/jenkins/jenkins:2.419-jdk21
docker.io/jenkins/jenkins:2.419-jdk21-preview
docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-slim
docker.io/jenkins/jenkins:2.419-slim-jdk11
docker.io/jenkins/jenkins:2.419-slim-jdk17
docker.io/jenkins/jenkins:2.419-slim-jdk21
docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
docker.io/jenkins/jenkins:almalinux
docker.io/jenkins/jenkins:alpine
docker.io/jenkins/jenkins:alpine-jdk11
docker.io/jenkins/jenkins:alpine-jdk17
docker.io/jenkins/jenkins:alpine-jdk21
docker.io/jenkins/jenkins:alpine3.18-jdk11
docker.io/jenkins/jenkins:alpine3.18-jdk17
docker.io/jenkins/jenkins:alpine3.18-jdk21
docker.io/jenkins/jenkins:centos7
docker.io/jenkins/jenkins:centos7-jdk11
docker.io/jenkins/jenkins:jdk11
docker.io/jenkins/jenkins:jdk17
docker.io/jenkins/jenkins:jdk21
docker.io/jenkins/jenkins:jdk21-preview
docker.io/jenkins/jenkins:latest
docker.io/jenkins/jenkins:latest-jdk11
docker.io/jenkins/jenkins:latest-jdk17
docker.io/jenkins/jenkins:latest-jdk21
docker.io/jenkins/jenkins:latest-jdk21-preview
docker.io/jenkins/jenkins:rhel-ubi8-jdk11
docker.io/jenkins/jenkins:rhel-ubi9-jdk17
docker.io/jenkins/jenkins:rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:slim
docker.io/jenkins/jenkins:slim-jdk11
docker.io/jenkins/jenkins:slim-jdk17
docker.io/jenkins/jenkins:slim-jdk21
docker.io/jenkins/jenkins:slim-jdk21-preview
```
### Diff with `LATEST_WEEKLY=true` before/after:
```diff
@@ -2,6 +2,7 @@
 docker.io/jenkins/jenkins:2.419-almalinux
 docker.io/jenkins/jenkins:2.419-alpine
 docker.io/jenkins/jenkins:2.419-alpine-jdk11
+docker.io/jenkins/jenkins:2.419-alpine-jdk17
 docker.io/jenkins/jenkins:2.419-alpine-jdk21
 docker.io/jenkins/jenkins:2.419-centos7
 docker.io/jenkins/jenkins:2.419-jdk11
@@ -13,6 +14,7 @@
 docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
 docker.io/jenkins/jenkins:2.419-slim
 docker.io/jenkins/jenkins:2.419-slim-jdk11
+docker.io/jenkins/jenkins:2.419-slim-jdk17
 docker.io/jenkins/jenkins:2.419-slim-jdk21
 docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
 docker.io/jenkins/jenkins:almalinux
```

## With `LATEST_LTS=true`:
### Before:
```
docker.io/jenkins/jenkins:2.419
docker.io/jenkins/jenkins:2.419-almalinux
docker.io/jenkins/jenkins:2.419-alpine
docker.io/jenkins/jenkins:2.419-alpine-jdk11
docker.io/jenkins/jenkins:2.419-alpine-jdk21
docker.io/jenkins/jenkins:2.419-centos7
docker.io/jenkins/jenkins:2.419-jdk11
docker.io/jenkins/jenkins:2.419-jdk17
docker.io/jenkins/jenkins:2.419-jdk21
docker.io/jenkins/jenkins:2.419-jdk21-preview
docker.io/jenkins/jenkins:2.419-lts
docker.io/jenkins/jenkins:2.419-lts-alpine
docker.io/jenkins/jenkins:2.419-lts-centos7
docker.io/jenkins/jenkins:2.419-lts-jdk11
docker.io/jenkins/jenkins:2.419-lts-jdk17
docker.io/jenkins/jenkins:2.419-lts-jdk21
docker.io/jenkins/jenkins:2.419-lts-jdk21-preview
docker.io/jenkins/jenkins:2.419-lts-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-lts-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-lts-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-lts-slim
docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-slim
docker.io/jenkins/jenkins:2.419-slim-jdk11
docker.io/jenkins/jenkins:2.419-slim-jdk21
docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
docker.io/jenkins/jenkins:lts
docker.io/jenkins/jenkins:lts-almalinux
docker.io/jenkins/jenkins:lts-alpine
docker.io/jenkins/jenkins:lts-alpine-jdk11
docker.io/jenkins/jenkins:lts-alpine-jdk17
docker.io/jenkins/jenkins:lts-alpine-jdk21
docker.io/jenkins/jenkins:lts-centos7
docker.io/jenkins/jenkins:lts-centos7-jdk11
docker.io/jenkins/jenkins:lts-jdk11
docker.io/jenkins/jenkins:lts-jdk17
docker.io/jenkins/jenkins:lts-jdk21
docker.io/jenkins/jenkins:lts-jdk21-preview
docker.io/jenkins/jenkins:lts-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:lts-slim
docker.io/jenkins/jenkins:lts-slim-jdk11
docker.io/jenkins/jenkins:lts-slim-jdk17
docker.io/jenkins/jenkins:lts-slim-jdk21
docker.io/jenkins/jenkins:lts-slim-jdk21-preview
```
### After:
```
docker.io/jenkins/jenkins:2.419
docker.io/jenkins/jenkins:2.419-almalinux
docker.io/jenkins/jenkins:2.419-alpine
docker.io/jenkins/jenkins:2.419-alpine-jdk11
docker.io/jenkins/jenkins:2.419-alpine-jdk17
docker.io/jenkins/jenkins:2.419-alpine-jdk21
docker.io/jenkins/jenkins:2.419-centos7
docker.io/jenkins/jenkins:2.419-jdk11
docker.io/jenkins/jenkins:2.419-jdk17
docker.io/jenkins/jenkins:2.419-jdk21
docker.io/jenkins/jenkins:2.419-jdk21-preview
docker.io/jenkins/jenkins:2.419-lts
docker.io/jenkins/jenkins:2.419-lts-alpine
docker.io/jenkins/jenkins:2.419-lts-centos7
docker.io/jenkins/jenkins:2.419-lts-jdk11
docker.io/jenkins/jenkins:2.419-lts-jdk17
docker.io/jenkins/jenkins:2.419-lts-jdk21
docker.io/jenkins/jenkins:2.419-lts-jdk21-preview
docker.io/jenkins/jenkins:2.419-lts-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-lts-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-lts-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-lts-slim
docker.io/jenkins/jenkins:2.419-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:2.419-slim
docker.io/jenkins/jenkins:2.419-slim-jdk11
docker.io/jenkins/jenkins:2.419-slim-jdk17
docker.io/jenkins/jenkins:2.419-slim-jdk21
docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
docker.io/jenkins/jenkins:alpine-jdk17
docker.io/jenkins/jenkins:jdk17
docker.io/jenkins/jenkins:lts
docker.io/jenkins/jenkins:lts-almalinux
docker.io/jenkins/jenkins:lts-alpine
docker.io/jenkins/jenkins:lts-alpine-jdk11
docker.io/jenkins/jenkins:lts-alpine-jdk17
docker.io/jenkins/jenkins:lts-alpine-jdk21
docker.io/jenkins/jenkins:lts-centos7
docker.io/jenkins/jenkins:lts-centos7-jdk11
docker.io/jenkins/jenkins:lts-jdk11
docker.io/jenkins/jenkins:lts-jdk17
docker.io/jenkins/jenkins:lts-jdk21
docker.io/jenkins/jenkins:lts-jdk21-preview
docker.io/jenkins/jenkins:lts-rhel-ubi8-jdk11
docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk21-preview
docker.io/jenkins/jenkins:lts-slim
docker.io/jenkins/jenkins:lts-slim-jdk11
docker.io/jenkins/jenkins:lts-slim-jdk17
docker.io/jenkins/jenkins:lts-slim-jdk21
docker.io/jenkins/jenkins:lts-slim-jdk21-preview
docker.io/jenkins/jenkins:slim-jdk17
```
### Diff with `LATEST_LTS=true` before/after:
```diff
@@ -2,6 +2,7 @@
 docker.io/jenkins/jenkins:2.419-almalinux
 docker.io/jenkins/jenkins:2.419-alpine
 docker.io/jenkins/jenkins:2.419-alpine-jdk11
+docker.io/jenkins/jenkins:2.419-alpine-jdk17
 docker.io/jenkins/jenkins:2.419-alpine-jdk21
 docker.io/jenkins/jenkins:2.419-centos7
 docker.io/jenkins/jenkins:2.419-jdk11
@@ -24,8 +25,11 @@
 docker.io/jenkins/jenkins:2.419-rhel-ubi9-jdk21-preview
 docker.io/jenkins/jenkins:2.419-slim
 docker.io/jenkins/jenkins:2.419-slim-jdk11
+docker.io/jenkins/jenkins:2.419-slim-jdk17
 docker.io/jenkins/jenkins:2.419-slim-jdk21
 docker.io/jenkins/jenkins:2.419-slim-jdk21-preview
+docker.io/jenkins/jenkins:alpine-jdk17
+docker.io/jenkins/jenkins:jdk17
 docker.io/jenkins/jenkins:lts
 docker.io/jenkins/jenkins:lts-almalinux
 docker.io/jenkins/jenkins:lts-alpine
@@ -46,3 +50,4 @@
 docker.io/jenkins/jenkins:lts-slim-jdk17
 docker.io/jenkins/jenkins:lts-slim-jdk21
 docker.io/jenkins/jenkins:lts-slim-jdk21-preview
+docker.io/jenkins/jenkins:slim-jdk17
```



<details>

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
