### PR TITLE
hotfix(updatecli): adapt jdk manifests to also target build-windows-lts-with-jdk11.yaml

### DIFF
--- a/updatecli/updatecli.d/jdk11.yaml
+++ b/updatecli/updatecli.d/jdk11.yaml
@@ -64,7 +64,7 @@ targets:
     name: "Bump JDK11 version in build-windows.yaml"
     kind: yaml
     spec:
-      file: build-windows.yaml
+      file: build-windows-lts-with-jdk11.yaml
       key: $.services.jdk11.build.args.JAVA_VERSION
     scmid: default
   ## Dockerfiles

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -66,7 +66,9 @@ targets:
     name: "Bump JDK17 version in build-windows.yaml"
     kind: yaml
     spec:
-      file: build-windows.yaml
+      files:
+        - build-windows.yaml
+        - build-windows-lts-with-jdk11.yaml
       key: $.services.jdk17.build.args.JAVA_VERSION
     scmid: default
   ## Dockerfiles

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -64,7 +64,9 @@ targets:
     name: "Bump JDK21 version in build-windows.yaml"
     kind: yaml
     spec:
-      file: build-windows.yaml
+      files:
+        - build-windows.yaml
+        - build-windows-lts-with-jdk11.yaml
       key: $.services.jdk21.build.args.JAVA_VERSION
     scmid: default
 


### PR DESCRIPTION
This PR is a hotfix of:
- The jdk11 updatecli manifest to target build-windows-lts-with-jdk11.yaml instead of build-windows.yaml which doesn't contain jdk11 image definition anymore since #1891
- The jdk17 and jdk21 manifests to target both docker compose files

Hotfix of:
- #1891

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
