### PR TITLE
chore(updatecli): adapt manifests to unique Dockerfile per Linux variant

### DIFF
--- a/updatecli/updatecli.d/alpine.yaml
+++ b/updatecli/updatecli.d/alpine.yaml
@@ -29,30 +29,12 @@ sources:
       - trimprefix: "v"
 
 conditions:
-  testDockerfileArgJDK11:
-    name: "Does the JDK11 Dockerfile have an ARG instruction for the Alpine Linux version?"
+  testDockerfileArg:
+    name: "Does the Dockerfile have an ARG instruction for the Alpine Linux version?"
     kind: dockerfile
     disablesourceinput: true
     spec:
-      file: 11/alpine/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "ALPINE_TAG"
-  testDockerfileArgJDK17:
-    name: "Does the JDK17 Dockerfile have an ARG instruction for the Alpine Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 17/alpine/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "ALPINE_TAG"
-  testDockerfileArgJDK21:
-    name: "Does the JDK21 Dockerfile have an ARG instruction for the Alpine Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 21/alpine/hotspot/Dockerfile
+      file: alpine/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "ALPINE_TAG"
@@ -66,39 +48,21 @@ conditions:
       architecture: amd64
 
 targets:
-  updateDockerfileJDK11:
-    name: "Update the value of the JDK11 base image (ARG ALPINE_TAG) in the Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 11/alpine/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "ALPINE_TAG"
-    scmid: default
-    updateDockerfileJDK17:
-      name: "Update the value of the JDK17 base image (ARG ALPINE_TAG) in the Dockerfile"
-      kind: dockerfile
-      spec:
-        file: 17/alpine/hotspot/Dockerfile
-        instruction:
-          keyword: "ARG"
-          matcher: "ALPINE_TAG"
-      scmid: default
-  updateDockerfileJDK21:
-    name: "Update the value of the JDK21 base image (ARG ALPINE_TAG) in the Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/alpine/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "ALPINE_TAG"
-    scmid: default
   updateDockerBake:
     name: "Update the value of the base image (ARG ALPINE_TAG) in the docker-bake.hcl"
     kind: hcl
     spec:
       file: docker-bake.hcl
       path: variable.ALPINE_FULL_TAG.default
+    scmid: default
+  updateDockerfile:
+    name: "Update the value of the JDK base image (ARG ALPINE_TAG) in the Dockerfile"
+    kind: dockerfile
+    spec:
+      file: alpine/hotspot/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "ALPINE_TAG"
     scmid: default
 actions:
   default:

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -26,71 +26,16 @@ sources:
         kind: regex
         pattern: >-
           bookworm-\d+$
-  bookwormSlimLatestVersion:
-    kind: dockerimage
-    name: "Get the latest Debian Bookworm Linux version"
-    transformers:
-      - trimprefix: "bookworm-"
-    spec:
-      image: "debian"
-      tagfilter: "bookworm-*"
-      versionfilter:
-        kind: regex
-        pattern: >-
-          bookworm-\d+-slim$
 
 conditions:
-  testDockerfileArgJDK11:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
+  testDockerfileArg:
+    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm & Bookworm Slim Linux version?"
     kind: dockerfile
     disablesourceinput: true
     spec:
-      file: 11/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-  testDockerfileArgJDK11Slim:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 11/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-  testDockerfileArgJDK17:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 17/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-  testDockerfileArgJDK17Slim:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 17/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-  testDockerfileArgJDK21:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 21/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-  testDockerfileArgJDK21Slim:
-    name: "Does the Dockerfile have an ARG instruction for the Debian Bookworm Linux version?"
-    kind: dockerfile
-    disablesourceinput: true
-    spec:
-      file: 21/debian/bookworm-slim/hotspot/Dockerfile
+      files:
+        - debian/bookworm/hotspot/Dockerfile
+        - debian/bookworm-slim/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "BOOKWORM_TAG"
@@ -103,66 +48,6 @@ conditions:
       matchpattern: "(.*BOOKWORM_TAG.*)"
 
 targets:
-  updateDockerfileJDK11:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: 11/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-    scmid: default
-  updateDockerfileJDK11Slim:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: 11/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-    scmid: default
-  updateDockerfileJDK17:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: 17/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-    scmid: default
-  updateDockerfileJDK17Slim:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: 17/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-    scmid: default
-  updateDockerfileJDK21:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: 21/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-    scmid: default
-  updateDockerfileJDK21Slim:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfile"
-    kind: dockerfile
-    sourceid: bookwormLatestVersion
-    spec:
-      file: 21/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
-    scmid: default
   updateDockerBake:
     name: "Update the value of the base image (ARG BOOKWORM_TAG) in the docker-bake.hcl"
     kind: file
@@ -173,6 +58,18 @@ targets:
         variable(.*)"BOOKWORM_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
       replacepattern: >-
         variable${1}"BOOKWORM_TAG"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
+    scmid: default
+  updateDockerfile:
+    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfiles"
+    kind: dockerfile
+    sourceid: bookwormLatestVersion
+    spec:
+      files:
+        - debian/bookworm/hotspot/Dockerfile
+        - debian/bookworm-slim/hotspot/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "BOOKWORM_TAG"
     scmid: default
 actions:
   default:

--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -52,6 +52,7 @@ conditions:
     disablesourceinput: true
 
 targets:
+  ## Global config files
   setJDK11VersionDockerBake:
     name: "Bump JDK11 version for Linux images in the docker-bake.hcl file"
     kind: hcl
@@ -59,38 +60,20 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA11_VERSION.default
     scmid: default
+  setJDK11VersionWindowsDockerCompose:
+    name: "Bump JDK11 version in build-windows.yaml"
+    kind: yaml
+    spec:
+      file: build-windows.yaml
+      key: $.services.jdk11.build.args.JAVA_VERSION
+    scmid: default
+  ## Dockerfiles
+  # Setting default JAVA_VERSION ARG for remaining ad hoc JDK11 images
   setJDK11VersionAlmaLinux8:
     name: "Bump JDK11 version for Linux images in the Alma Linux 8 Dockerfile"
     kind: dockerfile
     spec:
-      file: 11/almalinux/almalinux8/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionAlpine:
-    name: "Bump JDK11 version for Linux images in the Alpine Linux Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 11/alpine/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionDebian:
-    name: "Bump JDK11 version for Linux images in the Debian Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 11/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionDebianSlim:
-    name: "Bump JDK11 version for Linux images in the Debian Slim Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 11/debian/bookworm-slim/hotspot/Dockerfile
+      file: almalinux/almalinux8/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
@@ -99,17 +82,10 @@ targets:
     name: "Bump JDK11 version for Linux images in the Rhel Dockerfile"
     kind: dockerfile
     spec:
-      file: 11/rhel/ubi8/hotspot/Dockerfile
+      file: rhel/ubi8/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
-    scmid: default
-  setJDK11VersionWindowsDockerCompose:
-    name: "Bump JDK11 version in build-windows.yaml"
-    kind: yaml
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk11.build.args.JAVA_VERSION
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -54,6 +54,7 @@ conditions:
     disablesourceinput: true
 
 targets:
+  ## Global config files
   setJDK17VersionDockerBake:
     name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
     kind: hcl
@@ -61,29 +62,31 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA17_VERSION.default
     scmid: default
+  setJDK17VersionWindowsDockerCompose:
+    name: "Bump JDK17 version in build-windows.yaml"
+    kind: yaml
+    spec:
+      file: build-windows.yaml
+      key: $.services.jdk17.build.args.JAVA_VERSION
+    scmid: default
+  ## Dockerfiles
+  # Setting default JAVA_VERSION ARG to current Jenkins default JDK17
   setJDK17VersionAlpine:
     name: "Bump JDK17 version for Linux images in the Alpine Linux Dockerfile"
     kind: dockerfile
     spec:
-      file: 17/alpine/hotspot/Dockerfile
+      file: alpine/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
     scmid: default
   setJDK17VersionDebian:
-    name: "Bump JDK17 version for Linux images in the Debian Dockerfile"
+    name: "Bump JDK17 version for Linux images in the Debian Dockerfiles"
     kind: dockerfile
     spec:
-      file: 17/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK17VersionDebianSlim:
-    name: "Bump JDK17 version for Linux images in the Debian Slim Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 17/debian/bookworm-slim/hotspot/Dockerfile
+      files:
+        - debian/bookworm/hotspot/Dockerfile
+        - debian/bookworm-slim/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
@@ -92,7 +95,7 @@ targets:
     name: "Bump JDK17 version for Linux images in the Rhel Dockerfile"
     kind: dockerfile
     spec:
-      file: 17/rhel/ubi9/hotspot/Dockerfile
+      file: rhel/ubi9/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
@@ -105,13 +108,6 @@ targets:
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION
-    scmid: default
-  setJDK17VersionWindowsDockerCompose:
-    name: "Bump JDK17 version in build-windows.yaml"
-    kind: yaml
-    spec:
-      file: build-windows.yaml
-      key: $.services.jdk17.build.args.JAVA_VERSION
     scmid: default
 
 actions:

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -52,48 +52,13 @@ conditions:
     disablesourceinput: true
 
 targets:
+  ## Global config files
   setJDK21VersionDockerBake:
     name: "Bump JDK21 version for Linux images in the docker-bake.hcl file"
     kind: hcl
     spec:
       file: docker-bake.hcl
       path: variable.JAVA21_VERSION.default
-    scmid: default
-  setJDK21VersionAlpine:
-    name: "Bump JDK21 version for Linux images in the Alpine Linux Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/alpine/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK21VersionDebian:
-    name: "Bump JDK21 version for Linux images in the Debian Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/debian/bookworm/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK21VersionDebianSlim:
-    name: "Bump JDK21 version for Linux images in the Debian Slim Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/debian/bookworm-slim/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
-    scmid: default
-  setJDK21VersionRhel:
-    name: "Bump JDK21 version for Linux images in the Rhel Dockerfile"
-    kind: dockerfile
-    spec:
-      file: 21/rhel/ubi9/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JAVA_VERSION
     scmid: default
   setJDK21VersionWindowsDockerCompose:
     name: "Bump JDK21 version in build-windows.yaml"


### PR DESCRIPTION
This PR adapts updatecli manifests to unique Dockerfile per Linux variant.

Note: I removed the unused `bookwormSlimLatestVersion` source as `bookwormLatestVersion` is used for both Debian & Debian slim images.

Follow-up of:
- #1857

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
