### PR TITLE
chore: include docker bake target name in `make tags` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ show:
 	@$(bake_base_cli) --progress=quiet linux --print | jq
 
 tags:
-	@make show | jq -r ' .target | to_entries[] | .key as $$name | .value.tags[] | "\($$name):\(.)"' | LC_ALL=C sort -u
+	@make show | jq -r ' .target | to_entries[] | .key as $$name | .value.tags[] | "\(.) (\($$name))"' | LC_ALL=C sort -u
 
 list: check-reqs
 	@set -x; make --silent show | jq -r '.target | path(.. | select(.platforms[] | contains("linux/$(ARCH)"))?) | add'

--- a/tests/golden/expected_tags.txt
+++ b/tests/golden/expected_tags.txt
@@ -1,11 +1,11 @@
-alpine_jdk17:docker.io/jenkins/jenkins:2.504-alpine-jdk17
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-alpine
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-alpine-jdk21
-debian_jdk17:docker.io/jenkins/jenkins:2.504-jdk17
-debian_jdk21:docker.io/jenkins/jenkins:2.504
-debian_jdk21:docker.io/jenkins/jenkins:2.504-jdk21
-debian_slim_jdk17:docker.io/jenkins/jenkins:2.504-slim-jdk17
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-slim
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-slim-jdk21
-rhel_ubi9_jdk17:docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17
-rhel_ubi9_jdk21:docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21
+docker.io/jenkins/jenkins:2.504 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-alpine-jdk17 (alpine_jdk17)
+docker.io/jenkins/jenkins:2.504-alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:2.504-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17 (rhel_ubi9_jdk17)
+docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21 (rhel_ubi9_jdk21)
+docker.io/jenkins/jenkins:2.504-slim (debian_slim_jdk21)
+docker.io/jenkins/jenkins:2.504-slim-jdk17 (debian_slim_jdk17)
+docker.io/jenkins/jenkins:2.504-slim-jdk21 (debian_slim_jdk21)

--- a/tests/golden/expected_tags_latest_lts.txt
+++ b/tests/golden/expected_tags_latest_lts.txt
@@ -1,29 +1,29 @@
-alpine_jdk17:docker.io/jenkins/jenkins:2.504-alpine-jdk17
-alpine_jdk17:docker.io/jenkins/jenkins:lts-alpine-jdk17
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-alpine
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-alpine-jdk21
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-lts-alpine
-alpine_jdk21:docker.io/jenkins/jenkins:lts-alpine
-alpine_jdk21:docker.io/jenkins/jenkins:lts-alpine-jdk21
-debian_jdk17:docker.io/jenkins/jenkins:2.504-jdk17
-debian_jdk17:docker.io/jenkins/jenkins:2.504-lts-jdk17
-debian_jdk17:docker.io/jenkins/jenkins:lts-jdk17
-debian_jdk21:docker.io/jenkins/jenkins:2.504
-debian_jdk21:docker.io/jenkins/jenkins:2.504-jdk21
-debian_jdk21:docker.io/jenkins/jenkins:2.504-lts
-debian_jdk21:docker.io/jenkins/jenkins:2.504-lts-jdk21
-debian_jdk21:docker.io/jenkins/jenkins:lts
-debian_jdk21:docker.io/jenkins/jenkins:lts-jdk21
-debian_slim_jdk17:docker.io/jenkins/jenkins:2.504-slim-jdk17
-debian_slim_jdk17:docker.io/jenkins/jenkins:lts-slim-jdk17
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-lts-slim
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-slim
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-slim-jdk21
-debian_slim_jdk21:docker.io/jenkins/jenkins:lts-slim
-debian_slim_jdk21:docker.io/jenkins/jenkins:lts-slim-jdk21
-rhel_ubi9_jdk17:docker.io/jenkins/jenkins:2.504-lts-rhel-ubi9-jdk17
-rhel_ubi9_jdk17:docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17
-rhel_ubi9_jdk17:docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk17
-rhel_ubi9_jdk21:docker.io/jenkins/jenkins:2.504-lts-rhel-ubi9-jdk21
-rhel_ubi9_jdk21:docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21
-rhel_ubi9_jdk21:docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk21
+docker.io/jenkins/jenkins:2.504 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-alpine-jdk17 (alpine_jdk17)
+docker.io/jenkins/jenkins:2.504-alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:2.504-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-lts (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-lts-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-lts-jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:2.504-lts-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-lts-rhel-ubi9-jdk17 (rhel_ubi9_jdk17)
+docker.io/jenkins/jenkins:2.504-lts-rhel-ubi9-jdk21 (rhel_ubi9_jdk21)
+docker.io/jenkins/jenkins:2.504-lts-slim (debian_slim_jdk21)
+docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17 (rhel_ubi9_jdk17)
+docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21 (rhel_ubi9_jdk21)
+docker.io/jenkins/jenkins:2.504-slim (debian_slim_jdk21)
+docker.io/jenkins/jenkins:2.504-slim-jdk17 (debian_slim_jdk17)
+docker.io/jenkins/jenkins:2.504-slim-jdk21 (debian_slim_jdk21)
+docker.io/jenkins/jenkins:lts (debian_jdk21)
+docker.io/jenkins/jenkins:lts-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:lts-alpine-jdk17 (alpine_jdk17)
+docker.io/jenkins/jenkins:lts-alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:lts-jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:lts-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk17 (rhel_ubi9_jdk17)
+docker.io/jenkins/jenkins:lts-rhel-ubi9-jdk21 (rhel_ubi9_jdk21)
+docker.io/jenkins/jenkins:lts-slim (debian_slim_jdk21)
+docker.io/jenkins/jenkins:lts-slim-jdk17 (debian_slim_jdk17)
+docker.io/jenkins/jenkins:lts-slim-jdk21 (debian_slim_jdk21)

--- a/tests/golden/expected_tags_latest_weekly.txt
+++ b/tests/golden/expected_tags_latest_weekly.txt
@@ -1,26 +1,26 @@
-alpine_jdk17:docker.io/jenkins/jenkins:2.504-alpine-jdk17
-alpine_jdk17:docker.io/jenkins/jenkins:alpine-jdk17
-alpine_jdk17:docker.io/jenkins/jenkins:alpine3.23-jdk17
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-alpine
-alpine_jdk21:docker.io/jenkins/jenkins:2.504-alpine-jdk21
-alpine_jdk21:docker.io/jenkins/jenkins:alpine
-alpine_jdk21:docker.io/jenkins/jenkins:alpine-jdk21
-alpine_jdk21:docker.io/jenkins/jenkins:alpine3.23-jdk21
-debian_jdk17:docker.io/jenkins/jenkins:2.504-jdk17
-debian_jdk17:docker.io/jenkins/jenkins:jdk17
-debian_jdk17:docker.io/jenkins/jenkins:latest-jdk17
-debian_jdk21:docker.io/jenkins/jenkins:2.504
-debian_jdk21:docker.io/jenkins/jenkins:2.504-jdk21
-debian_jdk21:docker.io/jenkins/jenkins:jdk21
-debian_jdk21:docker.io/jenkins/jenkins:latest
-debian_jdk21:docker.io/jenkins/jenkins:latest-jdk21
-debian_slim_jdk17:docker.io/jenkins/jenkins:2.504-slim-jdk17
-debian_slim_jdk17:docker.io/jenkins/jenkins:slim-jdk17
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-slim
-debian_slim_jdk21:docker.io/jenkins/jenkins:2.504-slim-jdk21
-debian_slim_jdk21:docker.io/jenkins/jenkins:slim
-debian_slim_jdk21:docker.io/jenkins/jenkins:slim-jdk21
-rhel_ubi9_jdk17:docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17
-rhel_ubi9_jdk17:docker.io/jenkins/jenkins:rhel-ubi9-jdk17
-rhel_ubi9_jdk21:docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21
-rhel_ubi9_jdk21:docker.io/jenkins/jenkins:rhel-ubi9-jdk21
+docker.io/jenkins/jenkins:2.504 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-alpine-jdk17 (alpine_jdk17)
+docker.io/jenkins/jenkins:2.504-alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:2.504-jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:2.504-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk17 (rhel_ubi9_jdk17)
+docker.io/jenkins/jenkins:2.504-rhel-ubi9-jdk21 (rhel_ubi9_jdk21)
+docker.io/jenkins/jenkins:2.504-slim (debian_slim_jdk21)
+docker.io/jenkins/jenkins:2.504-slim-jdk17 (debian_slim_jdk17)
+docker.io/jenkins/jenkins:2.504-slim-jdk21 (debian_slim_jdk21)
+docker.io/jenkins/jenkins:alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:alpine-jdk17 (alpine_jdk17)
+docker.io/jenkins/jenkins:alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:alpine3.23-jdk17 (alpine_jdk17)
+docker.io/jenkins/jenkins:alpine3.23-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:latest (debian_jdk21)
+docker.io/jenkins/jenkins:latest-jdk17 (debian_jdk17)
+docker.io/jenkins/jenkins:latest-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:rhel-ubi9-jdk17 (rhel_ubi9_jdk17)
+docker.io/jenkins/jenkins:rhel-ubi9-jdk21 (rhel_ubi9_jdk21)
+docker.io/jenkins/jenkins:slim (debian_slim_jdk21)
+docker.io/jenkins/jenkins:slim-jdk17 (debian_slim_jdk17)
+docker.io/jenkins/jenkins:slim-jdk21 (debian_slim_jdk21)


### PR DESCRIPTION
This PR updates `make tags` to include docker bake target name like `make platforms`, and updates related golden files.

Follow-up of:
- #2134 
- #2139 

### Testing done

`bats tests/tags.bats`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
