### PR TITLE
chore(tests): strip line break indicator to fix `get_jenkins_password` helper function

### DIFF
--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -110,7 +110,7 @@ function get_jenkins_url {
 }
 
 function get_jenkins_password {
-    docker logs "$(get_sut_container_name)" 2>&1 | grep -A 2 "Please use the following password to proceed to installation" | tail -n 1
+    docker logs "$(get_sut_container_name)" 2>&1 | grep -A 2 "Please use the following password to proceed to installation" | tail -n 1 | sed 's/\[LF]> //'
 }
 
 function test_url {


### PR DESCRIPTION
This PR fixes tests for Jenkins 2.528 and later by stripping line break indicator from docker logs (added for https://www.jenkins.io/security/advisory/2025-09-17/#SECURITY-3424, in this case: password prefixed with `[LF]> `).

Fixes:
- #2148 

Refs:
- https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.528
- https://github.com/jenkinsci/winstone/releases/tag/winstone-8.13.1
- https://github.com/jenkinsci/lib-support-log-formatter/releases/tag/support-log-formatter-1.3.1

### Testing done

```
make test JENKINS_VERSION=2.528 WAR_SHA=0077a6377878eceb659fe0e4c5104fd4adbc36fa307a495eb2264fe4105ed88c
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
