### PR TITLE
Install git-lfs from tar.gz instead of packagecloud

### DIFF
--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -54,13 +54,17 @@ RUN apt-get update \
     tzdata \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh -o /tmp/script.deb.sh \
-  && bash /tmp/script.deb.sh \
-  && rm -f /tmp/script.deb.sh \
-  && apt-get install -y --no-install-recommends \
-    git-lfs \
-  && rm -rf /var/lib/apt/lists/* \
-  && git lfs install
+# Git LFS is not available from a package manager on all the platforms we support
+# Download and unpack the tar.gz distribution
+RUN tmpdir=$(mktemp -d) \
+  && git_lfs_ver=3.6.0 \
+  && arch=$(uname -m | sed -e 's,x86_64,amd64,g' -e 's,aarch64,arm64,g') \
+  && cd $tmpdir \
+  && curl -L -s https://github.com/git-lfs/git-lfs/releases/download/v${git_lfs_ver}/git-lfs-linux-${arch}-v${git_lfs_ver}.tar.gz | tar xzf - \
+  && cd git-lfs-$git_lfs_ver \
+  && bash ./install.sh \
+  && cd .. \
+  && rm -rf $tmpdir
 
 ENV LANG=C.UTF-8
 

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -54,13 +54,17 @@ RUN apt-get update \
     tzdata \
   && rm -rf /var/lib/apt/lists/*
 
-RUN curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh -o /tmp/script.deb.sh \
-  && bash /tmp/script.deb.sh \
-  && rm -f /tmp/script.deb.sh \
-  && apt-get install -y --no-install-recommends \
-    git-lfs \
-  && rm -rf /var/lib/apt/lists/* \
-  && git lfs install
+# Git LFS is not available from a package manager on all the platforms we support
+# Download and unpack the tar.gz distribution
+RUN tmpdir=$(mktemp -d) \
+  && git_lfs_ver=3.6.0 \
+  && arch=$(uname -m | sed -e 's,x86_64,amd64,g' -e 's,aarch64,arm64,g') \
+  && cd $tmpdir \
+  && curl -L -s https://github.com/git-lfs/git-lfs/releases/download/v${git_lfs_ver}/git-lfs-linux-${arch}-v${git_lfs_ver}.tar.gz | tar xzf - \
+  && cd git-lfs-$git_lfs_ver \
+  && bash ./install.sh \
+  && cd .. \
+  && rm -rf $tmpdir
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
## Install git-lfs from tar.gz instead of packagecloud

Install fails from packagecloud on one or more of the required platforms

Use tar.gz for Debian because it is not available from packagecloud.

Fixes #1953

### Testing done

Confirmed that the container builds complete successfully and that the `git lfs version` output reports 3.6.0 as expected.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
