### PR TITLE
Use JDK 21.0.1+12, not 21+35

### DIFF
--- a/21/alpine/hotspot/Dockerfile
+++ b/21/alpine/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_TAG=3.18.4
-ARG JAVA_VERSION=21_35
+ARG JAVA_VERSION=21.0.1_12
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/21/debian/bookworm-slim/hotspot/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20231030
-ARG JAVA_VERSION=21_35
+ARG JAVA_VERSION=21.0.1_12
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \

--- a/21/debian/bookworm-slim/hotspot/preview/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/preview/Dockerfile
@@ -1,6 +1,6 @@
 ARG BOOKWORM_TAG=20231030
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
-ARG JAVA_VERSION=21+35
+ARG JAVA_VERSION=21.0.1_12
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/21/debian/bookworm/hotspot/Dockerfile
+++ b/21/debian/bookworm/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20231030
-ARG JAVA_VERSION=21_35
+ARG JAVA_VERSION=21.0.1_12
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \

--- a/21/debian/bookworm/hotspot/preview/Dockerfile
+++ b/21/debian/bookworm/hotspot/preview/Dockerfile
@@ -1,6 +1,6 @@
 ARG BOOKWORM_TAG=20231030
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
-ARG JAVA_VERSION=21+35
+ARG JAVA_VERSION=21.0.1_12
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/21/rhel/ubi9/hotspot/Dockerfile
+++ b/21/rhel/ubi9/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.2-722 as jre-build
-ARG JAVA_VERSION=21+35
+ARG JAVA_VERSION=21.0.1_12
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/21/rhel/ubi9/hotspot/Dockerfile
+++ b/21/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.2-722 as jre-build
+FROM registry.access.redhat.com/ubi9/ubi:9.3-1361 as jre-build
 ARG JAVA_VERSION=21.0.1_12
 ARG TARGETPLATFORM
 
@@ -28,7 +28,7 @@ RUN jlink \
   --compress=zip-6 \
   --output /javaruntime
 
-FROM registry.access.redhat.com/ubi9/ubi:9.2-722
+FROM registry.access.redhat.com/ubi9/ubi:9.3-1361
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
## Use JDK 21.0.1+12, not 21+35 for Java 21

Also updates to the most recent release of the Red Hat Enterprise Linux universal base image.

- Use JDK 21.0.1_12 instead of 21_35 - latest JDK 21 release
- Use ubi9:3-1361, not ubi9:2-722

### Testing done

Confirmed that `make test` passes for Java 21 and for other variants.

I've been using Java 21.0.1+12 on my Jenkins agents for several days without any issues.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
