### PR TITLE
chore(rhel9): use an argument to specify `UBI9_TAG`

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -98,6 +98,10 @@ variable "TRIXIE_TAG" {
   default = "20251020"
 }
 
+variable "UBI9_TAG" {
+  default = "9.6-1760340943"
+}
+
 # ----  user-defined functions ----
 
 # return a tag prefixed by the Jenkins version

--- a/rhel/ubi9/hotspot/Dockerfile
+++ b/rhel/ubi9/hotspot/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1760340943 AS jre-build
+ARG UBI9_TAG=9.6-1760340943
+FROM registry.access.redhat.com/ubi9/ubi:${UBI9_TAG} AS jre-build
 
 ARG JAVA_VERSION=17.0.16_8
 


### PR DESCRIPTION
This PR introduces `UBI9_TAG` (like in docker-agent and docker-ssh-agent) so it can be picked up by updatecli more easily: current updates managed by Dependabot, we want to add architectures availability checks.

Ref:
- Note in https://github.com/jenkinsci/docker/pull/2105
- https://github.com/jenkinsci/docker-ssh-agent/issues/570

### Testing done

```
make build-rhel_ubi9_jdk21
```

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
