### PR TITLE
breaking(linux) Update debian images to trixie

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @jenkinsci/team-docker-packaging
-*/debian/bookworm/hotspot @ksalerno99
+*/debian/trixie/hotspot @ksalerno99
 */rhel/ubi9/hotspot @ksalerno99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
 # Debian Linux
 
 - package-ecosystem: docker
-  directory: "debian/bookworm/hotspot"
+  directory: "debian/trixie/hotspot"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -31,7 +31,7 @@ updates:
   - dependency-name: "eclipse-temurin"
 
 - package-ecosystem: docker
-  directory: "debian/bookworm-slim/hotspot"
+  directory: "debian/trixie-slim/hotspot"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2

--- a/debian/trixie-slim/hotspot/Dockerfile
+++ b/debian/trixie-slim/hotspot/Dockerfile
@@ -1,6 +1,6 @@
-ARG BOOKWORM_TAG=20250811
+ARG TRIXIE_TAG=20250811
 
-FROM debian:bookworm-"${BOOKWORM_TAG}" AS jre-build
+FROM debian:trixie-"${TRIXIE_TAG}"-slim AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
 
@@ -36,7 +36,7 @@ RUN case "$(jlink --version 2>&1)" in \
       --no-header-files \
       --output /javaruntime
 
-FROM debian:bookworm-"${BOOKWORM_TAG}" AS controller
+FROM debian:trixie-"${TRIXIE_TAG}"-slim AS controller
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/debian/trixie/hotspot/Dockerfile
+++ b/debian/trixie/hotspot/Dockerfile
@@ -1,6 +1,6 @@
-ARG BOOKWORM_TAG=20250811
+ARG TRIXIE_TAG=20250811
 
-FROM debian:bookworm-"${BOOKWORM_TAG}"-slim AS jre-build
+FROM debian:trixie-"${TRIXIE_TAG}" AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
 
@@ -36,7 +36,7 @@ RUN case "$(jlink --version 2>&1)" in \
       --no-header-files \
       --output /javaruntime
 
-FROM debian:bookworm-"${BOOKWORM_TAG}"-slim AS controller
+FROM debian:trixie-"${TRIXIE_TAG}" AS controller
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -90,7 +90,7 @@ variable "JAVA21_VERSION" {
   default = "21.0.8_9"
 }
 
-variable "BOOKWORM_TAG" {
+variable "TRIXIE_TAG" {
   default = "20250811"
 }
 
@@ -167,14 +167,14 @@ target "alpine_jdk21" {
 }
 
 target "debian_jdk17" {
-  dockerfile = "debian/bookworm/hotspot/Dockerfile"
+  dockerfile = "debian/trixie/hotspot/Dockerfile"
   context    = "."
   args = {
     JENKINS_VERSION    = JENKINS_VERSION
     JENKINS_SHA        = JENKINS_SHA
     COMMIT_SHA         = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    BOOKWORM_TAG       = BOOKWORM_TAG
+    TRIXIE_TAG         = TRIXIE_TAG
     JAVA_VERSION       = JAVA17_VERSION
   }
   tags = [
@@ -188,14 +188,14 @@ target "debian_jdk17" {
 }
 
 target "debian_jdk21" {
-  dockerfile = "debian/bookworm/hotspot/Dockerfile"
+  dockerfile = "debian/trixie/hotspot/Dockerfile"
   context    = "."
   args = {
     JENKINS_VERSION    = JENKINS_VERSION
     JENKINS_SHA        = JENKINS_SHA
     COMMIT_SHA         = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    BOOKWORM_TAG       = BOOKWORM_TAG
+    TRIXIE_TAG         = TRIXIE_TAG
     JAVA_VERSION       = JAVA21_VERSION
   }
   tags = [
@@ -213,14 +213,14 @@ target "debian_jdk21" {
 }
 
 target "debian_slim_jdk17" {
-  dockerfile = "debian/bookworm-slim/hotspot/Dockerfile"
+  dockerfile = "debian/trixie-slim/hotspot/Dockerfile"
   context    = "."
   args = {
     JENKINS_VERSION    = JENKINS_VERSION
     JENKINS_SHA        = JENKINS_SHA
     COMMIT_SHA         = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    BOOKWORM_TAG       = BOOKWORM_TAG
+    TRIXIE_TAG         = TRIXIE_TAG
     JAVA_VERSION       = JAVA17_VERSION
   }
   tags = [
@@ -232,14 +232,14 @@ target "debian_slim_jdk17" {
 }
 
 target "debian_slim_jdk21" {
-  dockerfile = "debian/bookworm-slim/hotspot/Dockerfile"
+  dockerfile = "debian/trixie-slim/hotspot/Dockerfile"
   context    = "."
   args = {
     JENKINS_VERSION    = JENKINS_VERSION
     JENKINS_SHA        = JENKINS_SHA
     COMMIT_SHA         = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    BOOKWORM_TAG       = BOOKWORM_TAG
+    TRIXIE_TAG         = TRIXIE_TAG
     JAVA_VERSION       = JAVA21_VERSION
   }
   tags = [

--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -14,18 +14,18 @@ scms:
       branch: "{{ .github.branch }}"
 
 sources:
-  bookwormLatestVersion:
+  trixieLatestVersion:
     kind: dockerimage
     name: "Get the latest Debian Bookworm Linux version"
     transformers:
-      - trimprefix: "bookworm-"
+      - trimprefix: "trixie-"
     spec:
       image: "debian"
-      tagfilter: "bookworm-*"
+      tagfilter: "trixie-*"
       versionfilter:
         kind: regex
         pattern: >-
-          bookworm-\d+$
+          trixie-\d+$
 
 conditions:
   testDockerfileArg:
@@ -34,48 +34,48 @@ conditions:
     disablesourceinput: true
     spec:
       files:
-        - debian/bookworm/hotspot/Dockerfile
-        - debian/bookworm-slim/hotspot/Dockerfile
+        - debian/trixie/hotspot/Dockerfile
+        - debian/trixie-slim/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
+        matcher: "TRIXIE_TAG"
   testVersionInBakeFile:
-    name: "Does the bake file have variable BOOKWORM_TAG"
+    name: "Does the bake file have variable TRIXIE_TAG"
     kind: file
     disablesourceinput: true
     spec:
       file: docker-bake.hcl
-      matchpattern: "(.*BOOKWORM_TAG.*)"
+      matchpattern: "(.*TRIXIE_TAG.*)"
 
 targets:
   updateDockerBake:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the docker-bake.hcl"
+    name: "Update the value of the base image (ARG TRIXIE_TAG) in the docker-bake.hcl"
     kind: file
-    sourceid: bookwormLatestVersion
+    sourceid: trixieLatestVersion
     spec:
       file: docker-bake.hcl
       matchpattern: >-
-        variable(.*)"BOOKWORM_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
+        variable(.*)"TRIXIE_TAG"(.*){(.*)(\r\n|\r|\n)(.*)default(.*)=(.*)
       replacepattern: >-
-        variable${1}"BOOKWORM_TAG"${2}{${3}${4}${5}default${6}= "{{ source "bookwormLatestVersion" }}"
+        variable${1}"TRIXIE_TAG"${2}{${3}${4}${5}default${6}= "{{ source "trixieLatestVersion" }}"
     scmid: default
   updateDockerfile:
-    name: "Update the value of the base image (ARG BOOKWORM_TAG) in the Dockerfiles"
+    name: "Update the value of the base image (ARG TRIXIE_TAG) in the Dockerfiles"
     kind: dockerfile
-    sourceid: bookwormLatestVersion
+    sourceid: trixieLatestVersion
     spec:
       files:
-        - debian/bookworm/hotspot/Dockerfile
-        - debian/bookworm-slim/hotspot/Dockerfile
+        - debian/trixie/hotspot/Dockerfile
+        - debian/trixie-slim/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
-        matcher: "BOOKWORM_TAG"
+        matcher: "TRIXIE_TAG"
     scmid: default
 actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Debian Bookworm Linux Version to {{ source "bookwormLatestVersion" }}
+    title: Bump Debian Bookworm Linux Version to {{ source "trixieLatestVersion" }}
     spec:
       labels:
         - dependencies

--- a/updatecli/updatecli.d/git-lfs.yaml
+++ b/updatecli/updatecli.d/git-lfs.yaml
@@ -34,8 +34,8 @@ targets:
     kind: dockerfile
     spec:
       files:
-        - debian/bookworm/hotspot/Dockerfile
-        - debian/bookworm-slim/hotspot/Dockerfile
+        - debian/trixie/hotspot/Dockerfile
+        - debian/trixie-slim/hotspot/Dockerfile
       instruction:
         keyword: "ARG"
         matcher: "GIT_LFS_VERSION"

--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -86,8 +86,8 @@ targets:
           to: "_"
     spec:
       files:
-        - debian/bookworm/hotspot/Dockerfile
-        - debian/bookworm-slim/hotspot/Dockerfile
+        - debian/trixie/hotspot/Dockerfile
+        - debian/trixie-slim/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION


### PR DESCRIPTION
Update debian images to trixie

### Testing done
Tested

```
docker buildx bake debian_jdk21 --set=debian_jdk21.platform=linux/amd64
docker buildx bake debian_jdk17 --set=debian_jdk17.platform=linux/amd64
```

Ensuring that Jenkins boot

```
docker run -p 8080:8080 docker.io/jenkins/jenkins:2.504-jdk17
docker run -p 8080:8080 docker.io/jenkins/jenkins:2.504-jdk21
```


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
