### PR TITLE
chore: update simulated LTS Jenkins version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,9 +22,9 @@ def SIMULATE_LTS_BUILD = false
 if (SIMULATE_LTS_BUILD) {
     envVars = [
         'PUBLISH=false',
-        'TAG_NAME=2.462.3',
-        'JENKINS_VERSION=2.462.3',
-        'WAR_SHA=3e53b52a816405e3b10ad07f1c48cd0cb5cb3f893207ef7f9de28415806b93c1'
+        'TAG_NAME=2.504.3',
+        'JENKINS_VERSION=2.504.3',
+        'WAR_SHA=ea8883431b8b5ef6b68fe0e5817c93dc0a11def380054e7de3136486796efeb0'
     ]
 }
 


### PR DESCRIPTION
This PR fixes the simulated LTS Jenkins build by updating the simulated values to a more recent LTS version than 2.462.3 from one year ago (cf https://www.jenkins.io/changelog/2.462.3/).

- Closes #2077 

### Testing done

Replay with:
```diff
--- old/Jenkinsfile
+++ new/Jenkinsfile
@@ -17,7 +17,7 @@
 // Set to true in a replay to simulate a LTS build on ci.jenkins.io
 // It will set the environment variables needed for a LTS
 // and disable images publication out of caution
-def SIMULATE_LTS_BUILD = false
+def SIMULATE_LTS_BUILD = true
 
 if (SIMULATE_LTS_BUILD) {
```
https://ci.jenkins.io/job/Packaging/job/docker/job/PR-2089/2/

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
