### PR TITLE
chore: Use the Junit output format of bats

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,10 +100,7 @@ test-%: prepare-test
 # Ensure that the image is built
 	@make --silent build-$*
 # Execute the test harness and write result to a TAP file
-	IMAGE=$* bats/bin/bats $(bats_flags) | tee target/results-$*.tap
-# convert TAP to JUNIT
-	docker run --rm -v "$(CURDIR)":/usr/src/app -w /usr/src/app node:22-alpine \
-		sh -c "npm install -g npm@latest && npm install tap-xunit -g && cat target/results-$*.tap | tap-xunit --package='jenkinsci.docker.$*' > target/junit-results-$*.xml"
+	IMAGE=$* bats/bin/bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
 
 test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -15,6 +15,7 @@ teardown() {
 @test "[${SUT_DESCRIPTION}] test version in docker metadata" {
   local version
   version=$(get_jenkins_version)
+  [ 0 -eq 1 ]
   assert "${version}" docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' $SUT_IMAGE
 }
 

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -15,7 +15,6 @@ teardown() {
 @test "[${SUT_DESCRIPTION}] test version in docker metadata" {
   local version
   version=$(get_jenkins_version)
-  [ 0 -eq 1 ]
   assert "${version}" docker inspect --format '{{ index .Config.Labels "org.opencontainers.image.version"}}' $SUT_IMAGE
 }
 


### PR DESCRIPTION
Avoids requiring an npm package to convert from the TAP format to the Junit format (ref #2022).

Note: aligns bats usage with docker-agent and docker-ssh-agent.