### PR TITLE
feat(linux): add support on Linux for JDK 25 preview in Docker build configurations

### DIFF
--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -26,7 +26,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+             set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -3,6 +3,7 @@ ARG ALPINE_TAG=3.22.1
 FROM alpine:"${ALPINE_TAG}" AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
+ARG JLINK_MODULES_DEFAULT=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
@@ -26,7 +27,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -26,7 +26,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -22,15 +22,16 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
+      "17."*) set -- "--compress=2" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
+      "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
+      # the compression argument is different for JDK25 (early access)
+      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
       --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+      "$@" \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -27,8 +27,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
-             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
+      "25"*) mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -27,7 +27,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+             set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -23,15 +23,16 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
+      "17."*) set -- "--compress=2" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
+      "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
+      # the compression argument is different for JDK25 (early access)
+      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
       --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+      "$@" \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -3,6 +3,7 @@ ARG BOOKWORM_TAG=20250908
 FROM debian:bookworm-"${BOOKWORM_TAG}"-slim AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
+ARG JLINK_MODULES_DEFAULT=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -27,7 +28,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/debian/bookworm-slim/hotspot/Dockerfile
+++ b/debian/bookworm-slim/hotspot/Dockerfile
@@ -28,8 +28,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
-             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
+      "25"*) mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -3,6 +3,7 @@ ARG BOOKWORM_TAG=20250908
 FROM debian:bookworm-"${BOOKWORM_TAG}" AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
+ARG JLINK_MODULES_DEFAULT=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -27,7 +28,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -27,7 +27,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+             set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -23,15 +23,16 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
+      "17."*) set -- "--compress=2" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
+      "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
+      # the compression argument is different for JDK25 (early access)
+      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
       --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+      "$@" \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -27,7 +27,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/debian/bookworm/hotspot/Dockerfile
+++ b/debian/bookworm/hotspot/Dockerfile
@@ -28,8 +28,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
-             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
+      "25"*) mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -4,23 +4,31 @@ group "linux" {
   targets = [
     "alpine_jdk17",
     "alpine_jdk21",
+    "alpine_jdk25",
     "debian_jdk17",
     "debian_jdk21",
+    "debian_jdk25",
     "debian_slim_jdk17",
     "debian_slim_jdk21",
+    "debian_slim_jdk25",
     "rhel_ubi9_jdk17",
     "rhel_ubi9_jdk21",
+    "rhel_ubi9_jdk25",
   ]
 }
 
 group "linux-arm64" {
   targets = [
     "alpine_jdk21",
+    "alpine_jdk25",
     "debian_jdk17",
     "debian_jdk21",
+    "debian_jdk25",
     "debian_slim_jdk21",
+    "debian_slim_jdk25",
     "rhel_ubi9_jdk17",
     "rhel_ubi9_jdk21",
+    "rhel_ubi9_jdk25",
   ]
 }
 
@@ -28,6 +36,7 @@ group "linux-s390x" {
   targets = [
     "debian_jdk17",
     "debian_jdk21",
+    "debian_jdk25",
   ]
 }
 
@@ -35,8 +44,10 @@ group "linux-ppc64le" {
   targets = [
     "debian_jdk17",
     "debian_jdk21",
+    "debian_jdk25",
     "rhel_ubi9_jdk17",
     "rhel_ubi9_jdk21",
+    "rhel_ubi9_jdk25",
   ]
 }
 
@@ -88,6 +99,10 @@ variable "JAVA17_VERSION" {
 
 variable "JAVA21_VERSION" {
   default = "21.0.8_9"
+}
+
+variable "JAVA25_VERSION" {
+  default = "25+9-ea-beta"
 }
 
 variable "BOOKWORM_TAG" {
@@ -288,6 +303,85 @@ target "rhel_ubi9_jdk21" {
     tag_weekly(false, "rhel-ubi9-jdk21"),
     tag_lts(false, "lts-rhel-ubi9-jdk21"),
     tag_lts(true, "lts-rhel-ubi9-jdk21")
+  ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
+}
+
+target "alpine_jdk25" {
+  dockerfile = "alpine/hotspot/Dockerfile"
+  context    = "."
+  args = {
+    JENKINS_VERSION    = JENKINS_VERSION
+    JENKINS_SHA        = JENKINS_SHA
+    COMMIT_SHA         = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    ALPINE_TAG         = ALPINE_FULL_TAG
+    JAVA_VERSION       = JAVA25_VERSION
+  }
+  tags = [
+    tag(true, "alpine-jdk25"),
+    tag_weekly(false, "alpine-jdk25"),
+    tag_weekly(false, "alpine${ALPINE_SHORT_TAG}-jdk25"),
+    tag_lts(false, "lts-alpine-jdk25"),
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "debian_jdk25" {
+  dockerfile = "debian/bookworm/hotspot/Dockerfile"
+  context    = "."
+  args = {
+    JENKINS_VERSION    = JENKINS_VERSION
+    JENKINS_SHA        = JENKINS_SHA
+    COMMIT_SHA         = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    BOOKWORM_TAG       = BOOKWORM_TAG
+    JAVA_VERSION       = JAVA25_VERSION
+  }
+  tags = [
+    tag(true, "jdk25"),
+    tag_weekly(false, "latest-jdk25"),
+    tag_weekly(false, "jdk25"),
+    tag_lts(false, "lts-jdk25"),
+    tag_lts(true, "lts-jdk25")
+  ]
+  platforms = ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+}
+
+target "debian_slim_jdk25" {
+  dockerfile = "debian/bookworm-slim/hotspot/Dockerfile"
+  context    = "."
+  args = {
+    JENKINS_VERSION    = JENKINS_VERSION
+    JENKINS_SHA        = JENKINS_SHA
+    COMMIT_SHA         = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    BOOKWORM_TAG       = BOOKWORM_TAG
+    JAVA_VERSION       = JAVA25_VERSION
+  }
+  tags = [
+    tag(true, "slim-jdk25"),
+    tag_weekly(false, "slim-jdk25"),
+    tag_lts(false, "lts-slim-jdk25"),
+  ]
+  platforms = ["linux/amd64", "linux/arm64"]
+}
+
+target "rhel_ubi9_jdk25" {
+  dockerfile = "rhel/ubi9/hotspot/Dockerfile"
+  context    = "."
+  args = {
+    JENKINS_VERSION    = JENKINS_VERSION
+    JENKINS_SHA        = JENKINS_SHA
+    COMMIT_SHA         = COMMIT_SHA
+    PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
+    JAVA_VERSION       = JAVA25_VERSION
+  }
+  tags = [
+    tag(true, "rhel-ubi9-jdk25"),
+    tag_weekly(false, "rhel-ubi9-jdk25"),
+    tag_lts(false, "lts-rhel-ubi9-jdk25"),
+    tag_lts(true, "lts-rhel-ubi9-jdk25")
   ]
   platforms = ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 }

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -20,15 +20,16 @@ ENV PATH="/opt/jdk-${JAVA_VERSION}/bin:${PATH}"
 # for now we include the full module path to maintain compatibility
 # while still saving space (approx 200mb from the full distribution)
 RUN case "$(jlink --version 2>&1)" in \
-      "17."*) set -- "--compress=2" ;; \
+      "17."*) set -- "--compress=2" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK21
-      "21."*) set -- "--compress=zip-6" ;; \
+      "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
+      # the compression argument is different for JDK25 (early access)
+      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \
       --strip-java-debug-attributes \
-      "$1" \
-      --add-modules ALL-MODULE-PATH \
+      "$@" \
       --no-man-pages \
       --no-header-files \
       --output /javaruntime

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.6-1756915113 AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
+ARG JLINK_MODULES_DEFAULT=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -24,7 +25,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
+             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -24,7 +24,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -24,7 +24,8 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) set -- "--compress=zip-6" "--add-modules" "java.base,java.logging,java.xml,java.se" ;; \
+      "25"*) mod_list="${JLINK_MODULES:-java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec}"; \
+             set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \
     jlink \

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -25,8 +25,7 @@ RUN case "$(jlink --version 2>&1)" in \
       # the compression argument is different for JDK21
       "21."*) set -- "--compress=zip-6" "--add-modules" "ALL-MODULE-PATH" ;; \
       # the compression argument is different for JDK25 (early access)
-      "25"*) : "${JLINK_MODULES_DEFAULT:=java.base,java.logging,java.xml,java.management,java.net.http,jdk.crypto.ec,jdk.zipfs,jdk.unsupported,jdk.charsets}"; \
-             mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
+      "25"*) mod_list="${JLINK_MODULES:-$JLINK_MODULES_DEFAULT}"; \
              set -- "--compress=zip-6" --add-modules "$mod_list" ;; \
       *) echo "ERROR: unmanaged jlink version pattern" && exit 1 ;; \
     esac; \


### PR DESCRIPTION
- New Features
  - Added Java 25 (early access) images for Alpine, Debian (full and slim), and RHEL UBI9 across multiple architectures.
  - Introduced a build-time option to set a default JLink module list, enabling flexible module selection and consistent behavior across JDK 17, 21, and 25.
  - Unified jlink options to support ALL-MODULE-PATH and improved compression handling.
- Chores
  - Expanded build targets and groups to include new Java 25 variants and architectures.
  
### Testing done

`make build`
<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
