### PR TITLE
fix: Adapt to recent changes in JDK download URL response

### DIFF
--- a/jdk-download-url.sh
+++ b/jdk-download-url.sh
@@ -74,7 +74,7 @@ for ARCH in $ARCHS; do
     URL="https://api.adoptium.net/v3/binary/version/jdk-${ENCODED_ARCHIVE_DIRECTORY}/${OS_TYPE}/${ARCH}/jdk/hotspot/normal/eclipse?project=jdk"
 
     if ! RESPONSE=$(curl -fsI "$URL"); then
-        echo "Error: Failed to fetch the URL for architecture ${ARCH}. Exiting with status 1." >&2
+        echo "Error: Failed to fetch the URL for architecture ${ARCH} from ${URL}. Exiting with status 1." >&2
         echo "Response: $RESPONSE" >&2
         exit 1
     fi
@@ -84,7 +84,7 @@ for ARCH in $ARCHS; do
 
     # If no redirect URL was found, exit the script with an error message
     if [ -z "$REDIRECTED_URL" ]; then
-        echo "Error: No redirect URL found for architecture ${ARCH}. Exiting with status 1." >&2
+        echo "Error: No redirect URL found for architecture ${ARCH} from ${URL}. Exiting with status 1." >&2
         echo "Response: $RESPONSE" >&2
         exit 1
     fi

--- a/jdk-download-url.sh
+++ b/jdk-download-url.sh
@@ -80,7 +80,7 @@ for ARCH in $ARCHS; do
     fi
 
     # Extract the redirect URL from the HTTP response
-    REDIRECTED_URL=$(echo "$RESPONSE" | grep Location | awk '{print $2}' | tr -d '\r')
+    REDIRECTED_URL=$(echo "$RESPONSE" | grep -i location | awk '{print $2}' | tr -d '\r')
 
     # If no redirect URL was found, exit the script with an error message
     if [ -z "$REDIRECTED_URL" ]; then


### PR DESCRIPTION
## fix: Adapt to recent changes in JDK download URL response
    
Parse the JDK redirect URL for a case insensitive redirect location

[Mozilla documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/307) shows the HTTP 307 response as:

> location: /en-US/docs/Learn/JavaScript/Client-side_web_APIs/Fetching_data
> content-type: text/plain; charset=utf-8
> date: Fri, 19 Jul 2024 12:57:17 GMT

Previously, the response must have used "Location:" rather than "location:"

Include URL in download failure error message

Much easier to diagnose failures if the requesting URL is included in the message.  Since the failure will end that portion of the build job, the extra verbosity is not additionally harmful.

### Testing done

Confirmed that `make build` fails without this change and that it succeeds with this change.  Builds are currently failing on the master branch.

Rely on ci.jenkins.io for deeper testing.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
