### PR TITLE
chore(test): show `bats` version and test timing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ ifeq ($(CI), true)
 	IMAGE=$* bats/bin/bats $(bats_flags) --formatter junit | tee target/junit-results-$*.xml
 else
 # Execute the test harness
-	IMAGE=$* bats/bin/bats $(bats_flags)
+	IMAGE=$* bats/bin/bats $(bats_flags) --timing
 endif
 
 test: prepare-test


### PR DESCRIPTION
This PR logs `bats` version, and adds `--timing` option when executing `make test` locally. (keeping CI output constant across builds)

### Testing done

```
$ make test-debian_jdk21
```
While in progress:
<img width="1452" height="176" alt="image" src="https://github.com/user-attachments/assets/a1ee029b-468f-4c93-b3c9-8601ee433fcc" />

Finished:
<img width="1056" height="591" alt="image" src="https://github.com/user-attachments/assets/44f12eb6-cd0d-4d08-840e-87875eab0120" />


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
