### PR TITLE
Improve logging for common failure when using default config

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -4,6 +4,10 @@
 : "${JENKINS_HOME:="/var/jenkins_home"}"
 : "${COPY_REFERENCE_FILE_LOG:="${JENKINS_HOME}/copy_reference_file.log"}"
 : "${REF:="/usr/share/jenkins/ref"}"
+
+if ! [ -r "${JENKINS_HOME}" ] || ! [ -w "${JENKINS_HOME}" ]; then
+        echo "INSTALL WARNING: User: ${USER} missing rw permissions on JENKINS_HOME: ${JENKINS_HOME}"
+fi
 touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find "${REF}" \( -type f -o -type l \) -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +


### PR DESCRIPTION
- Improve user guidance for JENKINS_HOME permission issues by adding detailed warning message if USER lacks rw access
- Took me a few minutes to resolve this, and saw quite a few so threads of people running into the same issue
- installing the docker container onto unRaid led me into this error touch: cannot touch '/var/jenkins_home/copy_reference_file.log' Accompanied by the application failing to launch

### Testing done
Tested by validating logging for permission failure again as well as testing negative case where logging didnt appear with correct permissions

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
