### PR TITLE
Add finished date to copy_reference_file.log

### DIFF
--- a/jenkins.ps1
+++ b/jenkins.ps1
@@ -13,6 +13,7 @@ try {
 
 Add-Content -Path $COPY_REFERENCE_FILE_LOG -Value "--- Copying files at $(Get-Date)"
 Get-ChildItem -Recurse -File -Path 'C:/ProgramData/Jenkins/Reference' | ForEach-Object { Copy-ReferenceFile $_.FullName }
+Add-Content -Path $COPY_REFERENCE_FILE_LOG -Value "--- Copied files finished at $(Get-Date)"
 
 # if `docker run` first argument starts with `--` the user is passing jenkins launcher arguments
 if(($args.Count -eq 0) -or ($args[0] -match "^--.*")) {

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -11,6 +11,7 @@ fi
 touch "${COPY_REFERENCE_FILE_LOG}" || { echo "Can not write to ${COPY_REFERENCE_FILE_LOG}. Wrong volume permissions?"; exit 1; }
 echo "--- Copying files at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 find "${REF}" \( -type f -o -type l \) -exec bash -c '. /usr/local/bin/jenkins-support; for arg; do copy_reference_file "$arg"; done' _ {} +
+echo "--- Copied files finished at $(date)" >> "$COPY_REFERENCE_FILE_LOG"
 
 # if `docker run` first argument start with `--` the user is passing jenkins launcher arguments
 if [[ $# -lt 1 ]] || [[ "$1" == "--"* ]]; then


### PR DESCRIPTION
I'm unvestigating some issue with one of my controller that the copy reference function take much more time that usual. It's probably due to something in my infra.

In order to compare timeout I would like to have the end date/time when reference are copied into the volume.

The `copy_reference_file.log` already contains the start date/time and would be useful to also have the end time

### Testing done

Didn't test but I don't expect any side effect for adding a log

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
