### PR TITLE
chore(updatecli): Duplicate file path in targets configuration.

### DIFF
--- a/updatecli/updatecli.d/git-lfs.yaml
+++ b/updatecli/updatecli.d/git-lfs.yaml
@@ -35,7 +35,7 @@ targets:
     spec:
       files:
         - debian/bookworm/hotspot/Dockerfile
-        - debian/bookworm/hotspot/Dockerfile
+        - debian/bookworm-slim/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "GIT_LFS_VERSION"


### PR DESCRIPTION
This is a follow-up to PR #1955, as there appears to be a typo in it, involving a repeated file path.

### Testing done

```
updatecli diff --config ./updatecli/updatecli.d/git-lfs.yaml --values ./updatecli/values.github-a
ction.yaml 2>&1
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
