### PR TITLE
chore: don't run golden file based tests when simulating a build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -24,7 +24,8 @@ if (SIMULATE_LTS_BUILD) {
         'PUBLISH=false',
         'TAG_NAME=2.504.3',
         'JENKINS_VERSION=2.504.3',
-        'WAR_SHA=ea8883431b8b5ef6b68fe0e5817c93dc0a11def380054e7de3136486796efeb0'
+        'WAR_SHA=ea8883431b8b5ef6b68fe0e5817c93dc0a11def380054e7de3136486796efeb0',
+        'SIMULATED_BUILD=true'
     ]
 }
 

--- a/tests/bake.bats
+++ b/tests/bake.bats
@@ -4,6 +4,12 @@ load test_helpers
 
 SUT_DESCRIPTION="docker bake"
 
+function setup() {
+  if [[ "${SIMULATED_BUILD:-}" == "true" ]]; then
+    skip "Simulated build, no golden file based tests"
+  fi
+}
+
 @test "[${SUT_DESCRIPTION}: tags] Default tags unchanged" {
   assert_matches_golden expected_tags make --silent tags
 }


### PR DESCRIPTION
This PR allows to skip golden file based tests when running a simulated build (`SIMULATE_LTS_BUILD` set to true in a replay), to avoid test failures in that case as the Jenkins version won't generally be the same as the one in those golden files.

Adding this change to allow me a proper report of issue(s) encountered while working on #2146.

Amends:
- #2134
- #2139 

Ref:
- #2135 

### Testing done

- Local testing:
```
## Normal build
$ make test-debian_jdk21
IMAGE=debian_jdk21 bats/bin/bats /Users/vv/oss/docker/tests --jobs 28
bake.bats
 ✓ [docker bake: tags] Default tags unchanged
 ✓ [docker bake: tags] Latest weekly tags unchanged
 ✓ [docker bake: tags] Latest LTS tags unchanged
 ✓ [docker bake: platforms] Platforms per target unchanged
functions.bats
 ✓ [debian_jdk21-functions] versionLT
<...snip...>

## Simulated build
$ SIMULATED_BUILD=true make test-debian_jdk21
IMAGE=debian_jdk21 bats/bin/bats /Users/vv/oss/docker/tests --jobs 28
bake.bats
 - [docker bake: tags] Default tags unchanged (skipped: Simulated build, no golden file based tests)
 - [docker bake: tags] Latest weekly tags unchanged (skipped: Simulated build, no golden file based tests)
 - [docker bake: tags] Latest LTS tags unchanged (skipped: Simulated build, no golden file based tests)
 - [docker bake: platforms] Platforms per target unchanged (skipped: Simulated build, no golden file based tests)
functions.bats
 ✓ [debian_jdk21-functions] versionLT
<...snip...>
```

- CI testing:
  - Simulated build with `SIMULATE_LTS_BUILD=true` and `JENKINS_VERSION=2.527` (+ its SHA) via a replay: https://ci.jenkins.io/job/Packaging/job/docker/job/PR-2147/2/
    ```diff
     // Set to true in a replay to simulate a LTS build on ci.jenkins.io
     // It will set the environment variables needed for a LTS
     // and disable images publication out of caution
    -def SIMULATE_LTS_BUILD = false
    +def SIMULATE_LTS_BUILD = true
     
     if (SIMULATE_LTS_BUILD) {
         envVars = [
             'PUBLISH=false',
    -        'TAG_NAME=2.504.3',
    -        'JENKINS_VERSION=2.504.3',
    -        'WAR_SHA=ea8883431b8b5ef6b68fe0e5817c93dc0a11def380054e7de3136486796efeb0',
    +        'TAG_NAME=2.527',
    +        'JENKINS_VERSION=2.527',
    +        'WAR_SHA=fdada2d547ef03690088c2d616ea9f48b403323d29cd635484a8d1ed5dee473b',
             'SIMULATED_BUILD=true'
         ]
     }
    ```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
