### PR TITLE
chore(updatecli): check architectures availability in debian manifest

### DIFF
--- a/updatecli/updatecli.d/debian.yaml
+++ b/updatecli/updatecli.d/debian.yaml
@@ -46,6 +46,17 @@ conditions:
     spec:
       file: docker-bake.hcl
       matchpattern: "(.*TRIXIE_TAG.*)"
+  checkArchitecturesAvailability:
+    kind: dockerimage
+    name: Check if container image is available for all architectures
+    sourceid: trixieLatestVersion
+    spec:
+      image: "debian"
+      architectures:
+        - linux/amd64
+        - linux/arm64
+        - linux/s390x
+        - linux/ppc64le
 
 targets:
   updateDockerBake:


### PR DESCRIPTION
This PR adds a condition to check if all architectures are available before opening a pull request to avoid premature builds.

Note: cf https://github.com/jenkinsci/docker-ssh-agent/issues/570#issuecomment-3486104260 similar checks should be added to rhel9, but for that I need to introduce a `UBI9_VERSION` argument first so it can be catched more easily by updatecli: https://github.com/jenkinsci/docker/blob/3d4eaf908f05ecca16dd05732e56b43576229fe0/rhel/ubi9/hotspot/Dockerfile#L1

Refs:
- https://github.com/jenkinsci/docker-ssh-agent/issues/570

### Testing done

```
$ updatecli diff --config ./updatecli/updatecli.d/debian.yaml --values updatecli/values.github-action.yaml 
```

<details>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/debian.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##############################
# BUMP DEBIAN TRIXIE VERSION #
##############################

source: source#trixieLatestVersion
--------------------------

Searching for version matching pattern "trixie-\\d+$"
✔ Docker Image Tag "trixie-20251103" found matching pattern "trixie-\\d+$"
[transformers]
✔ Result correctly transformed from "trixie-20251103" to "20251103"

condition: condition#testDockerfileArg
---------------------------
✔ Line "ARG TRIXIE_TAG=20251020" found, matching the keyword "ARG" and the matcher "TRIXIE_TAG".
✔ Line "ARG TRIXIE_TAG=20251020" found, matching the keyword "ARG" and the matcher "TRIXIE_TAG".
✔ key map["keyword":"ARG" "matcher":"TRIXIE_TAG"] found in Dockerfile "debian/trixie/hotspot/Dockerfile", key map["keyword":"ARG" "matcher":"TRIXIE_TAG"] found in Dockerfile "debian/trixie-slim/hotspot/Dockerfile"

condition: condition#testVersionInBakeFile
-------------------------------
✔ Content of the file "docker-bake.hcl" matched the pattern "(.*TRIXIE_TAG.*)"
✔ condition on file ["docker-bake.hcl"] passed

target: target#updateDockerfile
-----------------------

**Dry Run enabled**

⚠ The line #1, matched by the keyword "ARG" and the matcher "TRIXIE_TAG", is changed from "ARG TRIXIE_TAG=20251020" to "ARG TRIXIE_TAG=20251103".
⚠ The line #1, matched by the keyword "ARG" and the matcher "TRIXIE_TAG", is changed from "ARG TRIXIE_TAG=20251020" to "ARG TRIXIE_TAG=20251103".
⚠ - changed lines [1] of file "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/debian/trixie/hotspot/Dockerfile", changed lines [1] of file "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/debian/trixie-slim/hotspot/Dockerfile"

target: target#updateDockerBake
-----------------------

**Dry Run enabled**

"docker-bake.hcl" updated with [dry run] content "variable${1}\"TRIXIE_TAG\"${2}{${3}${4}${5}default${6}= \"20251103\""

```
--- docker-bake.hcl
+++ docker-bake.hcl
@@ -95,7 +95,7 @@
 }
 
 variable "TRIXIE_TAG" {
-  default = "20251020"
+  default = "20251103"
 }
 
 # ----  user-defined functions ----

```

⚠ - 1 file(s) updated with "variable${1}\"TRIXIE_TAG\"${2}{${3}${4}${5}default${6}= \"20251103\"":
        * docker-bake.hcl


ACTIONS
========


Bump Debian Trixie version
  => Bump Debian Trixie version to 20251103

[Dry Run] An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:



⚠ Bump Debian Trixie version:
        Source:
                ✔ [trixieLatestVersion] Get the latest Debian Trixie Linux version
        Condition:
                ✔ [testDockerfileArg] Does the Dockerfile have an ARG instruction for the Debian Trixie & Trixie Slim Linux version?
                ✔ [testVersionInBakeFile] Does the bake file have variable TRIXIE_TAG
        Target:
                ⚠ [updateDockerBake] Update the value of the base image (ARG TRIXIE_TAG) in the docker-bake.hcl
                ⚠ [updateDockerfile] Update the value of the base image (ARG TRIXIE_TAG) in the Dockerfiles


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
