### PR TITLE
fix: set jlink compression arg to `zip-6` for Windows jdk21 image

### DIFF
--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -25,9 +25,14 @@ RUN Write-Host 'javac --version' ; javac --version ; `
 
 RUN $version = (jlink --version) ; `
     $stripJavaDebugFlags = '--strip-java-debug-attributes' ; `
+    $compressArg = '--compress=2' ; `
     # jlink version 11 has less features than JDK17+
     if ($version.StartsWith('11')) { `
         $stripJavaDebugFlags = '--strip-debug' ; `
+    } `
+    # jlink version 11 has less features than JDK17+
+    if ($version.StartsWith('21')) { `
+        $compressArg = '--compress=zip-6' ; `
     } `
     & jlink `
     --add-modules ALL-MODULE-PATH `


### PR DESCRIPTION
This PR sets jlink compression arg to `zip-6` for Windows jdk21 image like it's done in Linux jdk21 images.

From https://github.com/jenkinsci/docker/pull/1857:
> Complement of https://github.com/jenkinsci/docker/pull/1848 which introduced jlink in the Windows controller image.
>
> Note: jlink on Windows should be properly tested, might worth its own issue.

Extracted here if it needs to be merged separately.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
