### PR TITLE
chore: sync README.md with Docker Hub

### DIFF
--- a/.github/workflows/update-dockerhub-description.yml
+++ b/.github/workflows/update-dockerhub-description.yml
@@ -1,0 +1,20 @@
+name: Update Docker Hub description
+on:
+  release:
+    types: [ published ]
+  workflow_dispatch:
+
+jobs:
+  dockerHubDescription:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Update Docker Hub description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          enable-url-completion: true
+          short-description: The leading open source automation server
+          repository: jenkins/jenkins
+          readme-filepath: ./README.md


### PR DESCRIPTION
This PR allows to automatically sync the content of the README to Docker Hub so it stays up to date.

Similar to:
- https://github.com/jenkinsci/docker-inbound-agent/pull/385

Closes:
- #2091 

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
