### PR TITLE
chore(debian): adapt .github content to unified variants Dockerfile

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 * @jenkinsci/team-docker-packaging
-*/debian/trixie/hotspot @ksalerno99
+*/debian @ksalerno99
 */rhel/ubi9/hotspot @ksalerno99

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,7 @@ updates:
 # Debian Linux
 
 - package-ecosystem: docker
-  directory: "debian/trixie/hotspot"
+  directory: "debian"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2
@@ -31,7 +31,7 @@ updates:
   - dependency-name: "eclipse-temurin"
 
 - package-ecosystem: docker
-  directory: "debian/trixie-slim/hotspot"
+  directory: "debian"
   schedule:
     interval: weekly
   open-pull-requests-limit: 2


### PR DESCRIPTION
This PR fixes references to unified debian Dockerfile.

Amends:
- #2138

Ref:
- #2136

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
