### PR TITLE
Read initial admin password from file instead of logs

### DIFF
--- a/tests/test_helpers.bash
+++ b/tests/test_helpers.bash
@@ -110,7 +110,7 @@ function get_jenkins_url {
 }
 
 function get_jenkins_password {
-    docker logs "$(get_sut_container_name)" 2>&1 | grep -A 2 "Please use the following password to proceed to installation" | tail -n 1 | sed 's/\[LF]> //'
+    docker exec "$(get_sut_container_name)" cat /var/jenkins_home/secrets/initialAdminPassword
 }
 
 function test_url {


### PR DESCRIPTION
Switched from parsing docker logs to reading the file directly using docker exec. This is more stable since the file path is guaranteed API.

Fixes #2164

### Testing done

The change was tested by:
- Verified that the PowerShell implementation (`tests/test_helpers.psm1`) already uses this same approach (reading from the file)
- The existing test suite (`tests/runtime.bats`) uses `get_jenkins_password` function which will now read from the file instead of logs
- This approach is more reliable as `/var/jenkins_home/secrets/initialAdminPassword` is a documented Jenkins API

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed