### PR TITLE
chore(Windows): replace hardcoded directory separator in `make.ps1`

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -26,8 +26,8 @@ $builds = @{}
 
 Get-ChildItem -Recurse -Include windows -Directory | ForEach-Object {
     Get-ChildItem -Recurse -Directory -Path $_ | Where-Object { Test-Path (Join-Path $_.FullName "Dockerfile") } | ForEach-Object {
-        $dir = $_.FullName.Replace((Get-Location), "").TrimStart("\")
-        $items = $dir.Split("\")
+        $dir = $_.FullName.Replace((Get-Location), "").TrimStart([IO.Path]::DirectorySeparatorChar)
+        $items = $dir.Split([IO.Path]::DirectorySeparatorChar)
         $jdkVersion = $items[0]
         $baseImage = $items[2]
         $jvmType = $items[3]


### PR DESCRIPTION
This PR replaces the hardcoded directory separator `\` by the PowerShell normalized directory separator in the Windows build script `make1.ps1`, allowing to use and test this script on other OS than Windows.

Fixes https://github.com/jenkinsci/docker/issues/1763

### Testing done
With #910, on a Darwin OS machine:

#### Before
```console
pwsh make.ps1        
= PREPARE: List of jenkins4eval/jenkins images and tags to be processed:
{
  "jdk/11/windows/windowsservercore-2019/hotspot--": {
    "Folder": "/11/windows/windowsservercore-2019/hotspot",
    "Tags": [
      "jdk/11/windows/windowsservercore-2019/hotspot--"
    ]
  }
}
```

#### After
```console
pwsh make.ps1
= PREPARE: List of jenkins4eval/jenkins images and tags to be processed:
{
  "jdk11-hotspot-windowsservercore-2019": {
    "Folder": "11/windows/windowsservercore-2019/hotspot",
    "Tags": [
      "jdk11-hotspot-windowsservercore-2019"
    ]
  }
}
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
