### PR TITLE
chore(updatecli): keep default `JENKINS_VERSION` and `WAR_SHA` up to date

### DIFF
--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -15,19 +15,10 @@ scms:
 
 sources:
   latestVersion:
-    kind: githubrelease
+    kind: file
     name: Get latest Jenkins Core release version
     spec:
-      owner: jenkinsci
-      repository: jenkins
-      token: "{{ requiredEnv .github.token }}"
-      username: "{{ .github.username }}"
-      versionfilter:
-        kind: regex
-        pattern: >-
-          \d+\.\d+$
-    transformers:
-      - trimprefix: "jenkins-"
+      file: https://updates.jenkins.io/latestCore.txt
   latestWarSha:
     kind: shell
     name: Get latest Jenkins Core sha256 checksum


### PR DESCRIPTION
This PR adds an updatecli manifest to keep the default `JENKINS_VERSION` and `WAR_SHA` values up to date.

Ref:
- #2165 

### Testing done

<details><summary>updatecli diff --config ./updatecli/updatecli.d/jenkins-version.yaml --values ./updatecli/values.github-action.yaml</summary>

```

+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/jenkins-version.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++



##########################################
# BUMP DEFAULT `JENKINS_VERSION` VERSION #
##########################################

source: source#latestVersion
--------------------
Searching for version matching pattern "\\d+\\.\\d+$"
✔ GitHub release version "jenkins-2.544" found matching pattern "\\d+\\.\\d+$" of kind "regex"
[transformers]
✔ Result correctly transformed from "jenkins-2.544" to "2.544"

condition: condition#isDockerImagePublished
--------------------------------
✔ docker image jenkins/jenkins:2.544 found

source: source#latestWarSha
-------------------
The shell 🐚 command "/bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/4da12af0bc4e12a7c2ade878679d24ea017b483133c3bab84e97bbeca4f7c531.sh" ran successfully with the following output:
----
58d2c25c42859d0423329221629c9d4f99e68d68cb50d7c61f4474c27938a973
----
✔ shell command executed successfully

target: target#updateDockerfilesJenkinsVersion
--------------------------------------

**Dry Run enabled**

⚠ The line #97, matched by the keyword "ARG" and the matcher "JENKINS_VERSION", is changed from "ARG JENKINS_VERSION" to "ARG JENKINS_VERSION=2.544".
⚠ The line #111, matched by the keyword "ARG" and the matcher "JENKINS_VERSION", is changed from "ARG JENKINS_VERSION" to "ARG JENKINS_VERSION=2.544".
⚠ The line #101, matched by the keyword "ARG" and the matcher "JENKINS_VERSION", is changed from "ARG JENKINS_VERSION" to "ARG JENKINS_VERSION=2.544".
⚠ The line #100, matched by the keyword "ARG" and the matcher "JENKINS_VERSION", is changed from "ARG JENKINS_VERSION" to "ARG JENKINS_VERSION=2.544".
⚠ - changed lines [97] of file "alpine/hotspot/Dockerfile", changed lines [111] of file "debian/Dockerfile", changed lines [101] of file "rhel/Dockerfile", changed lines [100] of file "windows/windowsservercore/hotspot/Dockerfile"


CHANGELOG:
----------

Title: jenkins-2.544
Published At: 2025-12-30 11:00:27 +0000 UTC
Link: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.544
Description: _This is an automatically generated changelog draft for Jenkins weekly releases.
See https://www.jenkins.io/changelog/2.544/ for the official changelog for this release._

## 🐛 Bug fixes

* [JENKINS-75905](https://issue-redirect.jenkins.io/issue/75905) - Include update site URL in signature verification in error messages (#25980) @adhamahmad

All contributors: @NotMyFault, @adhamahmad, @jenkins-release-bot, @renovate[bot], @shbhmexe and [renovate[bot]](https://github.com/apps/renovate)


target: target#updateGoldenFiles
------------------------

**Dry Run enabled**

"tests/golden/expected_tags.txt" updated with [dry run] content "2.544"

[snip, nested script block breaking GH markdown...]

"tests/golden/expected_tags_latest_weekly.txt" updated with [dry run] content "2.544"

[snip, nested script block breaking GH markdown...]

"tests/golden/expected_tags_latest_lts.txt" updated with [dry run] content "2.544"

[snip, nested script block breaking GH markdown...]

⚠ - 3 file(s) updated with "2.544":
	* tests/golden/expected_tags.txt
	* tests/golden/expected_tags_latest_weekly.txt
	* tests/golden/expected_tags_latest_lts.txt


CHANGELOG:
----------

Title: jenkins-2.544
Published At: 2025-12-30 11:00:27 +0000 UTC
Link: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.544
Description: _This is an automatically generated changelog draft for Jenkins weekly releases.
See https://www.jenkins.io/changelog/2.544/ for the official changelog for this release._

## 🐛 Bug fixes

* [JENKINS-75905](https://issue-redirect.jenkins.io/issue/75905) - Include update site URL in signature verification in error messages (#25980) @adhamahmad

All contributors: @NotMyFault, @adhamahmad, @jenkins-release-bot, @renovate[bot], @shbhmexe and [renovate[bot]](https://github.com/apps/renovate)


target: target#updateDockerBakeJenkinsVersion
-------------------------------------

**Dry Run enabled**

⚠ - changes detected:
	path "variable.JENKINS_VERSION.default" updated from "2.534" to "2.544" in file "docker-bake.hcl"


CHANGELOG:
----------

Title: jenkins-2.544
Published At: 2025-12-30 11:00:27 +0000 UTC
Link: https://github.com/jenkinsci/jenkins/releases/tag/jenkins-2.544
Description: _This is an automatically generated changelog draft for Jenkins weekly releases.
See https://www.jenkins.io/changelog/2.544/ for the official changelog for this release._

## 🐛 Bug fixes

* [JENKINS-75905](https://issue-redirect.jenkins.io/issue/75905) - Include update site URL in signature verification in error messages (#25980) @adhamahmad

All contributors: @NotMyFault, @adhamahmad, @jenkins-release-bot, @renovate[bot], @shbhmexe and [renovate[bot]](https://github.com/apps/renovate)


target: target#updateDockerBakeWarSha
-----------------------------

**Dry Run enabled**

⚠ - changes detected:
	path "variable.WAR_SHA.default" updated from "fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228" to "58d2c25c42859d0423329221629c9d4f99e68d68cb50d7c61f4474c27938a973" in file "docker-bake.hcl"


ACTIONS
========

No target found for action "default"

=============================

SUMMARY:



⚠ Bump default `JENKINS_VERSION` version:
	Source:
		✔ [latestVersion] Get latest Jenkins Core release version
		✔ [latestWarSha] Get latest Jenkins Core sha256 checksum
	Condition:
		✔ [isDockerImagePublished] Check if the docker image has been published
	Target:
		⚠ [updateDockerBakeJenkinsVersion] Update default value of JENKINS_VERSION in docker-bake.hcl
		⚠ [updateDockerBakeWarSha] Update default value of WAR_SHA in docker-bake.hcl
		⚠ [updateDockerfilesJenkinsVersion] Update value of JENKINS_VERSION in Dockerfile
		⚠ [updateGoldenFiles] Update value of JENKINS_VERSION in golden files


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
```

</default>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
