### PR TITLE
Remove Java 11 images on weekly release line

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -68,9 +68,15 @@ else
     LATEST_WEEKLY="false"
 fi
 
+# Build all images including Java 11 if the version match latest LTS version
+# TODO: remove when Java 11 is removed from LTS line
+# See https://github.com/jenkinsci/docker/issues/1890
+TARGET="linux"
+
 if [[ "${JENKINS_VERSION}" == "${latest_lts_version}" ]]
 then
     LATEST_LTS="true"
+    TARGET="linux-lts-with-jdk11"
 else
     LATEST_LTS="false"
 fi
@@ -84,7 +90,7 @@ fi
 
 JENKINS_SHA="$(curl --disable --fail --silent --show-error --location "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war.sha256")"
 COMMIT_SHA=$(git rev-parse HEAD)
-export COMMIT_SHA JENKINS_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS
+export COMMIT_SHA JENKINS_VERSION JENKINS_SHA LATEST_WEEKLY LATEST_LTS TARGET
 
 cat <<EOF
 Using the following settings:
@@ -94,6 +100,7 @@ Using the following settings:
 * COMMIT_SHA: ${COMMIT_SHA}
 * LATEST_WEEKLY: ${LATEST_WEEKLY}
 * LATEST_LTS: ${LATEST_LTS}
+* TARGET: ${TARGET}
 EOF
 
-docker buildx bake --file docker-bake.hcl "${build_opts[@]}" linux
+docker buildx bake --file docker-bake.hcl "${build_opts[@]}" "${TARGET}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,60 +13,76 @@ properties(listOfProperties)
 
 stage('Build') {
     def builds = [:]
-    def windowsImageTypes = [
-        'windowsservercore-ltsc2019',
-    ]
-    for (anImageType in windowsImageTypes) {
-        def imageType = anImageType
-        builds[imageType] = {
-            nodeWithTimeout('windows-2019') {
-                stage('Checkout') {
-                    checkout scm
-                }
 
-                withEnv(["IMAGE_TYPE=${imageType}"]) {
-                    if (!infra.isTrusted()) {
-                        /* Outside of the trusted.ci environment, we're building and testing
-                        * the Dockerfile in this repository, but not publishing to docker hub
-                        */
-                        stage("Build ${imageType}") {
-                            infra.withDockerCredentials {
-                                powershell './make.ps1'
-                            }
-                        }
+    // Determine if the tag name (ie Jenkins version) correspond to a LTS (3 groups of digits)
+    // to use the appropriate bake target and set of images to build (including or not Java 11)
+    def isLTS
+    if (env.TAG_NAME && env.TAG_NAME =~ /^\d+\.\d+\.\d+$/) {
+        isLTS = true
+        target = 'linux-lts-with-jdk11'
+    } else {
+        isLTS = false
+        target = 'linux'
+    }
+    echo "= bake target: $target"
+    echo "= isLTS: $isLTS"
 
-                        stage("Test ${imageType}") {
-                            infra.withDockerCredentials {
-                                def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
-                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
-                                if (windowsTestStatus > 0) {
-                                    // If something bad happened let's clean up the docker images
-                                    error('Windows test stage failed.')
+    withEnv (["TARGET=${target}"]) {
+        def windowsImageTypes = [
+            'windowsservercore-ltsc2019',
+        ]
+        for (anImageType in windowsImageTypes) {
+            def imageType = anImageType
+            builds[imageType] = {
+                nodeWithTimeout('windows-2019') {
+                    stage('Checkout') {
+                        checkout scm
+                    }
+
+                    withEnv(["IMAGE_TYPE=${imageType}"]) {
+                        if (!infra.isTrusted()) {
+                            /* Outside of the trusted.ci environment, we're building and testing
+                            * the Dockerfile in this repository, but not publishing to docker hub
+                            */
+                            stage("Build ${imageType}") {
+                                infra.withDockerCredentials {
+                                    powershell './make.ps1'
                                 }
                             }
-                        }
 
-                        // disable until we get the parallel changes merged in
-                        // def branchName = "${env.BRANCH_NAME}"
-                        // if (branchName ==~ 'master'){
-                        //    stage('Publish Experimental') {
-                        //        infra.withDockerCredentials {
-                        //            withEnv(['DOCKERHUB_ORGANISATION=jenkins4eval','DOCKERHUB_REPO=jenkins']) {
-                        //                powershell './make.ps1 publish'
-                        //            }
-                        //        }
-                        //    }
-                        // }
-                    } else {
-                        // Only publish when a tag triggered the build
-                        if (env.TAG_NAME) {
-                            // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-                            jenkins_version = env.TAG_NAME.split('-')[0]
-                            withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
-                                stage('Publish') {
-                                    infra.withDockerCredentials {
-                                        withEnv(['DOCKERHUB_ORGANISATION=jenkins','DOCKERHUB_REPO=jenkins']) {
-                                            powershell './make.ps1 publish'
+                            stage("Test ${imageType}") {
+                                infra.withDockerCredentials {
+                                    def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
+                                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
+                                    if (windowsTestStatus > 0) {
+                                        // If something bad happened let's clean up the docker images
+                                        error('Windows test stage failed.')
+                                    }
+                                }
+                            }
+
+                            // disable until we get the parallel changes merged in
+                            // def branchName = "${env.BRANCH_NAME}"
+                            // if (branchName ==~ 'master'){
+                            //    stage('Publish Experimental') {
+                            //        infra.withDockerCredentials {
+                            //            withEnv(['DOCKERHUB_ORGANISATION=jenkins4eval','DOCKERHUB_REPO=jenkins']) {
+                            //                powershell './make.ps1 publish'
+                            //            }
+                            //        }
+                            //    }
+                            // }
+                        } else {
+                            // Only publish when a tag triggered the build
+                            if (env.TAG_NAME) {
+                                // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
+                                jenkins_version = env.TAG_NAME.split('-')[0]
+                                withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                                    stage('Publish') {
+                                        infra.withDockerCredentials {
+                                            withEnv(['DOCKERHUB_ORGANISATION=jenkins','DOCKERHUB_REPO=jenkins']) {
+                                                powershell './make.ps1 publish'
+                                            }
                                         }
                                     }
                                 }
@@ -76,10 +92,21 @@ stage('Build') {
                 }
             }
         }
-    }
 
-    if (!infra.isTrusted()) {
-        def images = [
+        if (!infra.isTrusted()) {
+            def images
+
+            def imagesWithoutJava11 = [
+                'alpine_jdk17',
+                'alpine_jdk21',
+                'debian_jdk17',
+                'debian_jdk21',
+                'debian_slim_jdk17',
+                'debian_slim_jdk21',
+                'rhel_ubi9_jdk17',
+                'rhel_ubi9_jdk21',
+            ]
+            def imagesWithJava11 = [
                 'almalinux_jdk11',
                 'alpine_jdk11',
                 'alpine_jdk17',
@@ -93,95 +120,103 @@ stage('Build') {
                 'rhel_ubi8_jdk11',
                 'rhel_ubi9_jdk17',
                 'rhel_ubi9_jdk21',
-        ]
-        for (i in images) {
-            def imageToBuild = i
-
-            builds[imageToBuild] = {
-                nodeWithTimeout('docker') {
-                    deleteDir()
-
-                    stage('Checkout') {
-                        checkout scm
-                    }
-
-                    stage('Static analysis') {
-                        sh 'make hadolint shellcheck'
-                    }
-
-                    /* Outside of the trusted.ci environment, we're building and testing
-                    * the Dockerfile in this repository, but not publishing to docker hub
-                    */
-                    stage("Build linux-${imageToBuild}") {
-                        infra.withDockerCredentials {
-                            sh "make build-${imageToBuild}"
-                        }
-                    }
-
-                    stage("Test linux-${imageToBuild}") {
-                        sh "make prepare-test"
-                        try {
-                            infra.withDockerCredentials {
-                                sh "make test-${imageToBuild}"
-                            }
-                        } catch (err) {
-                            error("${err.toString()}")
-                        } finally {
-                            junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
-                        }
-                    }
-                }
+            ]
+            // Build all images including Java 11 if the version match a LTS versioning pattern
+            // TODO: remove when Java 11 is removed from LTS line
+            // See https://github.com/jenkinsci/docker/issues/1890
+            if (isLTS) {
+                images = imagesWithJava11
+            } else {
+                images = imagesWithoutJava11
             }
-        }
-        builds['multiarch-build'] = {
-            nodeWithTimeout('docker') {
-                stage('Checkout') {
-                    deleteDir()
-                    checkout scm
-                }
+            for (i in images) {
+                def imageToBuild = i
 
-                // sanity check that proves all images build on declared platforms
-                stage('Multi arch build') {
-                    infra.withDockerCredentials {
-                        sh '''
-                            docker buildx create --use
-                            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                            docker buildx bake --file docker-bake.hcl linux
-                        '''
-                    }
-                }
-            }
-        }
-    } else {
-        // Only publish when a tag triggered the build
-        if (env.TAG_NAME) {
-            // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-            jenkins_version = env.TAG_NAME.split('-')[0]
-            builds['linux'] = {
-                withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                builds[imageToBuild] = {
                     nodeWithTimeout('docker') {
+                        deleteDir()
+
                         stage('Checkout') {
                             checkout scm
                         }
 
-                        stage('Publish') {
+                        stage('Static analysis') {
+                            sh 'make hadolint shellcheck'
+                        }
+
+                        /* Outside of the trusted.ci environment, we're building and testing
+                        * the Dockerfile in this repository, but not publishing to docker hub
+                        */
+                        stage("Build linux-${imageToBuild}") {
                             infra.withDockerCredentials {
-                                sh '''
-                                    docker buildx create --use
-                                    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                                    make publish
-                                    '''
+                                sh "make build-${imageToBuild}"
+                            }
+                        }
+
+                        stage("Test linux-${imageToBuild}") {
+                            sh "make prepare-test"
+                            try {
+                                infra.withDockerCredentials {
+                                    sh "make test-${imageToBuild}"
+                                }
+                            } catch (err) {
+                                error("${err.toString()}")
+                            } finally {
+                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                            }
+                        }
+                    }
+                }
+            }
+            builds['multiarch-build'] = {
+                nodeWithTimeout('docker') {
+                    stage('Checkout') {
+                        deleteDir()
+                        checkout scm
+                    }
+
+                    // sanity check that proves all images build on declared platforms
+                    stage('Multi arch build') {
+                        infra.withDockerCredentials {
+                            sh '''
+                                docker buildx create --use
+                                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                docker buildx bake --file docker-bake.hcl "${TARGET}"
+                            '''
+                        }
+                    }
+                }
+            }
+        } else {
+            // Only publish when a tag triggered the build
+            if (env.TAG_NAME) {
+                // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
+                jenkins_version = env.TAG_NAME.split('-')[0]
+                builds['linux'] = {
+                    withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                        nodeWithTimeout('docker') {
+                            stage('Checkout') {
+                                checkout scm
+                            }
+
+                            stage('Publish') {
+                                infra.withDockerCredentials {
+                                    sh '''
+                                        docker buildx create --use
+                                        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                        make publish
+                                        '''
+                                }
                             }
                         }
                     }
                 }
             }
         }
+
+        parallel builds
     }
-
-    parallel builds
 }
-
 
 void nodeWithTimeout(String label, def body) {
     node(label) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,77 +11,96 @@ H 6,21 * * 3''')])
 
 properties(listOfProperties)
 
+// Default environment variable set to allow images publication
+def envVars = ["PUBLISH=true"]
+
+// Set to true in a replay to simulate a LTS build on ci.jenkins.io
+// It will set the environment variables needed for a LTS
+// and disable images publication out of caution
+def SIMULATE_LTS_BUILD = false
+
+if (SIMULATE_LTS_BUILD) {
+    envVars = [
+        "PUBLISH=false",
+        "TAG_NAME=2.452.2",
+        "JENKINS_VERSION=2.452.2",
+        "JENKINS_SHA=360efc8438db9a4ba20772981d4257cfe6837bf0c3fb8c8e9b2253d8ce6ba339"
+    ]
+}
+
 stage('Build') {
     def builds = [:]
 
-    // Determine if the tag name (ie Jenkins version) correspond to a LTS (3 groups of digits)
-    // to use the appropriate bake target and set of images to build (including or not Java 11)
-    def isLTS
-    if (env.TAG_NAME && env.TAG_NAME =~ /^\d+\.\d+\.\d+$/) {
-        isLTS = true
-        target = 'linux-lts-with-jdk11'
-    } else {
-        isLTS = false
-        target = 'linux'
-    }
-    echo "= bake target: $target"
-    echo "= isLTS: $isLTS"
+    withEnv (envVars) {
+        // Determine if the tag name (ie Jenkins version) correspond to a LTS (3 groups of digits)
+        // to use the appropriate bake target and set of images to build (including or not Java 11)
+        def isLTS
+        if (env.TAG_NAME && env.TAG_NAME =~ /^\d+\.\d+\.\d+$/) {
+            isLTS = true
+            target = 'linux-lts-with-jdk11'
+        } else {
+            isLTS = false
+            target = 'linux'
+        }
+        echo "= bake target: $target"
+        echo "= isLTS: $isLTS"
 
-    withEnv (["TARGET=${target}"]) {
-        def windowsImageTypes = [
-            'windowsservercore-ltsc2019',
-        ]
-        for (anImageType in windowsImageTypes) {
-            def imageType = anImageType
-            builds[imageType] = {
-                nodeWithTimeout('windows-2019') {
-                    stage('Checkout') {
-                        checkout scm
-                    }
+        withEnv (["TARGET=${target}"]) {
+            def windowsImageTypes = [
+                'windowsservercore-ltsc2019',
+            ]
+            for (anImageType in windowsImageTypes) {
+                def imageType = anImageType
+                builds[imageType] = {
+                    nodeWithTimeout('windows-2019') {
+                        stage('Checkout') {
+                            checkout scm
+                        }
 
-                    withEnv(["IMAGE_TYPE=${imageType}"]) {
-                        if (!infra.isTrusted()) {
-                            /* Outside of the trusted.ci environment, we're building and testing
-                            * the Dockerfile in this repository, but not publishing to docker hub
-                            */
-                            stage("Build ${imageType}") {
-                                infra.withDockerCredentials {
-                                    powershell './make.ps1'
-                                }
-                            }
-
-                            stage("Test ${imageType}") {
-                                infra.withDockerCredentials {
-                                    def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
-                                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
-                                    if (windowsTestStatus > 0) {
-                                        // If something bad happened let's clean up the docker images
-                                        error('Windows test stage failed.')
+                        withEnv(["IMAGE_TYPE=${imageType}"]) {
+                            if (!infra.isTrusted()) {
+                                /* Outside of the trusted.ci environment, we're building and testing
+                                * the Dockerfile in this repository, but not publishing to docker hub
+                                */
+                                stage("Build ${imageType}") {
+                                    infra.withDockerCredentials {
+                                        powershell './make.ps1'
                                     }
                                 }
-                            }
 
-                            // disable until we get the parallel changes merged in
-                            // def branchName = "${env.BRANCH_NAME}"
-                            // if (branchName ==~ 'master'){
-                            //    stage('Publish Experimental') {
-                            //        infra.withDockerCredentials {
-                            //            withEnv(['DOCKERHUB_ORGANISATION=jenkins4eval','DOCKERHUB_REPO=jenkins']) {
-                            //                powershell './make.ps1 publish'
-                            //            }
-                            //        }
-                            //    }
-                            // }
-                        } else {
-                            // Only publish when a tag triggered the build
-                            if (env.TAG_NAME) {
-                                // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-                                jenkins_version = env.TAG_NAME.split('-')[0]
-                                withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
-                                    stage('Publish') {
-                                        infra.withDockerCredentials {
-                                            withEnv(['DOCKERHUB_ORGANISATION=jenkins','DOCKERHUB_REPO=jenkins']) {
-                                                powershell './make.ps1 publish'
+                                stage("Test ${imageType}") {
+                                    infra.withDockerCredentials {
+                                        def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
+                                        junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
+                                        if (windowsTestStatus > 0) {
+                                            // If something bad happened let's clean up the docker images
+                                            error('Windows test stage failed.')
+                                        }
+                                    }
+                                }
+
+                                // disable until we get the parallel changes merged in
+                                // def branchName = "${env.BRANCH_NAME}"
+                                // if (branchName ==~ 'master'){
+                                //    stage('Publish Experimental') {
+                                //        infra.withDockerCredentials {
+                                //            withEnv(['DOCKERHUB_ORGANISATION=jenkins4eval','DOCKERHUB_REPO=jenkins']) {
+                                //                powershell './make.ps1 publish'
+                                //            }
+                                //        }
+                                //    }
+                                // }
+                            } else {
+                                // Only publish when a tag triggered the build & the publication is enabled (ie not simulating a LTS)
+                                if (env.TAG_NAME && (env.PUBLISH == "true")) {
+                                    // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
+                                    jenkins_version = env.TAG_NAME.split('-')[0]
+                                    withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                                        stage('Publish') {
+                                            infra.withDockerCredentials {
+                                                withEnv(['DOCKERHUB_ORGANISATION=jenkins','DOCKERHUB_REPO=jenkins']) {
+                                                    powershell './make.ps1 publish'
+                                                }
                                             }
                                         }
                                     }
@@ -91,130 +110,133 @@ stage('Build') {
                     }
                 }
             }
-        }
 
-        if (!infra.isTrusted()) {
-            def images
+            if (!infra.isTrusted()) {
+                def images
 
-            def imagesWithoutJava11 = [
-                'alpine_jdk17',
-                'alpine_jdk21',
-                'debian_jdk17',
-                'debian_jdk21',
-                'debian_slim_jdk17',
-                'debian_slim_jdk21',
-                'rhel_ubi9_jdk17',
-                'rhel_ubi9_jdk21',
-            ]
-            def imagesWithJava11 = [
-                'almalinux_jdk11',
-                'alpine_jdk11',
-                'alpine_jdk17',
-                'alpine_jdk21',
-                'debian_jdk11',
-                'debian_jdk17',
-                'debian_jdk21',
-                'debian_slim_jdk11',
-                'debian_slim_jdk17',
-                'debian_slim_jdk21',
-                'rhel_ubi8_jdk11',
-                'rhel_ubi9_jdk17',
-                'rhel_ubi9_jdk21',
-            ]
-            // Build all images including Java 11 if the version match a LTS versioning pattern
-            // TODO: remove when Java 11 is removed from LTS line
-            // See https://github.com/jenkinsci/docker/issues/1890
-            if (isLTS) {
-                images = imagesWithJava11
-            } else {
-                images = imagesWithoutJava11
-            }
-            for (i in images) {
-                def imageToBuild = i
-
-                builds[imageToBuild] = {
-                    nodeWithTimeout('docker') {
-                        deleteDir()
-
-                        stage('Checkout') {
-                            checkout scm
-                        }
-
-                        stage('Static analysis') {
-                            sh 'make hadolint shellcheck'
-                        }
-
-                        /* Outside of the trusted.ci environment, we're building and testing
-                        * the Dockerfile in this repository, but not publishing to docker hub
-                        */
-                        stage("Build linux-${imageToBuild}") {
-                            infra.withDockerCredentials {
-                                sh "make build-${imageToBuild}"
-                            }
-                        }
-
-                        stage("Test linux-${imageToBuild}") {
-                            sh "make prepare-test"
-                            try {
-                                infra.withDockerCredentials {
-                                    sh "make test-${imageToBuild}"
-                                }
-                            } catch (err) {
-                                error("${err.toString()}")
-                            } finally {
-                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
-                            }
-                        }
-                    }
+                def imagesWithoutJava11 = [
+                    'alpine_jdk17',
+                    'alpine_jdk21',
+                    'debian_jdk17',
+                    'debian_jdk21',
+                    'debian_slim_jdk17',
+                    'debian_slim_jdk21',
+                    'rhel_ubi9_jdk17',
+                    'rhel_ubi9_jdk21',
+                ]
+                def imagesWithJava11 = [
+                    'almalinux_jdk11',
+                    'alpine_jdk11',
+                    'alpine_jdk17',
+                    'alpine_jdk21',
+                    'debian_jdk11',
+                    'debian_jdk17',
+                    'debian_jdk21',
+                    'debian_slim_jdk11',
+                    'debian_slim_jdk17',
+                    'debian_slim_jdk21',
+                    'rhel_ubi8_jdk11',
+                    'rhel_ubi9_jdk17',
+                    'rhel_ubi9_jdk21',
+                ]
+                if (isLTS) {
+                    images = imagesWithJava11
+                } else {
+                    images = imagesWithoutJava11
                 }
-            }
-            builds['multiarch-build'] = {
-                nodeWithTimeout('docker') {
-                    stage('Checkout') {
-                        deleteDir()
-                        checkout scm
-                    }
+                // Build all images including Java 11 if the version match a LTS versioning pattern
+                // TODO: remove when Java 11 is removed from LTS line
+                // See https://github.com/jenkinsci/docker/issues/1890
+                for (i in images) {
+                    def imageToBuild = i
 
-                    // sanity check that proves all images build on declared platforms
-                    stage('Multi arch build') {
-                        infra.withDockerCredentials {
-                            sh '''
-                                docker buildx create --use
-                                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                                docker buildx bake --file docker-bake.hcl "${TARGET}"
-                            '''
-                        }
-                    }
-                }
-            }
-        } else {
-            // Only publish when a tag triggered the build
-            if (env.TAG_NAME) {
-                // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-                jenkins_version = env.TAG_NAME.split('-')[0]
-                builds['linux'] = {
-                    withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                    builds[imageToBuild] = {
                         nodeWithTimeout('docker') {
+                            deleteDir()
+
                             stage('Checkout') {
                                 checkout scm
                             }
 
-                            stage('Publish') {
+                            stage('Static analysis') {
+                                sh 'make hadolint shellcheck'
+                            }
+
+                            /* Outside of the trusted.ci environment, we're building and testing
+                            * the Dockerfile in this repository, but not publishing to docker hub
+                            */
+                            stage("Build linux-${imageToBuild}") {
                                 infra.withDockerCredentials {
-                                    sh '''
-                                        docker buildx create --use
-                                        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-                                        make publish
-                                        '''
+                                    sh "make build-${imageToBuild}"
+                                }
+                            }
+
+                            stage("Test linux-${imageToBuild}") {
+                                sh "make prepare-test"
+                                try {
+                                    infra.withDockerCredentials {
+                                        sh "make test-${imageToBuild}"
+                                    }
+                                } catch (err) {
+                                    error("${err.toString()}")
+                                } finally {
+                                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                                }
+                            }
+                        }
+                    }
+                }
+                builds['multiarch-build'] = {
+                    nodeWithTimeout('docker') {
+                        stage('Checkout') {
+                            deleteDir()
+                            checkout scm
+                        }
+
+                        // sanity check that proves all images build on declared platforms
+                        stage('Multi arch build') {
+                            infra.withDockerCredentials {
+                                sh '''
+                                    docker buildx create --use
+                                    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                    docker buildx bake --file docker-bake.hcl "${TARGET}"
+                                '''
+                            }
+                        }
+                    }
+                }
+            } else {
+                // Only publish when a tag triggered the build
+                if (env.TAG_NAME) {
+                    // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
+                    jenkins_version = env.TAG_NAME.split('-')[0]
+                    builds['linux'] = {
+                        withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                            nodeWithTimeout('docker') {
+                                stage('Checkout') {
+                                    checkout scm
+                                }
+
+                                stage('Publish') {
+                                    // Publication is enabled by default, disabled when simulating a LTS
+                                    if (env.PUBLISH == "true") {
+                                        infra.withDockerCredentials {
+                                            sh '''
+                                                docker buildx create --use
+                                                docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                                make publish
+                                                '''
+                                        }
+                                    }
                                 }
                             }
                         }
                     }
                 }
             }
-        }
 
-        parallel builds
+            parallel builds
+        }
     }
 }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,14 +139,14 @@ stage('Build') {
                     'rhel_ubi9_jdk17',
                     'rhel_ubi9_jdk21',
                 ]
+                // Build all images including Java 11 if the version match a LTS versioning pattern
+                // TODO: remove when Java 11 is removed from LTS line
+                // See https://github.com/jenkinsci/docker/issues/1890
                 if (isLTS) {
                     images = imagesWithJava11
                 } else {
                     images = imagesWithoutJava11
                 }
-                // Build all images including Java 11 if the version match a LTS versioning pattern
-                // TODO: remove when Java 11 is removed from LTS line
-                // See https://github.com/jenkinsci/docker/issues/1890
                 for (i in images) {
                     def imageToBuild = i
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ DISABLE_PARALLEL_TESTS ?= false
 # default is "all test suites in the "tests/" directory
 TEST_SUITES ?= $(CURDIR)/tests
 
+# Set to linux-lts-with-jdk11 to build all images including Java 11 if the version match a LTS versioning pattern
+# TODO: remove when Java 11 is removed from LTS line
+# See https://github.com/jenkinsci/docker/issues/1890
+TARGET ?= linux
+
 ##### Macros
 ## Check the presence of a CLI in the current PATH
 check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' required but not found. Exiting." ; exit 1 ; }
@@ -53,7 +58,7 @@ build-%: check-reqs
 	@set -x; $(bake_base_cli) --set '*.platform=linux/$(ARCH)' '$*'
 
 show:
-	@$(bake_base_cli) linux --print
+	@$(bake_base_cli) $(TARGET) --print
 
 list: check-reqs
 	@set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'

--- a/build-windows-lts-with-jdk11.yaml
+++ b/build-windows-lts-with-jdk11.yaml
@@ -1,4 +1,19 @@
 services:
+  jdk11:
+    image: ${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}${SEPARATOR_LTS_PREFIX}jdk11-hotspot-${WINDOWS_FLAVOR}-${WINDOWS_VERSION}
+    build:
+      context: ./
+      dockerfile: ./windows/${WINDOWS_FLAVOR}/hotspot/Dockerfile
+      args:
+        COMMIT_SHA: ${COMMIT_SHA}
+        JAVA_HOME: "C:/openjdk-11"
+        JAVA_VERSION: 11.0.23_9
+        JENKINS_SHA: ${JENKINS_SHA}
+        JENKINS_VERSION: ${JENKINS_VERSION}
+        TOOLS_WINDOWS_VERSION: ${TOOLS_WINDOWS_VERSION}
+        WINDOWS_VERSION: ${WINDOWS_VERSION}
+      tags:
+        - ${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}:${JENKINS_VERSION}-jdk11-hotspot-${WINDOWS_FLAVOR}-${WINDOWS_VERSION}
   jdk17:
     image: ${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}${SEPARATOR_LTS_PREFIX}jdk17-hotspot-${WINDOWS_FLAVOR}-${WINDOWS_VERSION}
     build:

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -2,6 +2,21 @@
 
 group "linux" {
   targets = [
+    "alpine_jdk17",
+    "alpine_jdk21",
+    "debian_jdk17",
+    "debian_jdk21",
+    "debian_slim_jdk17",
+    "debian_slim_jdk21",
+    "rhel_ubi9_jdk17",
+    "rhel_ubi9_jdk21",
+  ]
+}
+
+# TODO: remove when Java 11 is removed from LTS line
+# See https://github.com/jenkinsci/docker/issues/1890
+group "linux-lts-with-jdk11" {
+  targets = [
     "almalinux_jdk11",
     "alpine_jdk11",
     "alpine_jdk17",

--- a/make.ps1
+++ b/make.ps1
@@ -57,7 +57,14 @@ $env:JENKINS_SHA = $webClient.DownloadString($jenkinsShaURL).ToUpper()
 
 $env:COMMIT_SHA=$(git rev-parse HEAD)
 
-$baseDockerCmd = 'docker-compose --file=build-windows.yaml'
+# Build all images including Java 11 if the version match a LTS versioning pattern
+# TODO: remove when Java 11 is removed from LTS line
+# See https://github.com/jenkinsci/docker/issues/1890
+$dockerComposeFile = 'build-windows.yaml'
+if ($JenkinsVersion -match '^\d+\.\d+\.\d+$') {
+    $dockerComposeFile = 'build-windows-lts-with-jdk11.yaml'
+}
+$baseDockerCmd = 'docker-compose --file={0}' -f $dockerComposeFile
 $baseDockerBuildCmd = '{0} build --parallel --pull' -f $baseDockerCmd
 
 Write-Host "= PREPARE: List of $Organisation/$Repository images and tags to be processed:"


### PR DESCRIPTION
This PR removes the Java 11 images from the weekly release line by using new images definitions containing Java 11 for LTS release line until Java 17 is required on every lines. ("linux-lts-with-jdk11" docker bake target & "build-windows-lts-with-jdk11.yaml" docker compose file)
See https://github.com/jenkinsci/docker/pull/1891/commits/97c732b4eae040616900a3707c425a85447b6492

It also add a mechanism to easily simulate a LTS build on ci.jenkins.io (with images publication disabled out of caution even if it happens on trusted.ci.jenkins.io) by setting in a replay `SIMULATE_LTS_BUILD` to `true`.
See https://github.com/jenkinsci/docker/pull/1891/commits/dcbd563bad436ccdbae596cd68acfdb36548ed59?w=1

We can remove this code after Java 11 EOL.

Notes:
- Merging this pull request means there won't be any weekly release for the Almalinux Java 11 image.
- "Hide whitespace" recommended: https://github.com/jenkinsci/docker/pull/1891/files?w=1

Fixes:
- #1890 

### Testing done

#### Local tests

<details><summary>.ci/publis.sh</summary>

```console
$ JENKINS_VERSION=2.442 make publish
./.ci/publish.sh
Using the following settings:
* JENKINS_REPO: jenkins/jenkins
* JENKINS_VERSION: 2.442
* JENKINS_SHA: b0bc35b59ca923629cc440d79bebfa78d67cd0448c7a485168fc2719ac445e7b
* COMMIT_SHA: dbc09a35f9008b00ed98e23de8a7598c5e1cb074
* LATEST_WEEKLY: false
* LATEST_LTS: false
* TARGET: linux
#0 building with "desktop-linux" instance using docker driver
<...>

$ JENKINS_VERSION=2.452.1 make publish 
./.ci/publish.sh
Using the following settings:
* JENKINS_REPO: jenkins/jenkins
* JENKINS_VERSION: 2.452.1
* JENKINS_SHA: d9ec867a35987b545c82ed0df5d2240ac208a8d06e065e9cdb869464f3b87a56
* COMMIT_SHA: dbc09a35f9008b00ed98e23de8a7598c5e1cb074
* LATEST_WEEKLY: false
* LATEST_LTS: true
* TARGET: linux-lts-with-jdk11
#0 building with "desktop-linux" instance using docker driver
<...>
```

</details>

<details><summary>"list" make function used by other make targets</summary>
<br>
With the same main architecture as agents:

```console
$ ARCH=amd64 TARGET=linux make list 
+ make --silent show
+ jq -r '.target | path(.. | select(.platforms[] | contains("linux/amd64"))?) | add'
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 10.42kB / 10.42kB done
#1 DONE 0.0s
alpine_jdk17
alpine_jdk21
debian_jdk17
debian_jdk21
debian_slim_jdk17
debian_slim_jdk21
rhel_ubi9_jdk17
rhel_ubi9_jdk21


$ ARCH=amd64 TARGET=linux-lts-with-jdk11 make list                              
+ make --silent show
+ jq -r '.target | path(.. | select(.platforms[] | contains("linux/amd64"))?) | add'
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 10.42kB / 10.42kB done
#1 DONE 0.0s
almalinux_jdk11
alpine_jdk21
debian_jdk11
debian_jdk17
debian_jdk21
debian_slim_jdk21
rhel_ubi8_jdk11
rhel_ubi9_jdk17
rhel_ubi9_jdk21
```

</details>

<details><summary>Build tests depending on the bake target</summary>
<br>
With second call failing as expected:

```console
$ ARCH=amd64 TARGET=linux-lts-with-jdk11 make build-debian_jdk11
<build logs OK>

$ ARCH=amd64 TARGET=linux make build-debian_jdk11
+ make --silent show
+ jq -r '.target | path(.. | select(.platforms[] | contains("linux/amd64"))?) | add'
#1 [internal] load local bake definitions
#1 reading docker-bake.hcl 10.42kB / 10.42kB done
#1 DONE 0.0s
Error: the image 'debian_jdk11' does not exist in manifest for the platform 'linux/amd64'. Please check the output of 'make list'. Exiting.

$ ARCH=amd64 TARGET=linux-lts-with-jdk11 make build-debian_jdk17
<build logs OK>

$ ARCH=arm64 TARGET=linux-lts-with-jdk11 make build-debian_jdk17
<build logs OK>

$ ARCH=amd64 TARGET=linux make build-debian_jdk17
<build logs OK>

$ ARCH=ard64 TARGET=linux make build-debian_jdk17
<build logs OK>
```

</details>

<details><summary>make.ps1</summary>

```console
$ pwsh make.ps1 -JenkinsVersion 2.442 -DryRun
= PREPARE: List of jenkins4eval/jenkins images and tags to be processed:
name: jenkinsci-docker
services:
  jdk17:
    build:
      context: /Users/veve/j-infra/jenkinsci-docker
      dockerfile: ./windows/windowsservercore/hotspot/Dockerfile
      args:
        COMMIT_SHA: dcbd563bad436ccdbae596cd68acfdb36548ed59
        JAVA_HOME: C:/openjdk-17
        JAVA_VERSION: 17.0.11_9
        JENKINS_SHA: B0BC35B59CA923629CC440D79BEBFA78D67CD0448C7A485168FC2719AC445E7B
        JENKINS_VERSION: "2.442"
        TOOLS_WINDOWS_VERSION: "1809"
        WINDOWS_VERSION: ltsc2019
      tags:
        - jenkins4eval/jenkins:2.442-jdk17-hotspot-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:2.442-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:windowsservercore-ltsc2019
    image: jenkins4eval/jenkins:jdk17-hotspot-windowsservercore-ltsc2019
    networks:
      default: null
  jdk21:
    build:
      context: /Users/veve/j-infra/jenkinsci-docker
      dockerfile: ./windows/windowsservercore/hotspot/Dockerfile
      args:
        COMMIT_SHA: dcbd563bad436ccdbae596cd68acfdb36548ed59
        JAVA_HOME: C:/openjdk-21
        JAVA_VERSION: 21.0.3_9
        JENKINS_SHA: B0BC35B59CA923629CC440D79BEBFA78D67CD0448C7A485168FC2719AC445E7B
        JENKINS_VERSION: "2.442"
        TOOLS_WINDOWS_VERSION: "1809"
        WINDOWS_VERSION: ltsc2019
      tags:
        - jenkins4eval/jenkins:2.442-jdk21-hotspot-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:2.442-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:windowsservercore-ltsc2019
    image: jenkins4eval/jenkins:jdk21-hotspot-windowsservercore-ltsc2019
    networks:
      default: null
networks:
  default:
    name: jenkinsci-docker_default
= BUILD: Building all images...
(dry-run) docker-compose --file=build-windows.yaml build --parallel --pull
= BUILD: Finished building all images.
Build finished successfully
```
```console
$ pwsh make.ps1 -JenkinsVersion 2.452.1 -DryRun
= PREPARE: List of jenkins4eval/jenkins images and tags to be processed:
name: jenkinsci-docker
services:
  jdk11:
    build:
      context: /Users/veve/j-infra/jenkinsci-docker
      dockerfile: ./windows/windowsservercore/hotspot/Dockerfile
      args:
        COMMIT_SHA: dcbd563bad436ccdbae596cd68acfdb36548ed59
        JAVA_HOME: C:/openjdk-11
        JAVA_VERSION: 11.0.23_9
        JENKINS_SHA: D9EC867A35987B545C82ED0DF5D2240AC208A8D06E065E9CDB869464F3B87A56
        JENKINS_VERSION: 2.452.1
        TOOLS_WINDOWS_VERSION: "1809"
        WINDOWS_VERSION: ltsc2019
      tags:
        - jenkins4eval/jenkins:2.452.1-jdk11-hotspot-windowsservercore-ltsc2019
    image: jenkins4eval/jenkins:lts-jdk11-hotspot-windowsservercore-ltsc2019
    networks:
      default: null
  jdk17:
    build:
      context: /Users/veve/j-infra/jenkinsci-docker
      dockerfile: ./windows/windowsservercore/hotspot/Dockerfile
      args:
        COMMIT_SHA: dcbd563bad436ccdbae596cd68acfdb36548ed59
        JAVA_HOME: C:/openjdk-17
        JAVA_VERSION: 17.0.11_9
        JENKINS_SHA: D9EC867A35987B545C82ED0DF5D2240AC208A8D06E065E9CDB869464F3B87A56
        JENKINS_VERSION: 2.452.1
        TOOLS_WINDOWS_VERSION: "1809"
        WINDOWS_VERSION: ltsc2019
      tags:
        - jenkins4eval/jenkins:2.452.1-jdk17-hotspot-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:2.452.1-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:lts-windowsservercore-ltsc2019
    image: jenkins4eval/jenkins:lts-jdk17-hotspot-windowsservercore-ltsc2019
    networks:
      default: null
  jdk21:
    build:
      context: /Users/veve/j-infra/jenkinsci-docker
      dockerfile: ./windows/windowsservercore/hotspot/Dockerfile
      args:
        COMMIT_SHA: dcbd563bad436ccdbae596cd68acfdb36548ed59
        JAVA_HOME: C:/openjdk-21
        JAVA_VERSION: 21.0.3_9
        JENKINS_SHA: D9EC867A35987B545C82ED0DF5D2240AC208A8D06E065E9CDB869464F3B87A56
        JENKINS_VERSION: 2.452.1
        TOOLS_WINDOWS_VERSION: "1809"
        WINDOWS_VERSION: ltsc2019
      tags:
        - jenkins4eval/jenkins:2.452.1-jdk21-hotspot-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:2.452.1-windowsservercore-ltsc2019
        - jenkins4eval/jenkins:lts-windowsservercore-ltsc2019
    image: jenkins4eval/jenkins:lts-jdk21-hotspot-windowsservercore-ltsc2019
    networks:
      default: null
networks:
  default:
    name: jenkinsci-docker_default
= BUILD: Building all images...
(dry-run) docker-compose --file=build-windows-lts-with-jdk11.yaml build --parallel --pull
= BUILD: Finished building all images.
Build finished successfully
```

</details>

#### On ci.jenkins.io

- Normal/"weekly" build not including any Java 11 images: https://ci.jenkins.io/job/Packaging/job/docker/job/PR-1891/41/
- Emulated "LTS" build with a replay setting `SIMULATE_LTS_BUILD` to `true`:
  - Diff: https://ci.jenkins.io/job/Packaging/job/docker/job/PR-1891/42/replay/diff
  - Build including Java 11 images: https://ci.jenkins.io/job/Packaging/job/docker/job/PR-1891/42/

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
