### PR TITLE
Use Alpine 3.19.1, no 3.18.4 for Java 17 container default

### DIFF
--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_TAG=3.18.4
+ARG ALPINE_TAG=3.19.1
 ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 


### PR DESCRIPTION
## Use Alpine 3.19.1, not 3.18.4 for Java 17 container default

This changes the default Alpine version to match with the default Alpine versions in other containers.  Since the Alpine version is an argument provided by `docker buildx bake`, the actual impact of this change is very low.  Alpine containers will continue to use the Alpine version defined in the docker-bake.hcl file.

### Testing done

Confirmed `docker run jenkins/jenkins:2.442-alpine-jdk17 cat /etc/os-release` with a locally built container image now reports VERSION_ID=3.19.1 instead of VERSION_ID=3.19.0 as it did for 2.440.  The Alpine version is an argument, so this inconsistency was not as much of an issue as I assumed it would be.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
