### PR TITLE
Add `JENKINS_PLUGIN_INFO` to the "Setting update centers" README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,8 @@ During the download, the script will use update centers defined by the following
   Default value: https://repo.jenkins-ci.org/incrementals
 - `JENKINS_UC_DOWNLOAD` - Download url of the Update Center.
   Default value: `$JENKINS_UC/download`
+- `JENKINS_PLUGIN_INFO` - Location of plugin information.
+  Default value: https://updates.jenkins.io/current/plugin-versions.json
 
 It is possible to override the environment variables in images.
 

--- a/README.md
+++ b/README.md
@@ -180,13 +180,13 @@ COPY --chown=jenkins:jenkins custom.groovy /usr/share/jenkins/ref/init.groovy.d/
 
 ## Preinstalling plugins
 
-### Install plugins script
+### Install plugins
 
-You can rely on the plugin manager CLI to pass a set of plugins to download with their dependencies. This tool will perform downloads from update centers, and internet access is required for the default update centers.
+You can rely on [the plugin manager CLI](https://github.com/jenkinsci/plugin-installation-manager-tool/) to pass a set of plugins to download with their dependencies. This tool will perform downloads from update centers, and internet access is required for the default update centers.
 
 ### Setting update centers
 
-During the download, the script will use update centers defined by the following environment variables:
+During the download, the CLI will use update centers defined by the following environment variables:
 
 - `JENKINS_UC` - Main update center.
   This update center may offer plugin versions depending on the Jenkins LTS Core versions.
@@ -205,7 +205,7 @@ During the download, the script will use update centers defined by the following
 
 It is possible to override the environment variables in images.
 
-:exclamation: Note that changing update center variables **will not** change the Update Center being used by Jenkins runtime.
+:exclamation: Note that changing update center variables **will not** change the Update Center being used by Jenkins runtime, it concerns only the plugin manager CLI.
 
 ### Installing Custom Plugins
 


### PR DESCRIPTION
While working on https://github.com/jenkins-infra/helpdesk/issues/2649 and testing an alternative Update Center with Jenkins controller container, I've noticed that in addition to  `JENKINS_UC` and  `JENKINS_UC_EXPERIMENTAL`, you have to set  `JENKINS_PLUGIN_INFO` too if you want everything downloaded from your custom Update Center with the plugin manager CLI.

This PR mentions it in the dedicated README section, and slightly updates some of its elements.

<details><summary>Plugin installation with only the two environment variables currently mentioned set to azure.updates.jenkins.io as custom UC, and updates.jenkins.io blackholed via /etc/hosts:</summary>

```console
$ docker run -it \
--env JENKINS_UC="https://azure.updates.jenkins.io" \
--env JENKINS_UC_EXPERIMENTAL="https://azure.updates.jenkins.io/experimental" \
jenkins/jenkins jenkins-plugin-cli --verbose -p ansicolor

No .txt or .yaml file containing list of plugins to be downloaded entered.
No directory to download plugins entered. Will use default of /usr/share/jenkins/ref/plugins
Using update center https://azure.updates.jenkins.io/update-center.json from JENKINS_UC environment variable
Using experimental update center https://azure.updates.jenkins.io/experimental/update-center.json from JENKINS_UC_EXPERIMENTAL environment variable
Using incrementals mirror https://repo.jenkins-ci.org/incrementals from JENKINS_INCREMENTALS_REPO_MIRROR environment variable
No CLI option or environment variable set for plugin info, using default of https://updates.jenkins.io/plugin-versions.json
No war entered. Will use default of /usr/share/jenkins/jenkins.war

Retrieving update center information
Created cache at: /var/jenkins_home/.cache/jenkins-plugin-management-cli
Update center URL: https://azure.updates.jenkins.io/update-center.json?version=2.432
Cache miss for: update-center-2.432
Downloaded update-center-2.432 from https://westeurope.cloudflare.jenkins.io/update-center.json (attempt 1 of 3)
Cache miss for: experimental-update-center-2.432
Downloaded experimental-update-center-2.432 from https://westeurope.cloudflare.jenkins.io/experimental/update-center.json (attempt 1 of 3)
Cache miss for: plugin-versions
Unable to retrieve JSON from https://updates.jenkins.io/plugin-versions.json: Connect to updates.jenkins.io:443 [updates.jenkins.io/127.0.0.1] failed: Connection refused
Unable to retrieve JSON from https://updates.jenkins.io/plugin-versions.json: Connect to updates.jenkins.io:443 [updates.jenkins.io/127.0.0.1] failed: Connection refused
io.jenkins.tools.pluginmanager.impl.UpdateCenterInfoRetrievalException: Error getting update center json
        at io.jenkins.tools.pluginmanager.impl.PluginManager.getJson(PluginManager.java:839)
        at io.jenkins.tools.pluginmanager.impl.PluginManager.getUCJson(PluginManager.java:871)
        at io.jenkins.tools.pluginmanager.impl.PluginManager.start(PluginManager.java:225)
        at io.jenkins.tools.pluginmanager.impl.PluginManager.start(PluginManager.java:189)
        at io.jenkins.tools.pluginmanager.cli.Main.main(Main.java:52)
Caused by: java.io.IOException: Unable to retrieve JSON from https://updates.jenkins.io/plugin-versions.json: Connect to updates.jenkins.io:443 [updates.jenkins.io/127.0.0.1] failed: Connection refused
        at io.jenkins.tools.pluginmanager.impl.PluginManager.getViaHttpWithResponseHandler(PluginManager.java:1374)
        at io.jenkins.tools.pluginmanager.impl.PluginManager.getJson(PluginManager.java:825)
        ... 4 more
Caused by: org.apache.http.conn.HttpHostConnectException: Connect to updates.jenkins.io:443 [updates.jenkins.io/127.0.0.1] failed: Connection refused
        at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:156)
        at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376)
        at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393)
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186)
        at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89)
        at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:72)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:221)
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:165)
        at io.jenkins.tools.pluginmanager.impl.PluginManager.getViaHttpWithResponseHandler(PluginManager.java:1366)
        ... 5 more
Caused by: java.net.ConnectException: Connection refused
        at java.base/sun.nio.ch.Net.connect0(Native Method)
        at java.base/sun.nio.ch.Net.connect(Net.java:579)
        at java.base/sun.nio.ch.Net.connect(Net.java:568)
        at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:593)
        at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
        at java.base/java.net.Socket.connect(Socket.java:633)
        at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket(SSLConnectionSocketFactory.java:368)
        at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:142)
        ... 16 more
Error getting update center json
```

</details>

<details><summary>Plugin installation with the three environment variables set to azure.updates.jenkins.io as custom UC:</summary>

```console
$ docker run -it \
--env JENKINS_UC="https://azure.updates.jenkins.io" \
--env JENKINS_UC_EXPERIMENTAL="https://azure.updates.jenkins.io/experimental" \
--env JENKINS_PLUGIN_INFO="https://azure.updates.jenkins.io/update-center.json" \
jenkins/jenkins jenkins-plugin-cli --verbose -p ansicolor

No .txt or .yaml file containing list of plugins to be downloaded entered.
No directory to download plugins entered. Will use default of /usr/share/jenkins/ref/plugins
Using update center https://azure.updates.jenkins.io/update-center.json from JENKINS_UC environment variable
Using experimental update center https://azure.updates.jenkins.io/experimental/update-center.json from JENKINS_UC_EXPERIMENTAL environment variable
Using incrementals mirror https://repo.jenkins-ci.org/incrementals from JENKINS_INCREMENTALS_REPO_MIRROR environment variable
Using plugin info https://azure.updates.jenkins.io/update-center.json from JENKINS_PLUGIN_INFO environment variable
No war entered. Will use default of /usr/share/jenkins/jenkins.war

Retrieving update center information
Created cache at: /var/jenkins_home/.cache/jenkins-plugin-management-cli
Update center URL: https://azure.updates.jenkins.io/update-center.json?version=2.432
Cache miss for: update-center-2.432
Downloaded update-center-2.432 from https://westeurope.cloudflare.jenkins.io/update-center.json (attempt 1 of 3)
Cache miss for: experimental-update-center-2.432
Downloaded experimental-update-center-2.432 from https://westeurope.cloudflare.jenkins.io/experimental/update-center.json (attempt 1 of 3)
Cache miss for: plugin-versions
Downloaded plugin-versions from https://westeurope.cloudflare.jenkins.io/update-center.json (attempt 1 of 3)
Couldn't find checksum for ansicolor at version: latest

ansicolor depends on: 
workflow-api 1215.v2b_ee3e1b_dd39
workflow-step-api 639.v6eca_cd8c04a_a_
Setting checksum for: ansicolor to bUHwcLjm/CLLqmHVugbg3zT6xyG6XvRVzBSN9wKUal8=
Setting checksum for: ansicolor to bUHwcLjm/CLLqmHVugbg3zT6xyG6XvRVzBSN9wKUal8=
Setting checksum for: ansicolor to bUHwcLjm/CLLqmHVugbg3zT6xyG6XvRVzBSN9wKUal8=
Will install new plugin ansicolor 1.0.4
Will use url: https://azure.updates.jenkins.io/download/plugins/ansicolor/1.0.4/ansicolor.hpi to download ansicolor plugin
Downloaded ansicolor from https://ftp.belnet.be/mirror/jenkins/plugins/ansicolor/1.0.4/ansicolor.hpi (attempt 1 of 3)
Downloaded and validated plugin ansicolor
Checksum valid for: ansicolor
Done
```

</details>


### Testing done
N/A
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
