### PR TITLE
chore: fix "FromAsCasing: 'as' and 'FROM' keywords' casing do not match" warning

### DIFF
--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG BOOKWORM_TAG=20241111
 
-FROM debian:bookworm-"${BOOKWORM_TAG}"-slim as jre-build
+FROM debian:bookworm-"${BOOKWORM_TAG}"-slim AS jre-build
 
 ARG JAVA_VERSION=17.0.13_11
 

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -1,6 +1,6 @@
 ARG BOOKWORM_TAG=20241111
 
-FROM debian:bookworm-"${BOOKWORM_TAG}" as jre-build
+FROM debian:bookworm-"${BOOKWORM_TAG}" AS jre-build
 
 ARG JAVA_VERSION=17.0.13_11
 

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5 as jre-build
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS jre-build
 
 ARG JAVA_VERSION=17.0.13_11
 


### PR DESCRIPTION
This PR fixes this warning shown in docker build logs by putting incriminated `as` in uppercase.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
