### PR TITLE
Use most recent UBI 9 container image

### DIFF
--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5 AS jre-build
+FROM registry.access.redhat.com/ubi9/ubi:9.5-1734081738 AS jre-build
 
 ARG JAVA_VERSION=17.0.13_11
 
@@ -33,7 +33,7 @@ RUN case "$(jlink --version 2>&1)" in \
       --no-header-files \
       --output /javaruntime
 
-FROM registry.access.redhat.com/ubi9/ubi:9.5 AS controller
+FROM registry.access.redhat.com/ubi9/ubi:9.5-1734081738 AS controller
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
## Use most recent UBI 9 container image

Dependabot should have detected this container image update, but it did not.  Dependabot did not miss these updates in the platformlabeler repository, where a simpler syntax is used for the test data containers.

I'm not sure if that is due to the AS clause or some other reason, but we want to use the most recent UBI 9 container image as a base, so this pull request makes sense in any case.

Latest image released 2 days ago from https://catalog.redhat.com/software/containers/ubi9/ubi/615bcf606feffc5384e8452e

### Testing done

None.  Rely on ci.jenkins.io to check the new container image.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
