### PR TITLE
Remove JDK 19 from updatecli script

### DIFF
--- a/updatecli/scripts/check-jdk.sh
+++ b/updatecli/scripts/check-jdk.sh
@@ -25,10 +25,6 @@ function get_jdk_download_url() {
       ## JDK17 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-${jdk_version}/OpenJDK17U-jdk_${platform}_hotspot_${jdk_version//+/_}";
       return 0;;
-    19*)
-      ## JDK19 URLs have an underscore ('_') instead of a plus ('+') in their archive names
-      echo "https://github.com/adoptium/temurin19-binaries/releases/download/jdk-${jdk_version}/OpenJDK19U-jdk_${platform}_hotspot_${jdk_version//+/_}";
-      return 0;;
     21*)
       ## JDK21 URLs have an underscore ('_') instead of a plus ('+') in their archive names
       echo "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-${jdk_version}/OpenJDK21U-jdk_${platform}_hotspot_${jdk_version//+/_}";
@@ -46,8 +42,6 @@ case "${1}" in
   11.*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   17.*+*)
-    platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
-  19.*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux" "s390x_linux");;
   21*+*)
     platforms=("x64_linux" "x64_windows" "aarch64_linux");;


### PR DESCRIPTION
## Remove Java 19 from updatecli script

Java 19 was never supported by Jenkins. Java 19 support from the OpenJDK project ended 21 Mar 2023.  We do not need to define the download URL for a Java version that is not supported by Jenkins.

### Testing done

Confirmed by inspection that the Java 19 download URL is never used in this repository.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```
