### PR TITLE
chore(Windows): use Java 11.0.21_9

### DIFF
--- a/build-windows.yaml
+++ b/build-windows.yaml
@@ -7,7 +7,7 @@ services:
       args:
         COMMIT_SHA: ${COMMIT_SHA}
         JAVA_HOME: "C:/openjdk-11"
-        JAVA_VERSION: "11.0.20.1_1"
+        JAVA_VERSION: "11.0.21_9"
         JENKINS_SHA: ${JENKINS_SHA}
         JENKINS_VERSION: ${JENKINS_VERSION}
         TOOLS_WINDOWS_VERSION: ${TOOLS_WINDOWS_VERSION}


### PR DESCRIPTION
This PR manually sets the same Java version as the Linux images for Windows JDK11 image before the next Weekly and LTS release while the automation isn't fixed (WiP in #1781).

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Checked that the image exists on Docker Hub: https://hub.docker.com/layers/library/eclipse-temurin/11.0.21_9-jdk-windowsservercore/images/sha256-fbe694f025cf2999a7b0ea161197012c55d4bde2bca68e2321d1cc3a859d2c11?context=explore

The addition of CI build should be sufficient.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
