### PR TITLE
chore: use TOML config with buildx to avoid DockerHub rate limits

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,7 @@ stage('Build') {
 		    stage('Multi arch build') {
 			infra.withDockerCredentials {
 			    sh '''
-				docker buildx create --use
-				docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+				make docker-init
 				docker buildx bake --file docker-bake.hcl linux
 			    '''
 			}
@@ -184,11 +183,7 @@ stage('Build') {
 				// Publication is enabled by default, disabled when simulating a LTS
 				if (env.PUBLISH == "true") {
 				    infra.withDockerCredentials {
-					sh '''
-					    docker buildx create --use
-					    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-					    make publish
-					    '''
+						sh 'make docker-init publish'
 				    }
 				}
 			    }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -181,7 +181,8 @@ stage('Build') {
                                 // Publication is enabled by default, disabled when simulating a LTS
                                 if (env.PUBLISH == 'true') {
                                     infra.withDockerCredentials {
-                                        sh 'make docker-init publish'
+                                        sh 'make docker-init'
+                                        sh 'make publish'
                                     }
                                 }
                             }

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,20 @@ check-reqs:
 	@$(call check_cli,curl)
 	@$(call check_cli,jq)
 
+## This function is specific to Jenkins infrastructure and isn't required in other contexts
+docker-init: check-reqs
+ifeq ($(CI),true)
+ifeq ($(wildcard /etc/buildkitd.toml),)
+	echo 'WARNING: /etc/buildkitd.toml not found, using default configuration.'
+	docker buildx create --use --bootstrap --driver docker-container
+else
+	docker buildx create --use --bootstrap --driver docker-container --config /etc/buildkitd.toml
+endif
+else
+	docker buildx create --use --bootstrap --driver docker-container
+endif
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
 hadolint:
 	find . -type f -name 'Dockerfile*' -not -path "./bats/*" -print0 | xargs -0 $(ROOT_DIR)/tools/hadolint
 


### PR DESCRIPTION
This PR uses TOM config with buildx if executed on CI and if `/etc/buildkitd.toml` file exists to use registry mirrors.

~Pipeline reformated as there were a mix of tabs and spaces rendering the indentation less readable.~
~(Review with whitespace hidden: https://github.com/jenkinsci/docker/pull/2002/files?diff=unified&w=1)~
(Extracted in #2003)

Similar to:
- https://github.com/jenkinsci/docker-agent/pull/958
- https://github.com/jenkinsci/docker-ssh-agent/pull/501

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/4585#issuecomment-2751406309
- https://github.com/jenkins-infra/jenkins-infra/pull/3938
- https://docs.docker.com/build/buildkit/configure/#registry-mirror

### Testing done

`make docker-init` + CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
