### PR TITLE
Use Java 17.0.9_9

### DIFF
--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_TAG=3.18.4
-ARG JAVA_VERSION=17.0.8.1_1
+ARG JAVA_VERSION=17.0.9_9
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/17/debian/bookworm-slim/hotspot/Dockerfile
+++ b/17/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20231030
-ARG JAVA_VERSION=17.0.8.1_1
+ARG JAVA_VERSION=17.0.9_9
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \

--- a/17/debian/bookworm/hotspot/Dockerfile
+++ b/17/debian/bookworm/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20231030
-ARG JAVA_VERSION=17.0.8.1_1
+ARG JAVA_VERSION=17.0.9_9
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \

--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=17.0.8.1_1
+ARG JAVA_VERSION=17.0.9_9
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-ubi9-minimal as jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/17/windows/windowsservercore-2019/hotspot/Dockerfile
+++ b/17/windows/windowsservercore-2019/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 # escape=`
-ARG JAVA_VERSION=17.0.8.1_1
+ARG JAVA_VERSION=17.0.9_9
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-windowsservercore-1809
 # hadolint shell=powershell
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -94,7 +94,7 @@ variable "JAVA11_VERSION" {
 }
 
 variable "JAVA17_VERSION" {
-  default = "17.0.8.1_1"
+  default = "17.0.9_9"
 }
 
 # not passed through currently as inconsistent versions are published (2023-08-14)


### PR DESCRIPTION
## Use Java 17.0.9_9

Unclear why the automation did not detect that this upgrade is needed.  Maybe @gounthar is willing to investigate further?

Whether we update the automation or not, this is a good change because it uses the most recent patch release of Java 17.

### Testing done

Confirmed that `make test` passes and that the logfile from `make test` includes Java 17.0.9 in the output.  Also confirmed that the logfile does not include 17.0.8 in the output.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
