### PR TITLE
chore: add `git-lfs` updatecli manifest

### DIFF
--- a/updatecli/updatecli.d/git-lfs.yaml
+++ b/updatecli/updatecli.d/git-lfs.yaml
@@ -1,0 +1,52 @@
+---
+name: Bump `git-lfs` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastReleaseVersion:
+    kind: githubrelease
+    name: Get the latest `git-lfs` release version
+    spec:
+      owner: "git-lfs"
+      repository: "git-lfs"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: v
+
+targets:
+  updateVersion:
+    name: Update `git-lfs` version in debian dockerfiles
+    sourceid: lastReleaseVersion
+    kind: dockerfile
+    spec:
+      files:
+        - debian/bookworm/hotspot/Dockerfile
+        - debian/bookworm/hotspot/Dockerfile
+      instruction:
+        keyword: "ARG"
+        matcher: "GIT_LFS_VERSION"
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `git-lfs` version to {{ source "lastReleaseVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+        - git-lfs


### PR DESCRIPTION
This PR adds an updatecli manifest to track `git-lfs` version in Debian images.

Follow-up of:
- #1954 

### Testing done

Ran `updatecli diff` locally
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
