### PR TITLE
chore(updatecli/debian) fix typo in the PR title

### DIFF
--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -75,7 +75,7 @@ actions:
   default:
     kind: github/pullrequest
     scmid: default
-    title: Bump Debian Bookworm Linux Version to {{ source "trixieLatestVersion" }}
+    title: Bump Debian Trixie version to {{ source "trixieLatestVersion" }}
     spec:
       labels:
         - dependencies


### PR DESCRIPTION
Should fix the title of https://github.com/jenkinsci/docker/pull/2084

