### PR TITLE
fix(windows): remove `ConvertFrom-Json` issue by simplifying tags management

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -60,16 +60,6 @@ $env:COMMIT_SHA=$(git rev-parse HEAD)
 $baseDockerCmd = 'docker-compose --file=build-windows.yaml'
 $baseDockerBuildCmd = '{0} build --parallel --pull' -f $baseDockerCmd
 
-$builds = @{}
-$compose = Invoke-Expression "$baseDockerCmd config --format=json" 2>$null | ConvertFrom-Json
-foreach ($service in $compose.services.PSObject.Properties) {
-    $tags = @($service.Value.image)
-    $tags += $service.Value.build.tags
-    $builds[$service.Value.image] = @{
-        'Tags' = $tags;
-    }    
-}
-
 Write-Host "= PREPARE: List of $Organisation/$Repository images and tags to be processed:"
 Invoke-Expression "$baseDockerCmd config"
 
@@ -101,15 +91,18 @@ function Test-Image {
     $configuration.TestResult.OutputPath = ".\target\$ImageName\junit-results.xml"
 
     $TestResults = Invoke-Pester -Configuration $configuration
+    $failed = $false
     if ($TestResults.FailedCount -gt 0) {
         Write-Host "There were $($TestResults.FailedCount) failed tests in $ImageName"
-        $testFailed = $true
+        $failed = $true
     } else {
         Write-Host "There were $($TestResults.PassedCount) passed tests out of $($TestResults.TotalCount) in $ImageName"
     }
 
     Remove-Item env:\CONTROLLER_IMAGE
     Remove-Item env:\DOCKERFILE
+
+    return $failed
 }
 
 if($target -eq 'test') {
@@ -142,8 +135,10 @@ if($target -eq 'test') {
         $configuration.CodeCoverage.Enabled = $false
 
         Write-Host '= TEST: Testing all images...'
-        foreach($image in $builds.Keys) {
-            Test-Image $image.split(':')[1]
+        # Only fail the run afterwards in case of any test failures
+        $testFailed = $false
+        Invoke-Expression "$baseDockerCmd config" | yq '.services[].image' | ForEach-Object {
+            $testFailed = $testFailed -or (Test-Image $_.split(':')[1])
         }
 
         # Fail if any test failures
@@ -156,26 +151,16 @@ if($target -eq 'test') {
     }
 }
 
-if($target -eq 'publish') {
-    # Only fail the run afterwards in case of any issues when publishing the docker images
-    $publishFailed = 0
-    foreach($b in $builds.Keys) {
-        foreach($taggedImage in $Builds[$b]['Tags']) {
-            Write-Host "Publishing $b => tag=$taggedImage"
-            $cmd = 'docker push {0}' -f $taggedImage
-            switch ($DryRun) {
-                $true { Write-Host "(dry-run) $cmd" }
-                $false { Invoke-Expression $cmd}
-            }
-            if($lastExitCode -ne 0) {
-                $publishFailed = 1
-            }
-        }
+if($target -eq "publish") {
+    Write-Host "= PUBLISH: push all images and tags"
+    switch($DryRun) {
+        $true { Write-Host "(dry-run) $baseDockerCmd push" }
+        $false { Invoke-Expression "$baseDockerCmd push" }
     }
 
     # Fail if any issues when publising the docker images
-    if($publishFailed -ne 0 -and !$DryRun) {
-        Write-Error 'Publish failed!'
+    if($lastExitCode -ne 0) {
+        Write-Error "= PUBLISH: failed!"
         exit 1
     }
 }


### PR DESCRIPTION
This PR fixes the same kind of issue as https://github.com/jenkinsci/docker-agent/issues/780 also affecting this build by:
- Simplifying tags management using docker compose push to publish all tags at once
  - Similar to https://github.com/jenkinsci/docker-agent/pull/550)
- Removing the need for `ConvertFrom-Json` (failing due to a bug in docker compose, see https://github.com/docker/compose/issues/11627) with the use of `yq` to directly extract images from docker compose config YAML output
  - Similar to https://github.com/jenkinsci/docker-agent/pull/781)

### Testing done

CI build.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
