### PR TITLE
Use CODEOWNERS instead of dependabot reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,3 @@
 * @jenkinsci/team-docker-packaging
-*/rhel/ubi*/ @olivergondza
 */debian/bookworm/hotspot @ksalerno99
 */rhel/ubi9/hotspot @ksalerno99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
     interval: weekly
   open-pull-requests-limit: 2
   target-branch: master
-  reviewers:
-  - MarkEWaite
-  - slide
   labels:
   - dependencies
   ignore:
@@ -27,9 +24,6 @@ updates:
     interval: weekly
   open-pull-requests-limit: 2
   target-branch: master
-  reviewers:
-  - MarkEWaite
-  - slide
   labels:
   - dependencies
   ignore:
@@ -42,9 +36,6 @@ updates:
     interval: weekly
   open-pull-requests-limit: 2
   target-branch: master
-  reviewers:
-  - MarkEWaite
-  - slide
   labels:
   - dependencies
   ignore:
@@ -59,9 +50,6 @@ updates:
     interval: weekly
   open-pull-requests-limit: 2
   target-branch: master
-  reviewers:
-    - olivergondza
-    - slide
   labels:
     - dependencies
   ignore:


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

Same as https://github.com/jenkinsci/parallel-test-executor-plugin/pull/334 Use CODEOWNERS instead of dependabot reviewers

Dependabot is now posting this comment as a warning:

> The reviewers field in the dependabot.yml file will be removed soon. Please use the code owners file to specify reviewers for Dependabot PRs. For more information, see this [blog post](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/)

Resolve that warning by relying on the CODEOWNERS file.

### Testing done

None.  Rely on dependabot syntax checking

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
