### PR TITLE
Only run GitHub action from jenkinsci repositories

### DIFF
--- a/.github/workflows/sync-plugin-manager.yml
+++ b/.github/workflows/sync-plugin-manager.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'jenkinsci'
     steps:
       - name: Check out source code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Only run GitHub action from jenkinsci repositories

Avoid 'Run failed' mail messages from forks.  Inspired by https://github.com/jenkins-infra/jenkins.io/pull/6974 with special thanks to @NotMyFault.

### Testing done

No additional testing beyond the testing that is already done in the original pull request https://github.com/jenkins-infra/jenkins.io/pull/6974 and its use in forks of jenkins.io.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
```
