### PR TITLE
chore: format Jenkinsfile

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view
+# Format Jenkinsfile: https://github.com/jenkinsci/docker/pull/2003
+9ade9569a658c0ed27107915d7597fcc98d7a577

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ H 6,21 * * 3''')])
 properties(listOfProperties)
 
 // Default environment variable set to allow images publication
-def envVars = ["PUBLISH=true"]
+def envVars = ['PUBLISH=true']
 
 // Set to true in a replay to simulate a LTS build on ci.jenkins.io
 // It will set the environment variables needed for a LTS
@@ -21,184 +21,182 @@ def SIMULATE_LTS_BUILD = false
 
 if (SIMULATE_LTS_BUILD) {
     envVars = [
-        "PUBLISH=false",
-        "TAG_NAME=2.462.3",
-        "JENKINS_VERSION=2.462.3",
-        "JENKINS_SHA=3e53b52a816405e3b10ad07f1c48cd0cb5cb3f893207ef7f9de28415806b93c1"
+        'PUBLISH=false',
+        'TAG_NAME=2.462.3',
+        'JENKINS_VERSION=2.462.3',
+        'JENKINS_SHA=3e53b52a816405e3b10ad07f1c48cd0cb5cb3f893207ef7f9de28415806b93c1'
     ]
 }
 
 stage('Build') {
     def builds = [:]
 
-    withEnv (envVars) {
-        echo "= bake target: linux"
+    withEnv(envVars) {
+        echo '= bake target: linux'
 
-	def windowsImageTypes = [
-	    'windowsservercore-ltsc2019',
-	]
-	for (anImageType in windowsImageTypes) {
-	    def imageType = anImageType
-	    builds[imageType] = {
-		nodeWithTimeout('windows-2019') {
-		    stage('Checkout') {
-			checkout scm
-		    }
+        def windowsImageTypes = ['windowsservercore-ltsc2019']
+        for (anImageType in windowsImageTypes) {
+            def imageType = anImageType
+            builds[imageType] = {
+                nodeWithTimeout('windows-2019') {
+                    stage('Checkout') {
+                        checkout scm
+                    }
 
-		    withEnv(["IMAGE_TYPE=${imageType}"]) {
-			if (!infra.isTrusted()) {
-			    /* Outside of the trusted.ci environment, we're building and testing
-			    * the Dockerfile in this repository, but not publishing to docker hub
-			    */
-			    stage("Build ${imageType}") {
-				infra.withDockerCredentials {
-				    powershell './make.ps1'
-				}
-			    }
+                    withEnv(["IMAGE_TYPE=${imageType}"]) {
+                        if (!infra.isTrusted()) {
+                            /* Outside of the trusted.ci environment, we're building and testing
+                            * the Dockerfile in this repository, but not publishing to docker hub
+                            */
+                            stage("Build ${imageType}") {
+                                infra.withDockerCredentials {
+                                    powershell './make.ps1'
+                                }
+                            }
 
-			    stage("Test ${imageType}") {
-				infra.withDockerCredentials {
-				    def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
-				    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
-				    if (windowsTestStatus > 0) {
-					// If something bad happened let's clean up the docker images
-					error('Windows test stage failed.')
-				    }
-				}
-			    }
+                            stage("Test ${imageType}") {
+                                infra.withDockerCredentials {
+                                    def windowsTestStatus = powershell(script: './make.ps1 test', returnStatus: true)
+                                    junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/**/junit-results.xml')
+                                    if (windowsTestStatus > 0) {
+                                        // If something bad happened let's clean up the docker images
+                                        error('Windows test stage failed.')
+                                    }
+                                }
+                            }
 
-			    // disable until we get the parallel changes merged in
-			    // def branchName = "${env.BRANCH_NAME}"
-			    // if (branchName ==~ 'master'){
-			    //    stage('Publish Experimental') {
-			    //        infra.withDockerCredentials {
-			    //            withEnv(['DOCKERHUB_ORGANISATION=jenkins4eval','DOCKERHUB_REPO=jenkins']) {
-			    //                powershell './make.ps1 publish'
-			    //            }
-			    //        }
-			    //    }
-			    // }
-			} else {
-			    // Only publish when a tag triggered the build & the publication is enabled (ie not simulating a LTS)
-			    if (env.TAG_NAME && (env.PUBLISH == "true")) {
-				// Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-				jenkins_version = env.TAG_NAME.split('-')[0]
-				withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
-				    stage('Publish') {
-					infra.withDockerCredentials {
-					    withEnv(['DOCKERHUB_ORGANISATION=jenkins','DOCKERHUB_REPO=jenkins']) {
-						powershell './make.ps1 publish'
-					    }
-					}
-				    }
-				}
-			    }
-			}
-		    }
-		}
-	    }
-	}
+                        // disable until we get the parallel changes merged in
+                        // def branchName = "${env.BRANCH_NAME}"
+                        // if (branchName ==~ 'master'){
+                        //    stage('Publish Experimental') {
+                        //        infra.withDockerCredentials {
+                        //            withEnv(['DOCKERHUB_ORGANISATION=jenkins4eval','DOCKERHUB_REPO=jenkins']) {
+                        //                powershell './make.ps1 publish'
+                        //            }
+                        //        }
+                        //    }
+                        // }
+                        } else {
+                            // Only publish when a tag triggered the build & the publication is enabled (ie not simulating a LTS)
+                            if (env.TAG_NAME && (env.PUBLISH == 'true')) {
+                                // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
+                                jenkins_version = env.TAG_NAME.split('-')[0]
+                                withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                                    stage('Publish') {
+                                        infra.withDockerCredentials {
+                                            withEnv(['DOCKERHUB_ORGANISATION=jenkins', 'DOCKERHUB_REPO=jenkins']) {
+                                                powershell './make.ps1 publish'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-	if (!infra.isTrusted()) {
-	    def images = [
-		'alpine_jdk17',
-		'alpine_jdk21',
-		'debian_jdk17',
-		'debian_jdk21',
-		'debian_slim_jdk17',
-		'debian_slim_jdk21',
-		'rhel_ubi9_jdk17',
-		'rhel_ubi9_jdk21',
-	    ]
-	    for (i in images) {
-		def imageToBuild = i
+        if (!infra.isTrusted()) {
+            def images = [
+                'alpine_jdk17',
+                'alpine_jdk21',
+                'debian_jdk17',
+                'debian_jdk21',
+                'debian_slim_jdk17',
+                'debian_slim_jdk21',
+                'rhel_ubi9_jdk17',
+                'rhel_ubi9_jdk21',
+            ]
+            for (i in images) {
+                def imageToBuild = i
 
-		builds[imageToBuild] = {
-		    nodeWithTimeout('docker') {
-			deleteDir()
+                builds[imageToBuild] = {
+                    nodeWithTimeout('docker') {
+                        deleteDir()
 
-			stage('Checkout') {
-			    checkout scm
-			}
+                        stage('Checkout') {
+                            checkout scm
+                        }
 
-			stage('Static analysis') {
-			    sh 'make hadolint shellcheck'
-			}
+                        stage('Static analysis') {
+                            sh 'make hadolint shellcheck'
+                        }
 
-			/* Outside of the trusted.ci environment, we're building and testing
-			* the Dockerfile in this repository, but not publishing to docker hub
-			*/
-			stage("Build linux-${imageToBuild}") {
-			    infra.withDockerCredentials {
-				sh "make build-${imageToBuild}"
-			    }
-			}
+                        /* Outside of the trusted.ci environment, we're building and testing
+                        * the Dockerfile in this repository, but not publishing to docker hub
+                        */
+                        stage("Build linux-${imageToBuild}") {
+                            infra.withDockerCredentials {
+                                sh "make build-${imageToBuild}"
+                            }
+                        }
 
-			stage("Test linux-${imageToBuild}") {
-			    sh "make prepare-test"
-			    try {
-				infra.withDockerCredentials {
-				    sh "make test-${imageToBuild}"
-				}
-			    } catch (err) {
-				error("${err.toString()}")
-			    } finally {
-				junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
-			    }
-			}
-		    }
-		}
-	    }
-	    builds['multiarch-build'] = {
-		nodeWithTimeout('docker') {
-		    stage('Checkout') {
-			deleteDir()
-			checkout scm
-		    }
+                        stage("Test linux-${imageToBuild}") {
+                            sh 'make prepare-test'
+                            try {
+                                infra.withDockerCredentials {
+                                    sh "make test-${imageToBuild}"
+                                }
+                            } catch (err) {
+                                error("${err.toString()}")
+                            } finally {
+                                junit(allowEmptyResults: true, keepLongStdio: true, testResults: 'target/*.xml')
+                            }
+                        }
+                    }
+                }
+            }
+            builds['multiarch-build'] = {
+                nodeWithTimeout('docker') {
+                    stage('Checkout') {
+                        deleteDir()
+                        checkout scm
+                    }
 
-		    // sanity check that proves all images build on declared platforms
-		    stage('Multi arch build') {
-			infra.withDockerCredentials {
-			    sh '''
-				docker buildx create --use
-				docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-				docker buildx bake --file docker-bake.hcl linux
-			    '''
-			}
-		    }
-		}
-	    }
-	} else {
-	    // Only publish when a tag triggered the build
-	    if (env.TAG_NAME) {
-		// Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-		jenkins_version = env.TAG_NAME.split('-')[0]
-		builds['linux'] = {
-		    withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
-			nodeWithTimeout('docker') {
-			    stage('Checkout') {
-				checkout scm
-			    }
+                    // sanity check that proves all images build on declared platforms
+                    stage('Multi arch build') {
+                        infra.withDockerCredentials {
+                            sh '''
+                            docker buildx create --use
+                            docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                            docker buildx bake --file docker-bake.hcl linux
+                            '''
+                        }
+                    }
+                }
+            }
+        } else {
+            // Only publish when a tag triggered the build
+            if (env.TAG_NAME) {
+                // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
+                jenkins_version = env.TAG_NAME.split('-')[0]
+                builds['linux'] = {
+                    withEnv(["JENKINS_VERSION=${jenkins_version}"]) {
+                        nodeWithTimeout('docker') {
+                            stage('Checkout') {
+                                checkout scm
+                            }
 
-			    stage('Publish') {
-				// Publication is enabled by default, disabled when simulating a LTS
-				if (env.PUBLISH == "true") {
-				    infra.withDockerCredentials {
-					sh '''
-					    docker buildx create --use
-					    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-					    make publish
-					    '''
-				    }
-				}
-			    }
-			}
-		    }
-		}
-	    }
-	}
+                            stage('Publish') {
+                                // Publication is enabled by default, disabled when simulating a LTS
+                                if (env.PUBLISH == 'true') {
+                                    infra.withDockerCredentials {
+                                        sh '''
+                                        docker buildx create --use
+                                        docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+                                        make publish
+                                        '''
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
 
-	parallel builds
+        parallel builds
     }
 }
 


### PR DESCRIPTION
This PR formats the Jenkinsfile pipeline as there were some bad indentations and a mix of tabs and spaces rendering the indentation unreadable in VS Code.
It also uses single quotes where double quotes aren't needed.

It finally adds a .git-blame-ignore-revs file so GitHub could ignores the format commit in the blame view:
- Doc: https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view (can be [bypassed](https://docs.github.com/en/repositories/working-with-files/using-files/viewing-and-understanding-files#ignore-commits-in-the-blame-view))
- Corresponding blame view: https://github.com/jenkinsci/docker/blame/cd4c45957ab3a9e0134f3431813c1e58f2913d11/Jenkinsfile
- Corresponding blame view bypassing this: https://github.com/jenkinsci/docker/blame/cd4c45957ab3a9e0134f3431813c1e58f2913d11~/Jenkinsfile

> [!TIP]
> Review with whitespace hidden: https://github.com/jenkinsci/docker/pull/2003/files?diff=unified&w=1

Extracted from:
- #2002 

### Testing done

CI (no code change)

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
