### PR TITLE
doc: add link to post-installation setup wizard in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ docker exec <jenkins_container_id_or_name> cat /var/jenkins_home/secrets/initial
 ```
 Replace <jenkins_container_id_or_name> with your actual Jenkins container id or name.
 
-To access Jenkins interface and complete the initial setup, follow the steps described here: https://www.jenkins.io/doc/book/installing/docker/#setup-wizard
+To access Jenkins and complete the initial setup, follow the instructions in the [installation guide](https://www.jenkins.io/doc/book/installing/docker/#setup-wizard).
 
 ## Backing up data
 


### PR DESCRIPTION
This PR adds a link to https://www.jenkins.io/doc/book/installing/docker/#setup-wizard as detailled steps for a quickstart demo in order to avoid doc duplication.

Closes:
- #969 

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
