### PR TITLE
Use consistent jlink args within Java versions

### DIFF
--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -5,6 +5,7 @@ FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 11 jlink
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \

--- a/11/debian/bookworm-slim/hotspot/Dockerfile
+++ b/11/debian/bookworm-slim/hotspot/Dockerfile
@@ -2,6 +2,10 @@ ARG JAVA_VERSION=11.0.22_7
 ARG BOOKWORM_TAG=20240110
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 11 jlink
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
          --strip-debug \

--- a/11/debian/bookworm/hotspot/Dockerfile
+++ b/11/debian/bookworm/hotspot/Dockerfile
@@ -2,9 +2,15 @@ ARG JAVA_VERSION=11.0.22_7
 ARG BOOKWORM_TAG=20240110
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 11 jlink
 RUN jlink \
          --add-modules ALL-MODULE-PATH \
+         --strip-debug \
          --no-man-pages \
+         --no-header-files \
          --compress=2 \
          --output /javaruntime
 

--- a/17/alpine/hotspot/Dockerfile
+++ b/17/alpine/hotspot/Dockerfile
@@ -5,15 +5,11 @@ FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 17 jlink
 RUN if [ "$TARGETPLATFORM" != 'linux/arm/v7' ]; then \
-    case "$(jlink --version 2>&1)" in \
-      # jlink version 11 has less features than JDK17+
-      "11."*) strip_java_debug_flags="--strip-debug" ;; \
-      *) strip_java_debug_flags="--strip-java-debug-attributes" ;; \
-    esac; \
     jlink \
       --add-modules ALL-MODULE-PATH \
-      "$strip_java_debug_flags" \
+      --strip-java-debug-attributes \
       --no-man-pages \
       --no-header-files \
       --compress=2 \

--- a/17/debian/bookworm-slim/hotspot/Dockerfile
+++ b/17/debian/bookworm-slim/hotspot/Dockerfile
@@ -2,13 +2,17 @@ ARG BOOKWORM_TAG=20240110
 ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 17 jlink
 RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
+      --add-modules ALL-MODULE-PATH \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress=2 \
+      --output /javaruntime
 
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim
 

--- a/17/debian/bookworm/hotspot/Dockerfile
+++ b/17/debian/bookworm/hotspot/Dockerfile
@@ -117,11 +117,11 @@ ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # metadata labels
 LABEL \
-  org.opencontainers.image.vendor="Jenkins project" \
-  org.opencontainers.image.title="Official Jenkins Docker image" \
-  org.opencontainers.image.description="The Jenkins Continuous Integration and Delivery server" \
-  org.opencontainers.image.version="${JENKINS_VERSION}" \
-  org.opencontainers.image.url="https://www.jenkins.io/" \
-  org.opencontainers.image.source="https://github.com/jenkinsci/docker" \
-  org.opencontainers.image.revision="${COMMIT_SHA}" \
-  org.opencontainers.image.licenses="MIT"
+    org.opencontainers.image.vendor="Jenkins project" \
+    org.opencontainers.image.title="Official Jenkins Docker image" \
+    org.opencontainers.image.description="The Jenkins Continuous Integration and Delivery server" \
+    org.opencontainers.image.version="${JENKINS_VERSION}" \
+    org.opencontainers.image.url="https://www.jenkins.io/" \
+    org.opencontainers.image.source="https://github.com/jenkinsci/docker" \
+    org.opencontainers.image.revision="${COMMIT_SHA}" \
+    org.opencontainers.image.licenses="MIT"

--- a/17/debian/bookworm/hotspot/Dockerfile
+++ b/17/debian/bookworm/hotspot/Dockerfile
@@ -2,11 +2,17 @@ ARG BOOKWORM_TAG=20240110
 ARG JAVA_VERSION=17.0.10_7
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 17 jlink
 RUN jlink \
-  --add-modules ALL-MODULE-PATH \
-  --no-man-pages \
-  --compress=2 \
-  --output /javaruntime
+      --add-modules ALL-MODULE-PATH \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress=2 \
+      --output /javaruntime
 
 FROM debian:bookworm-"${BOOKWORM_TAG}"
 

--- a/17/rhel/ubi9/hotspot/Dockerfile
+++ b/17/rhel/ubi9/hotspot/Dockerfile
@@ -4,11 +4,14 @@ FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-ubi9-minimal as jre-build
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 17 jlink
 RUN jlink \
-         --add-modules ALL-MODULE-PATH \
-         --no-man-pages \
-         --compress=2 \
-         --output /javaruntime
+      --add-modules ALL-MODULE-PATH \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress=2 \
+      --output /javaruntime
 
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1552
 

--- a/21/alpine/hotspot/Dockerfile
+++ b/21/alpine/hotspot/Dockerfile
@@ -5,18 +5,14 @@ FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-alpine AS jre-build
 # Generate smaller java runtime without unneeded files
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 21 jlink
 RUN if [ "$TARGETPLATFORM" != 'linux/arm/v7' ]; then \
-    case "$(jlink --version 2>&1)" in \
-      # jlink version 11 has less features than JDK17+
-      "11."*) strip_java_debug_flags="--strip-debug" ;; \
-      *) strip_java_debug_flags="--strip-java-debug-attributes" ;; \
-    esac; \
     jlink \
       --add-modules ALL-MODULE-PATH \
-      "$strip_java_debug_flags" \
+      --strip-java-debug-attributes \
       --no-man-pages \
       --no-header-files \
-      --compress=zip-6 \
+      --compress zip-6 \
       --output /javaruntime; \
   else \
     cp -r /opt/java/openjdk /javaruntime; \

--- a/21/debian/bookworm-slim/hotspot/Dockerfile
+++ b/21/debian/bookworm-slim/hotspot/Dockerfile
@@ -2,12 +2,18 @@ ARG BOOKWORM_TAG=20240110
 ARG JAVA_VERSION=21.0.2_13
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 21 jlink
 RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
       jlink \
-        --add-modules ALL-MODULE-PATH \
-        --no-man-pages \
-        --compress=zip-6 \
-        --output /javaruntime; \
+      --add-modules ALL-MODULE-PATH \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress zip-6 \
+      --output /javaruntime; \
     # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
     # Because jlink fails with the error "jmods: Value too large for defined data type" error.
     else  \

--- a/21/debian/bookworm/hotspot/Dockerfile
+++ b/21/debian/bookworm/hotspot/Dockerfile
@@ -123,11 +123,11 @@ ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
 # metadata labels
 LABEL \
-  org.opencontainers.image.vendor="Jenkins project" \
-  org.opencontainers.image.title="Official Jenkins Docker image" \
-  org.opencontainers.image.description="The Jenkins Continuous Integration and Delivery server" \
-  org.opencontainers.image.version="${JENKINS_VERSION}" \
-  org.opencontainers.image.url="https://www.jenkins.io/" \
-  org.opencontainers.image.source="https://github.com/jenkinsci/docker" \
-  org.opencontainers.image.revision="${COMMIT_SHA}" \
-  org.opencontainers.image.licenses="MIT"
+    org.opencontainers.image.vendor="Jenkins project" \
+    org.opencontainers.image.title="Official Jenkins Docker image" \
+    org.opencontainers.image.description="The Jenkins Continuous Integration and Delivery server" \
+    org.opencontainers.image.version="${JENKINS_VERSION}" \
+    org.opencontainers.image.url="https://www.jenkins.io/" \
+    org.opencontainers.image.source="https://github.com/jenkinsci/docker" \
+    org.opencontainers.image.revision="${COMMIT_SHA}" \
+    org.opencontainers.image.licenses="MIT"

--- a/21/debian/bookworm/hotspot/Dockerfile
+++ b/21/debian/bookworm/hotspot/Dockerfile
@@ -2,12 +2,18 @@ ARG BOOKWORM_TAG=20240110
 ARG JAVA_VERSION=21.0.2_13
 FROM eclipse-temurin:"${JAVA_VERSION}"-jdk-jammy as jre-build
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 21 jlink
 RUN if test "${TARGETPLATFORM}" != 'linux/arm/v7'; then \
       jlink \
-        --add-modules ALL-MODULE-PATH \
-        --no-man-pages \
-        --compress=zip-6 \
-        --output /javaruntime; \
+      --add-modules ALL-MODULE-PATH \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress zip-6 \
+      --output /javaruntime; \
     # It is acceptable to have a larger image in arm/v7 (arm 32 bits) environment.
     # Because jlink fails with the error "jmods: Value too large for defined data type" error.
     else  \

--- a/21/rhel/ubi9/hotspot/Dockerfile
+++ b/21/rhel/ubi9/hotspot/Dockerfile
@@ -27,10 +27,12 @@ ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
 # while still saving space (approx 200mb from the full distribution)
 # Arguments to jlink are specific to Java 21 jlink
 RUN jlink \
-  --add-modules ALL-MODULE-PATH \
-  --no-man-pages \
-  --compress=zip-6 \
-  --output /javaruntime
+      --add-modules ALL-MODULE-PATH \
+      --strip-java-debug-attributes \
+      --no-man-pages \
+      --no-header-files \
+      --compress zip-6 \
+      --output /javaruntime
 
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1552
 

--- a/21/rhel/ubi9/hotspot/Dockerfile
+++ b/21/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.3-1361 as jre-build
+FROM registry.access.redhat.com/ubi9/ubi:9.3-1552 as jre-build
 ARG JAVA_VERSION=21.0.2_13
 ARG TARGETPLATFORM
 
@@ -22,13 +22,17 @@ RUN set -x; yum install -y jq wget \
 
 ENV PATH=/opt/jdk-${JAVA_VERSION}/bin:$PATH
 
+# Generate smaller java runtime without unneeded files
+# for now we include the full module path to maintain compatibility
+# while still saving space (approx 200mb from the full distribution)
+# Arguments to jlink are specific to Java 21 jlink
 RUN jlink \
   --add-modules ALL-MODULE-PATH \
   --no-man-pages \
   --compress=zip-6 \
   --output /javaruntime
 
-FROM registry.access.redhat.com/ubi9/ubi:9.3-1361
+FROM registry.access.redhat.com/ubi9/ubi:9.3-1552
 
 ENV LANG C.UTF-8
 


### PR DESCRIPTION
## Use consistent jlink args within Java versions

The jlink command had been preceded by some logic that was specific to the Java version.  However, the logic did not capture all the differences between Java versions and our Dockerfiles are specific to a Java version.  Since the Dockerfile is already specific to a Java version, we don't need conditional logic based on the major version of jlink.

Also updates all Java 21 jlink commands to use the same arguments for consistency within the JDK version.

Also updates all Java 17 jlink commands to use the same arguments for consistency within the JDK version.

Also updates all Java 11 jlink commands to use the same arguments for consistency within the JDK version.

Also updates ubi9 to the most recent release.

This is a predecessor to:

* #1811 

### Testing done

Confirmed that Jenkins runs as expected from each of the containers that are changed by this pull request.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
