### PR TITLE
chore: add `tags` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ build-%: check-reqs
 show:
 	@$(bake_base_cli) --progress=quiet linux --print | jq
 
-showtags:
+tags:
 	@make show | jq -r '.target[].tags[]' | sort
 
 list: check-reqs


### PR DESCRIPTION
This PR adds a Makefile target to list tags (to ease comparison before/after a change for example), and add colored output with `jq` to the `show` one without any internal bake lines (starting by `#1 ...` and which don't add anything in that context).

No functional change.

### Testing done

<details><summary>make show</summary>

Before:
> <img width="744" height="629" alt="image" src="https://github.com/user-attachments/assets/9f83f284-0926-4eb8-94c1-bd6272b4e2ba" />

After:
> <img width="748" height="610" alt="image" src="https://github.com/user-attachments/assets/6c9e762c-d69a-4b1f-89c9-b04518fae3f9" />

</details>

<details><summary>make tags</summary>

```
$ make tags
docker.io/jenkins/jenkins:2.504
docker.io/jenkins/jenkins:2.504-alpine
docker.io/jenkins/jenkins:2.504-alpine-jdk17
docker.io/jenkins/jenkins:2.504-alpine-jdk21
docker.io/jenkins/jenkins:2.504-jdk17
docker.io/jenkins/jenkins:2.504-jdk21
docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21
docker.io/jenkins/jenkins:2.504-slim
docker.io/jenkins/jenkins:2.504-slim-jdk17
docker.io/jenkins/jenkins:2.504-slim-jdk21

$ make tags | wc -l
      11

$ LATEST_WEEKLY=true make tags
docker.io/jenkins/jenkins:2.504-alpine-jdk17
docker.io/jenkins/jenkins:alpine-jdk17
docker.io/jenkins/jenkins:alpine3.23-jdk17
docker.io/jenkins/jenkins:2.504-alpine
docker.io/jenkins/jenkins:2.504-alpine-jdk21
docker.io/jenkins/jenkins:alpine
docker.io/jenkins/jenkins:alpine-jdk21
docker.io/jenkins/jenkins:alpine3.23-jdk21
docker.io/jenkins/jenkins:2.504-jdk17
docker.io/jenkins/jenkins:latest-jdk17
docker.io/jenkins/jenkins:jdk17
docker.io/jenkins/jenkins:2.504
docker.io/jenkins/jenkins:2.504-jdk21
docker.io/jenkins/jenkins:latest
docker.io/jenkins/jenkins:latest-jdk21
docker.io/jenkins/jenkins:jdk21
docker.io/jenkins/jenkins:2.504-slim-jdk17
docker.io/jenkins/jenkins:slim-jdk17
docker.io/jenkins/jenkins:2.504-slim
docker.io/jenkins/jenkins:2.504-slim-jdk21
docker.io/jenkins/jenkins:slim
docker.io/jenkins/jenkins:slim-jdk21
docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21
docker.io/jenkins/jenkins:rhel-ubi9-jdk21

$ LATEST_WEEKLY=true make tags | wc -l     
      26

$ LATEST_LTS=true make tags
docker.io/jenkins/jenkins:2.504-alpine-jdk17
docker.io/jenkins/jenkins:lts-alpine-jdk17
docker.io/jenkins/jenkins:2.504-alpine
docker.io/jenkins/jenkins:2.504-alpine-jdk21
docker.io/jenkins/jenkins:lts-alpine
docker.io/jenkins/jenkins:lts-alpine-jdk21
docker.io/jenkins/jenkins:2.504-lts-alpine
docker.io/jenkins/jenkins:2.504-jdk17
docker.io/jenkins/jenkins:lts-jdk17
docker.io/jenkins/jenkins:2.504-lts-jdk17
docker.io/jenkins/jenkins:2.504
docker.io/jenkins/jenkins:2.504-jdk21
docker.io/jenkins/jenkins:lts
docker.io/jenkins/jenkins:lts-jdk21
docker.io/jenkins/jenkins:2.504-lts
docker.io/jenkins/jenkins:2.504-lts-jdk21
docker.io/jenkins/jenkins:2.504-slim-jdk17
docker.io/jenkins/jenkins:lts-slim-jdk17
docker.io/jenkins/jenkins:2.504-slim
docker.io/jenkins/jenkins:2.504-slim-jdk21
docker.io/jenkins/jenkins:lts-slim
docker.io/jenkins/jenkins:lts-slim-jdk21
docker.io/jenkins/jenkins:2.504-lts-slim
docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.504-lts-rhel-ubi9-jdk17
docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21
docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk21
docker.io/jenkins/jenkins:2.504-lts-rhel-ubi9-jdk21

$ LATEST_LTS=true make tags | wc -l
      29
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
