### PR TITLE
chore: don't skip Windows tests when simulating LTS build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def envVars = ['PUBLISH=true']
 // Set to true in a replay to simulate a LTS build on ci.jenkins.io
 // It will set the environment variables needed for a LTS
 // and disable images publication out of caution
-def SIMULATE_LTS_BUILD = true
+def SIMULATE_LTS_BUILD = false
 
 if (SIMULATE_LTS_BUILD) {
     envVars = [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,7 +17,7 @@ def envVars = ['PUBLISH=true']
 // Set to true in a replay to simulate a LTS build on ci.jenkins.io
 // It will set the environment variables needed for a LTS
 // and disable images publication out of caution
-def SIMULATE_LTS_BUILD = false
+def SIMULATE_LTS_BUILD = true
 
 if (SIMULATE_LTS_BUILD) {
     envVars = [

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -21,7 +21,7 @@ Describe "[functions > $global:TEST_TAG] build image" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[functions > $global:TEST_TAG] Check-VersionLessThan" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[functions > $global:TEST_TAG] Check-VersionLessThan" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'exit codes work' {
     docker run --rm $global:SUT_IMAGE "exit -1"
     $LastExitCode | Should -Be -1
@@ -74,7 +74,7 @@ Describe "[functions > $global:TEST_TAG] Check-VersionLessThan" -Skip:(-not $glo
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[functions > $global:TEST_TAG] Copy-ReferenceFile" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[functions > $global:TEST_TAG] Copy-ReferenceFile" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'build test image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE $PSScriptRoot/functions
     $exitCode | Should -Be 0

--- a/tests/plugins-cli.Tests.ps1
+++ b/tests/plugins-cli.Tests.ps1
@@ -29,7 +29,7 @@ Describe "[plugins-cli > $global:TEST_TAG] cleanup container" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli $PSScriptRoot/plugins-cli
     $exitCode | Should -Be 0
@@ -64,7 +64,7 @@ Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-pl
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli with non-default REF" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli with non-default REF" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli-ref $PSScriptRoot/plugins-cli/ref
     $exitCode | Should -Be 0
@@ -102,7 +102,7 @@ Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-pl
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli from a plugins file" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli from a plugins file" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli $PSScriptRoot/plugins-cli
     $exitCode | Should -Be 0
@@ -140,7 +140,7 @@ Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-pl
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli even when already exist" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli even when already exist" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli $PSScriptRoot/plugins-cli
     $exitCode | Should -Be 0
@@ -167,7 +167,7 @@ Describe "[plugins-cli > $global:TEST_TAG] clean work directory" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] plugins are getting upgraded but not downgraded" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] plugins are getting upgraded but not downgraded" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     # Initial execution
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli $PSScriptRoot/plugins-cli
@@ -218,7 +218,7 @@ Describe "[plugins-cli > $global:TEST_TAG] clean work directory" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] do not upgrade if plugin has been manually updated" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] do not upgrade if plugin has been manually updated" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli $PSScriptRoot/plugins-cli
@@ -268,7 +268,7 @@ Describe "[plugins-cli > $global:TEST_TAG] clean work directory" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] upgrade plugin even if it has been manually updated when PLUGINS_FORCE_UPGRADE=true" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli $PSScriptRoot/plugins-cli
     $exitCode | Should -Be 0
@@ -315,7 +315,7 @@ Describe "[plugins-cli > $global:TEST_TAG] clean work directory" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli and no war" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-plugin-cli and no war" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli-no-war $PSScriptRoot/plugins-cli/no-war
     $exitCode | Should -Be 0
@@ -323,7 +323,7 @@ Describe "[plugins-cli > $global:TEST_TAG] plugins are installed with jenkins-pl
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[plugins-cli > $global:TEST_TAG] Use a custom jenkins.war" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[plugins-cli > $global:TEST_TAG] Use a custom jenkins.war" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'builds child image' {
     $exitCode, $stdout, $stderr = Build-DockerChild $global:SUT_IMAGE-plugins-cli-custom-war $PSScriptRoot/plugins-cli/custom-war --no-cache
     $exitCode | Should -Be 0

--- a/tests/runtime.Tests.ps1
+++ b/tests/runtime.Tests.ps1
@@ -27,7 +27,7 @@ Describe "[runtime > $global:TEST_TAG] cleanup container" {
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[runtime > $global:TEST_TAG] test multiple JENKINS_OPTS" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[runtime > $global:TEST_TAG] test multiple JENKINS_OPTS" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It '"--help --version" should return the version, not the help' {
     # need the last line of output
     $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --rm -e JENKINS_OPTS=`"--help --version`" --name $global:SUT_CONTAINER -P $global:SUT_IMAGE"
@@ -37,7 +37,7 @@ Describe "[runtime > $global:TEST_TAG] test multiple JENKINS_OPTS" -Skip:(-not $
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[runtime > $global:TEST_TAG] test jenkins arguments" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[runtime > $global:TEST_TAG] test jenkins arguments" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   It 'running --help --version should return the version, not the help' {
     # need the last line of output
     $exitCode, $stdout, $stderr = Run-Program 'docker.exe' "run --rm --name $global:SUT_CONTAINER -P $global:SUT_IMAGE --help --version"
@@ -59,7 +59,7 @@ Describe "[runtime > $global:TEST_TAG] test jenkins arguments" -Skip:(-not $glob
 }
 
 # Only test on Java 21, one JDK is enough to test all versions
-Describe "[runtime > $global:TEST_TAG] passing JVM parameters" -Skip:(-not $global:TEST_TAG.StartsWith('jdk21-')) {
+Describe "[runtime > $global:TEST_TAG] passing JVM parameters" -Skip:(-not $global:TEST_TAG.Contains('jdk21-')) {
   BeforeAll {
     $tzSetting = '-Duser.timezone=Europe/Madrid'
     $tzRegex = [regex]::Escape("Europe/Madrid")


### PR DESCRIPTION
As I noticed in that SUT image name starts with `lts-jdk21-` in https://ci.jenkins.io/job/Packaging/job/docker/job/PR-2074/14/pipeline-overview/?start-byte=0&selected-node=532#log-532-775, this PR allows Windows tests to run when simulating a LTS build while still avoiding duplicate tests accross JDK versions.

Follow-up of:
- #1820

### Testing done

CI

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
