### PR TITLE
fix break in the update center var.

### DIFF
--- a/rhel/ubi8/hotspot/Dockerfile
+++ b/rhel/ubi8/hotspot/Dockerfile
@@ -103,7 +103,7 @@ RUN curl -fsSL ${JENKINS_URL} -o /usr/share/jenkins/jenkins.war \
   && sha256sum -c --strict /tmp/jenkins_sha \
   && rm -f /tmp/jenkins_sha
 
-ENV JENKINS_UC=ttps://updates.jenkins.io
+ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"


### PR DESCRIPTION
The following PR is to address a bug that has been observed when trying to install the latest stable release helm chart for the ubi8 flavor of docker images. 

The error is as follows below:

└─$ kubectl logs -f -n cicd jenkins-0 -c init
disable Setup Wizard
download plugins
File containing list of plugins to be downloaded: /var/jenkins_home/plugins.txt
Reading in plugins from /var/jenkins_home/plugins.txt

No directory to download plugins entered. Will use default of /usr/share/jenkins/ref/plugins
java.lang.RuntimeException: java.net.MalformedURLException: unknown protocol: ttps
        at io.jenkins.tools.pluginmanager.cli.CliOptions.getUpdateCenter(CliOptions.java:373)
        at io.jenkins.tools.pluginmanager.cli.CliOptions.setup(CliOptions.java:168)
        at io.jenkins.tools.pluginmanager.cli.Main.main(Main.java:53)
Caused by: java.net.MalformedURLException: unknown protocol: ttps
        at java.base/java.net.URL.<init>(Unknown Source)
        at java.base/java.net.URL.<init>(Unknown Source)
        at java.base/java.net.URL.<init>(Unknown Source)
        at io.jenkins.tools.pluginmanager.cli.CliOptions.getUpdateCenter(CliOptions.java:361)
        ... 2 more
java.net.MalformedURLException: unknown protocol: ttps
