### PR TITLE
Use 2.504 as default base version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,8 @@ test-%: prepare-test
 # Execute the test harness and write result to a TAP file
 	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
 # convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:18-alpine \
-		sh -c "npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
+	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:22-alpine \
+		sh -c "npm install -g npm@latest && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -90,10 +90,10 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.479}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.504}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=910ea36cef37c45087e39d65e335988e036fccea47c79cc5a52e721a10cb1b49
+ARG JENKINS_SHA=efc91d6be8d79dd078e7f930fc4a5f135602d0822a5efe9091808fdd74607d32
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -101,10 +101,10 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.479}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.504}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=910ea36cef37c45087e39d65e335988e036fccea47c79cc5a52e721a10cb1b49
+ARG JENKINS_SHA=efc91d6be8d79dd078e7f930fc4a5f135602d0822a5efe9091808fdd74607d32
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -101,10 +101,10 @@ RUN mkdir -p ${REF}/init.groovy.d
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.479}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.504}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=910ea36cef37c45087e39d65e335988e036fccea47c79cc5a52e721a10cb1b49
+ARG JENKINS_SHA=efc91d6be8d79dd078e7f930fc4a5f135602d0822a5efe9091808fdd74607d32
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -43,11 +43,11 @@ group "linux-ppc64le" {
 # ---- variables ----
 
 variable "JENKINS_VERSION" {
-  default = "2.479"
+  default = "2.504"
 }
 
 variable "JENKINS_SHA" {
-  default = "910ea36cef37c45087e39d65e335988e036fccea47c79cc5a52e721a10cb1b49"
+  default = "efc91d6be8d79dd078e7f930fc4a5f135602d0822a5efe9091808fdd74607d32"
 }
 
 variable "REGISTRY" {

--- a/make.ps1
+++ b/make.ps1
@@ -2,7 +2,7 @@
 Param(
     [Parameter(Position=1)]
     [String] $Target = 'build',
-    [String] $JenkinsVersion = '2.479',
+    [String] $JenkinsVersion = '2.504',
     [switch] $DryRun = $false
 )
 

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -92,10 +92,10 @@ RUN curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.479}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.504}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=910ea36cef37c45087e39d65e335988e036fccea47c79cc5a52e721a10cb1b49
+ARG JENKINS_SHA=efc91d6be8d79dd078e7f930fc4a5f135602d0822a5efe9091808fdd74607d32
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war

--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -94,10 +94,10 @@ RUN New-Item -ItemType Directory -Force -Path C:/ProgramData/Jenkins/Reference/i
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.479}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.504}
 
 # jenkins.war checksum, download will be validated using it
-ARG JENKINS_SHA=910ea36cef37c45087e39d65e335988e036fccea47c79cc5a52e721a10cb1b49
+ARG JENKINS_SHA=efc91d6be8d79dd078e7f930fc4a5f135602d0822a5efe9091808fdd74607d32
 
 # Can be used to customize where jenkins.war get downloaded from
 ARG JENKINS_URL=https://repo.jenkins-ci.org/public/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war


### PR DESCRIPTION
## Use Jenkins 2.504 as base version instead of 2.479

- Use Jenkins 2.504 as base version instead of 2.479
- Process test results with latest npm

### Testing done

Ran make build-alpine_jdk17 test-alpine_jdk17 successfully after these changes.  Confirmed the build failed for me without these changes.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
