### PR TITLE
fixup: shortest jdk17 tags only for weekly releases

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -192,7 +192,6 @@ target "alpine_jdk17" {
   tags = [
     tag(true, "alpine"),
     tag(true, "alpine-jdk17"),
-    tag(false, "alpine-jdk17"),
     tag_weekly(false, "alpine"),
     tag_weekly(false, "alpine-jdk17"),
     tag_weekly(false, "alpine${ALPINE_SHORT_TAG}-jdk17"),
@@ -279,7 +278,6 @@ target "debian_jdk17" {
   tags = [
     tag(true, ""),
     tag(true, "jdk17"),
-    tag(false, "jdk17"),
     tag_weekly(false, "latest"),
     tag_weekly(false, "latest-jdk17"),
     tag_weekly(false, "jdk17"),
@@ -368,7 +366,6 @@ target "debian_slim_jdk17" {
   tags = [
     tag(true, "slim"),
     tag(true, "slim-jdk17"),
-    tag(false, "slim-jdk17"),
     tag_weekly(false, "slim"),
     tag_weekly(false, "slim-jdk17"),
     tag_lts(false, "lts-slim"),


### PR DESCRIPTION
As stated in https://github.com/jenkinsci/docker/pull/1756#pullrequestreview-1695048060,

> I would have expected `jenkins/jenkins:jdk17` to only be specified when `LATEST_WEEKLY=true`.
> 
> I don't think it's a problem blocking this PR because we only deploy latest weekly and latest LTS, but worth checking after.

This PR fixes tags to publish `jenkins:jdk17`, `jenkins:alpine-jdk17` and `jenkins:slim-jdk17` shortest tags only when `LATEST_WEEKLY` is true.

Fixup of #1756

Related: #1754 

### Testing done

Ran `docker buildx bake --print -f docker-bake.hcl linux | jq -r '.target.[].tags[]' | sort` before and after, with and without `LATEST_WEEKLY=true` or `LATEST_LTS=true` to compare tags.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
