### PR TITLE
Remove install-plugins.sh from ubi9 Java 17 and Java 21

### DIFF
--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -113,9 +113,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/21/rhel/ubi9/hotspot/Dockerfile
+++ b/21/rhel/ubi9/hotspot/Dockerfile
@@ -131,9 +131,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \


### PR DESCRIPTION
## Remove install-plugins.sh from ubi9 Java 17 and Java 21

The install-plugins.sh stub is only included in Java 11 containers.  The stub announces to the user that it has been superseded by the plugin installation manager tool.  Since it is not included in the other Java 17 and Java 21 containers, let's remove it from the single Java 17 container and the single Java 21 container that include it.

### Testing done

Confirmed that the build process completes successfully after this change.

Confirmed that `docker run jenkins/jenkins:2.440-rhel-ubi9-jdk17 cat /usr/local/bin/install-plugins.sh` shows the content of the file before the change.

Confirmed that `docker run jenkins/jenkins:2.442-rhel-ubi9-jdk17 cat /usr/local/bin/install-plugins.sh` with a locally built container correctly reports that the file is not found.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
