### PR TITLE
cleanup: remove deprecated `install-plugin.sh` script from Linux jdk11 images

### DIFF
--- a/11/almalinux/almalinux8/hotspot/Dockerfile
+++ b/11/almalinux/almalinux8/hotspot/Dockerfile
@@ -129,9 +129,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/11/alpine/hotspot/Dockerfile
+++ b/11/alpine/hotspot/Dockerfile
@@ -128,9 +128,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/11/debian/bookworm-slim/hotspot/Dockerfile
+++ b/11/debian/bookworm-slim/hotspot/Dockerfile
@@ -138,9 +138,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/11/debian/bookworm/hotspot/Dockerfile
+++ b/11/debian/bookworm/hotspot/Dockerfile
@@ -138,9 +138,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/11/rhel/ubi8/hotspot/Dockerfile
+++ b/11/rhel/ubi8/hotspot/Dockerfile
@@ -132,9 +132,6 @@ COPY jenkins-plugin-cli.sh /bin/jenkins-plugin-cli
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# from a derived Dockerfile, can use `RUN install-plugins.sh active.txt` to setup $REF/plugins from a support bundle
-COPY install-plugins.sh /usr/local/bin/install-plugins.sh
-
 # metadata labels
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \

--- a/install-plugins.sh
+++ b/install-plugins.sh
@@ -1,4 +1,0 @@
-#!/bin/bash -eu
-
-echo "WARN: install-plugins.sh has been removed, please switch to jenkins-plugin-cli"
-exit 1


### PR DESCRIPTION
This PR removes the `install-plugin.sh` script and its addition in the Linux jdk11 images.

From https://github.com/jenkinsci/docker/pull/1857:
> - Deprecated since September 2020
> - Does only echo a warning since https://github.com/jenkinsci/docker/pull/1408 almost two years ago: https://github.com/jenkinsci/docker/blob/bed10d624086e931cf1d053d62174a2355cfd15c/install-plugins.sh
> - I think it's time for it to go, it shouldn't functionally change anything for the end users anyway.

Extracted here if it needs to be merged separately.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
