### PR TITLE
chore(updatecli): add rhel9 manifest to ensure architectures availability

### DIFF
--- a/updatecli/scripts/ubi9-latest-tag.sh
+++ b/updatecli/scripts/ubi9-latest-tag.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# This script fetches the latest tag from the Red Hat Container Catalog API for UBI9 images.
+# It ensures that `jq` and `curl` are installed, fetches the most recent tags, and processes them to find the unique tag associated to `latest`s.
+
+# The Swagger API endpoints for the Red Hat Container Catalog API are documented at:
+# https://catalog.redhat.com/api/containers/v1/ui/#/Repositories/graphql.images.get_images_by_repo
+
+# The script uses the following parameters for the API request:
+# - registry: registry.access.redhat.com
+# - repository: ubi9
+# - page_size: 100
+# - page: 0
+# - sort_by: last_update_date[desc]
+
+# The curl command fetches the JSON data containing the tags for the UBI9 images, then parses it using `jq` to find the version associated with the "latest" tag.
+# It focuses on tags that contain a hyphen, as these represent the long-form tag names.
+# The script ensures that only one instance of each tag is kept, in case of duplicates.
+
+# Correct URL of the Red Hat Container Catalog API for UBI9
+URL="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/images?page_size=100&page=0&sort_by=last_update_date%5Bdesc%5D"
+
+# Check if jq and curl are installed
+# If they are not installed, exit the script with an error message
+if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    >&2 echo "jq and curl are required but not installed. Exiting with status 1." >&2
+    exit 1
+fi
+
+# Fetch `ubi9` from registry.access.redhat.com sorted by most recent update date, and keeping only the first page.
+response=$(curl --silent --fail --location --connect-timeout 10 --retry 3 --retry-delay 2 --max-time 30 --header 'accept: application/json' "$URL")
+
+# Check if the response is empty or null
+if [ -z "$response" ] || [ "$response" == "null" ]; then
+  >&2 echo "Error: Failed to fetch tags from the Red Hat Container Catalog API."
+  exit 1
+fi
+
+# Parse the JSON response using jq to find the version associated with the "latest" tag
+# - The response is expected to be a JSON object containing repository data.
+# - The script uses `jq` to:
+#   1. Iterate over all repositories in the `data` array.
+#   2. Select repositories where at least one tag has the name "latest".
+#   3. From those repositories, select tags that:
+#      - Do not have the name "latest".
+#      - Contain a hyphen in their name (indicating a long-form tag).
+#   4. Extract the `name` of the matching tags.
+#   5. Sort the tag names uniquely (`sort -u`).
+#   6. Take the last tag in the sorted list (`tail -n 1`), which is assumed to be the most recent valid tag.
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | tail -n 1)
+
+
+# Check if the latest_tag is empty
+if [ -z "$latest_tag" ]; then
+  echo "Error: No valid tags found."
+  exit 1
+fi
+
+# Output the latest tag version
+echo "$latest_tag"
+exit 0

--- a/updatecli/scripts/ubi9-tags.sh
+++ b/updatecli/scripts/ubi9-tags.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+# This script fetches all tags from the Red Hat Container Catalog API for UBI9 images.
+# It ensures that `jq` and `curl` are installed, fetches the tags, and processes them to find all unique tags.
+
+# Correct URL of the Red Hat Container Catalog API for UBI9
+URL="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/images?page_size=100&page=0&sort_by=last_update_date%5Bdesc%5D"
+
+# Check if jq and curl are installed
+if ! command -v jq >/dev/null 2>&1 || ! command -v curl >/dev/null 2>&1; then
+    echo "jq and curl are required but not installed. Exiting with status 1." >&2
+    exit 1
+fi
+
+# Fetch the tags using curl
+response=$(curl -s "$URL" -H 'accept: application/json')
+
+# Check if the response is empty or null
+if [ -z "$response" ] || [ "$response" == "null" ]; then
+  echo "Error: Failed to fetch tags from the Red Hat Container Catalog API."
+  exit 1
+fi
+
+# Parse the JSON response using jq to find all tags and their published dates
+all_tags=$(echo "$response" | jq -c '.data[] | {published_date: .repositories[].published_date, tags: .repositories[].signatures[].tags}')
+
+# Check if the all_tags is empty
+if [ -z "$all_tags" ]; then
+  echo "Error: No valid tags found."
+  exit 1
+fi
+
+# Declare an associative array to store tags and their published dates
+declare -A tag_dates
+
+# Declare an array to maintain the original order of tags
+ordered_tags=()
+
+# Iterate over the parsed JSON to populate the associative array and ordered array
+while IFS= read -r line; do
+  published_date=$(echo "$line" | jq -r '.published_date')
+  tags=$(echo "$line" | jq -r '.tags[]')
+  for tag in $tags; do
+    # Filter tags that contain a hyphen
+    if [[ $tag == *-* ]]; then
+      # Update the published_date if the current date is more recent or the same
+      if [[ -z "${tag_dates[$tag]}" || ! "$published_date" < "${tag_dates[$tag]}" ]]; then
+        tag_dates[$tag]=$published_date
+      fi
+      # Add or replace the tag in the ordered array
+      IFS='.' read -r part1 part2 _ <<< "$tag"
+      base_tag="${part1}.${part2}"
+      # echo "Base tag is $base_tag and tag is $tag"
+      replaced=false
+      for i in "${!ordered_tags[@]}"; do
+        if [[ "${ordered_tags[i]}" == "$base_tag" ]]; then
+          ordered_tags[i]="$tag"
+          replaced=true
+          break
+        fi
+      done
+      if ! $replaced; then
+        ordered_tags+=("$tag")
+      fi
+    fi
+  done
+done <<< "$all_tags"
+
+# Custom sort function with correct order
+sort_tags() {
+  printf "%s\n" "${ordered_tags[@]}" | sort -t '-' -k1,1n -k2,2n -k2.1,2.3n -k2.5,2.12n
+}
+
+# Print the sorted array and their corresponding published dates
+for tag in $(sort_tags | tac); do
+  echo "$tag"
+done

--- a/updatecli/updatecli.d/rhel-ubi9.yaml
+++ b/updatecli/updatecli.d/rhel-ubi9.yaml
@@ -1,0 +1,63 @@
+---
+name: Bump UBI9 version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  latestVersion:
+    name: "Get latest UBI9 Linux version"
+    kind: shell
+    spec:
+      command: bash -x updatecli/scripts/ubi9-latest-tag.sh
+
+conditions:
+  checkUbi9DockerImage:
+    kind: dockerimage
+    name: Check if container image "ubi9" is available
+    sourceid: latestVersion
+    spec:
+      architectures:
+        - linux/amd64
+        - linux/arm64
+        - linux/ppc64le
+      image: registry.access.redhat.com/ubi9
+
+targets:
+  updateDockerfile:
+    name: "Update value of base image (ARG UBI9_TAG) in Dockerfile"
+    kind: dockerfile
+    sourceid: latestVersion
+    spec:
+      file: rhel/ubi9/hotspot/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: UBI9_TAG
+    scmid: default
+  updateDockerBake:
+    name: "Update default value of variable UBI9_TAG in docker-bake.hcl"
+    kind: hcl
+    sourceid: latestVersion
+    spec:
+      file: docker-bake.hcl
+      path: variable.UBI9_TAG.default
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: Bump UBI9 version to {{ source "latestVersion" }}
+    spec:
+      labels:
+        - dependencies
+        - rhel-ubi9


### PR DESCRIPTION
This PR adds a condition to check if all architectures are available in rhel9 image before opening a pull request to avoid premature builds.

(Scripts copied from https://github.com/jenkinsci/docker-agent/tree/4dbfaaf8ee3f6ab4d851f91f148ec83ee2ed5035/updatecli/scripts without any change)

Refs:
- https://github.com/jenkinsci/docker-ssh-agent/issues/570
- https://github.com/jenkinsci/docker/pull/2106

### Testing done

```
$ updatecli diff --config ./updatecli/updatecli.d/rhel-ubi9.yaml --values updatecli/values.github-action.yaml 
```

<details>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/rhel-ubi9.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



#####################
# BUMP UBI9 VERSION #
#####################

source: source#latestVersion
--------------------
The shell 🐚 command "/bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/fe83d362aacf34e931f9bbb4677c803fdabf6abde8969e16b90d6fb4f448a14a.sh" ran successfully with the following output:
----
9.6-1760340943
----
✔ shell command executed successfully

condition: condition#checkUbi9DockerImage
------------------------------
✔ docker image registry.access.redhat.com/ubi9:9.6-1760340943 found

target: target#updateDockerBake
-----------------------

**Dry Run enabled**

✔ - no changes detected:
        path "variable.UBI9_TAG.default" already set to "9.6-1760340943", from file "docker-bake.hcl", 

target: target#updateDockerfile
-----------------------

**Dry Run enabled**

✔ The line #1, matched by the keyword "ARG" and the matcher "UBI9_TAG", is correctly set to "ARG UBI9_TAG=9.6-1760340943".
✔ - changed lines [] of file "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/rhel/ubi9/hotspot/Dockerfile"


ACTIONS
========


Bump UBI9 version
  => Bump UBI9 version to 9.6-1760340943

No follow up action needed

=============================

SUMMARY:



✔ Bump UBI9 version:
        Source:
                ✔ [latestVersion] Get latest UBI9 Linux version
        Condition:
                ✔ [checkUbi9DockerImage] Check if container image "ubi9" is available
        Target:
                ✔ [updateDockerBake] Update default value of variable UBI9_TAG in docker-bake.hcl
                ✔ [updateDockerfile] Update value of base image (ARG UBI9_TAG) in Dockerfile


Run Summary
===========
Pipeline(s) run:
  * Changed:    0
  * Failed:     0
  * Skipped:    0
  * Succeeded:  1
  * Total:      1
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
