### PR TITLE
Use latest Java releases

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 FROM almalinux:8.9 as jre-build
-ARG JAVA_VERSION=11.0.21_9
+ARG JAVA_VERSION=11.0.22_7
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_TAG=3.19.0
-ARG JAVA_VERSION=11.0.21_9
+ARG JAVA_VERSION=11.0.22_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/11/debian/bookworm-slim/hotspot/Dockerfile
+++ b/11/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=11.0.21_9
+ARG JAVA_VERSION=11.0.22_7
 ARG BOOKWORM_TAG=20240110
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/11/debian/bookworm/hotspot/Dockerfile
+++ b/11/debian/bookworm/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=11.0.21_9
+ARG JAVA_VERSION=11.0.22_7
 ARG BOOKWORM_TAG=20240110
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.9-1107.1705420509 as jre-build
-ARG JAVA_VERSION=11.0.21_9
+ARG JAVA_VERSION=11.0.22_7
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_TAG=3.18.4
-ARG JAVA_VERSION=17.0.9_9
+ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/17/debian/bookworm-slim/hotspot/Dockerfile
+++ b/17/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20240110
-ARG JAVA_VERSION=17.0.9_9
+ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \

--- a/17/debian/bookworm/hotspot/Dockerfile
+++ b/17/debian/bookworm/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20240110
-ARG JAVA_VERSION=17.0.9_9
+ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN jlink \

--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG JAVA_VERSION=17.0.9_9
+ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-ubi9-minimal as jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/21/alpine/hotspot/Dockerfile
+++ b/21/alpine/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG ALPINE_TAG=3.19.0
-ARG JAVA_VERSION=21.0.1_12
+ARG JAVA_VERSION=21.0.2_13
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 
 # Generate smaller java runtime without unneeded files

--- a/21/debian/bookworm-slim/hotspot/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20240110
-ARG JAVA_VERSION=21.0.1_12
+ARG JAVA_VERSION=21.0.2_13
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \

--- a/21/debian/bookworm-slim/hotspot/preview/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/preview/Dockerfile
@@ -1,6 +1,6 @@
 ARG BOOKWORM_TAG=20240110
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
-ARG JAVA_VERSION=21.0.1_12
+ARG JAVA_VERSION=21.0.2_13
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/21/debian/bookworm/hotspot/Dockerfile
+++ b/21/debian/bookworm/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 ARG BOOKWORM_TAG=20240110
-ARG JAVA_VERSION=21.0.1_12
+ARG JAVA_VERSION=21.0.2_13
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
 RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \

--- a/21/debian/bookworm/hotspot/preview/Dockerfile
+++ b/21/debian/bookworm/hotspot/preview/Dockerfile
@@ -1,6 +1,6 @@
 ARG BOOKWORM_TAG=20240110
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
-ARG JAVA_VERSION=21.0.1_12
+ARG JAVA_VERSION=21.0.2_13
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/21/rhel/ubi9/hotspot/Dockerfile
+++ b/21/rhel/ubi9/hotspot/Dockerfile
@@ -1,5 +1,5 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1361 as jre-build
-ARG JAVA_VERSION=21.0.1_12
+ARG JAVA_VERSION=21.0.2_13
 ARG TARGETPLATFORM
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/build-windows.yaml
+++ b/build-windows.yaml
@@ -22,7 +22,7 @@ services:
       args:
         COMMIT_SHA: ${COMMIT_SHA}
         JAVA_HOME: "C:/openjdk-17"
-        JAVA_VERSION: "17.0.9_9"
+        JAVA_VERSION: "17.0.10_7"
         JENKINS_SHA: ${JENKINS_SHA}
         JENKINS_VERSION: ${JENKINS_VERSION}
         TOOLS_WINDOWS_VERSION: ${TOOLS_WINDOWS_VERSION}

--- a/build-windows.yaml
+++ b/build-windows.yaml
@@ -7,7 +7,7 @@ services:
       args:
         COMMIT_SHA: ${COMMIT_SHA}
         JAVA_HOME: "C:/openjdk-11"
-        JAVA_VERSION: "11.0.21_9"
+        JAVA_VERSION: "11.0.22_7"
         JENKINS_SHA: ${JENKINS_SHA}
         JENKINS_VERSION: ${JENKINS_VERSION}
         TOOLS_WINDOWS_VERSION: ${TOOLS_WINDOWS_VERSION}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -104,7 +104,7 @@ variable "JAVA21_PREVIEW_VERSION" {
 }
 
 variable "JAVA21_VERSION" {
-  default = "21.0.1_12"
+  default = "21.0.2_13"
 }
 
 variable "BOOKWORM_TAG" {

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -94,7 +94,7 @@ variable "JAVA11_VERSION" {
 }
 
 variable "JAVA17_VERSION" {
-  default = "17.0.9_9"
+  default = "17.0.10_7"
 }
 
 # not passed through currently as inconsistent versions are published (2023-08-14)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -90,7 +90,7 @@ variable "ALPINE_SHORT_TAG" {
 }
 
 variable "JAVA11_VERSION" {
-  default = "11.0.21_9"
+  default = "11.0.22_7"
 }
 
 variable "JAVA17_VERSION" {

--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -1,7 +1,7 @@
 # escape=`
 # hadolint shell=powershell
 
-ARG JAVA_VERSION=17.0.9_9
+ARG JAVA_VERSION=17.0.10_7
 ARG WINDOWS_VERSION=ltsc2019
 ARG TOOLS_WINDOWS_VERSION=1809
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-windowsservercore-"${TOOLS_WINDOWS_VERSION}" AS jdk-core


### PR DESCRIPTION
## Use latest Java versions

The updatecli scripts don't process partial updates and there are no early access beta releases available for 21.0.2 because all the releases are available for all the platforms.  A separate pull request will be filed to remove early access and preview, since they are no longer needed.

- Use Java 11.0.22, not 11.0.21
- Use JDK 17.0.10, not 17.0.9
- Use JDK 21.0.2, not 21.0.1

### Testing done

Confirmed the correct Java versions are included in the container images with commands like:

Ran `make build` and `make test` on my amd64 Debian machine with good results.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
