### PR TITLE
chore(Jenkinsfile) fix missing type declaration potentially causing memory leak

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ stage('Build') {
                             // Only publish when a tag triggered the build & the publication is enabled (ie not simulating a LTS)
                             if (env.TAG_NAME && (env.PUBLISH == 'true')) {
                                 // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-                                jenkins_version = env.TAG_NAME.split('-')[0]
+                                String jenkins_version = env.TAG_NAME.split('-')[0]
                                 // Setting WAR_URL to download war from Artifactory instead of mirrors on publication from trusted.ci.jenkins.io
                                 withEnv([
                                     "JENKINS_VERSION=${jenkins_version}",
@@ -173,7 +173,7 @@ stage('Build') {
             // Only publish when a tag triggered the build
             if (env.TAG_NAME) {
                 // Split to ensure any suffix is not taken in account (but allow suffix tags to trigger rebuilds)
-                jenkins_version = env.TAG_NAME.split('-')[0]
+                String jenkins_version = env.TAG_NAME.split('-')[0]
                 builds['linux'] = {
                     // Setting WAR_URL to download war from Artifactory instead of mirrors on publication from trusted.ci.jenkins.io
                     withEnv([


### PR DESCRIPTION
This change aims at fixing the message below in pipeline execution by setting explicit type for the `jenkins_version` variable.

```
Did you forget the `def` keyword? WorkflowScript seems to be setting a field named jenkins_version (to a value of type String) which could lead to memory leaks or other issues.
```

It is only pipeline related: no changes on the container image itself.