### PR TITLE
chore(deps): bump ubi9/ubi in /rhel/ubi9/hotspot

### DIFF
--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1754586119 AS jre-build
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1755678605 AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
 
@@ -33,7 +33,7 @@ RUN case "$(jlink --version 2>&1)" in \
       --no-header-files \
       --output /javaruntime
 
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1754586119 AS controller
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1755678605 AS controller
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
Bumps ubi9/ubi from 9.6-1754586119 to 9.6-1755678605.

Copied from another of my repositories because Dependabot processing of this dependency was taking a very long time.

---
updated-dependencies:
- dependency-name: ubi9/ubi dependency-version: 9.6-1755678605 dependency-type: direct:production ...

### Testing done

None.  Rely on ci.jenkins.io to test the change.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
