### PR TITLE
Use 'ENV variable=xxx' instead of 'ENV variable xxx'

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ FROM jenkins/jenkins:lts-jdk17
 
 COPY --chown=jenkins:jenkins certificate.pfx /var/lib/jenkins/certificate.pfx
 COPY --chown=jenkins:jenkins https.key /var/lib/jenkins/pk
-ENV JENKINS_OPTS --httpPort=-1 --httpsPort=8083 --httpsKeyStore=/var/lib/jenkins/certificate.pfx --httpsKeyStorePassword=Password12
+ENV JENKINS_OPTS="--httpPort=-1 --httpsPort=8083 --httpsKeyStore=/var/lib/jenkins/certificate.pfx --httpsKeyStorePassword=Password12"
 EXPOSE 8083
 ```
 
@@ -141,7 +141,7 @@ You can also change the default agent port for Jenkins by defining `JENKINS_SLAV
 
 ```
 FROM jenkins/jenkins:lts-jdk17
-ENV JENKINS_SLAVE_AGENT_PORT 50001
+ENV JENKINS_SLAVE_AGENT_PORT=50001
 ```
 
 or as a parameter to docker,

--- a/almalinux/almalinux8/hotspot/Dockerfile
+++ b/almalinux/almalinux8/hotspot/Dockerfile
@@ -29,7 +29,7 @@ RUN jlink \
 
 FROM almalinux:8.10 AS controller
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG TARGETARCH
 ARG COMMIT_SHA
@@ -52,9 +52,9 @@ ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
 ARG REF=/usr/share/jenkins/ref
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-ENV REF $REF
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -85,7 +85,7 @@ RUN curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -100,7 +100,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
@@ -118,10 +118,10 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -55,7 +55,7 @@ RUN apk add --no-cache \
     unzip \
   && git lfs install
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG TARGETARCH
 ARG COMMIT_SHA
@@ -69,9 +69,9 @@ ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
 ARG REF=/usr/share/jenkins/ref
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-ENV REF $REF
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -92,7 +92,7 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -107,7 +107,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
@@ -125,10 +125,10 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
   && rm -rf /var/lib/apt/lists/* \
   && git lfs install
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG TARGETARCH
 ARG COMMIT_SHA
@@ -78,9 +78,9 @@ ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
 ARG REF=/usr/share/jenkins/ref
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-ENV REF $REF
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -101,7 +101,7 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -116,7 +116,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
@@ -134,10 +134,10 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -64,7 +64,7 @@ RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.d
   && rm -rf /var/lib/apt/lists/* \
   && git lfs install
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG TARGETARCH
 ARG COMMIT_SHA
@@ -78,9 +78,9 @@ ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
 ARG REF=/usr/share/jenkins/ref
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-ENV REF $REF
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -101,7 +101,7 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -116,7 +116,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
@@ -134,10 +134,10 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}

--- a/rhel/ubi8/hotspot/Dockerfile
+++ b/rhel/ubi8/hotspot/Dockerfile
@@ -30,7 +30,7 @@ RUN jlink \
 
 FROM registry.access.redhat.com/ubi8/ubi:8.10-901.1717584420 AS controller
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG TARGETARCH
 ARG COMMIT_SHA
@@ -55,9 +55,9 @@ ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
 ARG REF=/usr/share/jenkins/ref
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-ENV REF $REF
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -88,7 +88,7 @@ RUN curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -103,7 +103,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=ttps://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
@@ -121,10 +121,10 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -37,7 +37,7 @@ RUN case "$(jlink --version 2>&1)" in \
 
 FROM registry.access.redhat.com/ubi9/ubi:9.4-1123 AS controller
 
-ENV LANG C.UTF-8
+ENV LANG=C.UTF-8
 
 ARG TARGETARCH
 ARG COMMIT_SHA
@@ -61,9 +61,9 @@ ARG agent_port=50000
 ARG JENKINS_HOME=/var/jenkins_home
 ARG REF=/usr/share/jenkins/ref
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_SLAVE_AGENT_PORT ${agent_port}
-ENV REF $REF
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_SLAVE_AGENT_PORT=${agent_port}
+ENV REF=$REF
 
 # Jenkins is run with user `jenkins`, uid = 1000
 # If you bind mount a volume from the host or a data container,
@@ -94,7 +94,7 @@ RUN curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -109,7 +109,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
@@ -127,10 +127,10 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 COPY --from=jre-build /javaruntime $JAVA_HOME
 
 USER ${user}

--- a/tests/plugins-cli/custom-war/Dockerfile
+++ b/tests/plugins-cli/custom-war/Dockerfile
@@ -1,7 +1,7 @@
 FROM bats-jenkins
 
 # Define a custom location for the war
-ENV JENKINS_WAR /test-custom-dockerfile/my-custom-jenkins.war
+ENV JENKINS_WAR=/test-custom-dockerfile/my-custom-jenkins.war
 WORKDIR /test-custom-dockerfile
 # Add there a new weird plugin to assert
 COPY --chown=jenkins:jenkins WEB-INF/ WEB-INF/

--- a/tests/plugins-cli/custom-war/Dockerfile-windows
+++ b/tests/plugins-cli/custom-war/Dockerfile-windows
@@ -2,7 +2,7 @@ FROM bats-jenkins
 # hadolint shell=powershell
 
 # Define a custom location for the war
-ENV JENKINS_WAR C:/ProgramData/TestCustomDockerfile/my-custom-jenkins.war
+ENV JENKINS_WAR=C:/ProgramData/TestCustomDockerfile/my-custom-jenkins.war
 WORKDIR C:/ProgramData/TestCustomDockerfile
 # Add there a new weird plugin to assert
 COPY WEB-INF/ WEB-INF/

--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -66,8 +66,8 @@ ARG JENKINS_HOME=C:/ProgramData/Jenkins/JenkinsHome
 
 ARG COMMIT_SHA
 
-ENV JENKINS_HOME $JENKINS_HOME
-ENV JENKINS_AGENT_PORT ${agent_port}
+ENV JENKINS_HOME=$JENKINS_HOME
+ENV JENKINS_AGENT_PORT=${agent_port}
 
 # Jenkins home directory is a volume, so configuration and build history
 # can be persisted and survive image upgrades
@@ -97,7 +97,7 @@ RUN New-Item -ItemType Directory -Force -Path C:/ProgramData/Jenkins/Reference/i
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION ${JENKINS_VERSION:-2.442}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.442}
 
 # jenkins.war checksum, download will be validated using it
 ARG JENKINS_SHA=b4f596923eb37b93c3f5a21a6a32fc3bedd57d04a1b63186811c0ce8b3d9f07c
@@ -110,7 +110,7 @@ ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-w
 RUN Invoke-WebRequest -Uri "$env:JENKINS_URL" -OutFile C:/ProgramData/Jenkins/jenkins.war ; `
     if ((Get-FileHash C:/ProgramData/Jenkins/jenkins.war -Algorithm SHA256).Hash -ne $env:JENKINS_SHA) {exit 1}
 
-ENV JENKINS_UC https://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 
@@ -126,7 +126,7 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-ENV COPY_REFERENCE_FILE_LOG $JENKINS_HOME/copy_reference_file.log
+ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 COPY jenkins-support.psm1 C:/ProgramData/Jenkins
 COPY jenkins.ps1 C:/ProgramData/Jenkins


### PR DESCRIPTION
## Use `ENV variable=xxx` instead of `ENV variable xxx`

The [Docker ENV documentation](https://docs.docker.com/reference/dockerfile/#env) says:

> The ENV instruction also allows an alternative syntax ENV <key> <value>, omitting the =.

> This syntax does not allow for multiple environment-variables to be set in a single ENV instruction, and can be confusing.

> The alternative syntax is supported for backward compatibility, but discouraged for the reasons outlined above, and may be removed in a future release.

Recent versions of `docker build` now issue a warning about the use of the older syntax.  Rather than have warnings displayed in our builds, let's switch to the newer syntax.

### Testing done

* Successfully ran `make build` and `make test` on my Linux
* Successfully transitioned my personal container definitions to new syntax without issue

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
