### PR TITLE
chore(updatecli): keep simulated LTS `JENKINS_VERSION` and `WAR_SHA` up to date

### DIFF
--- a/updatecli/updatecli.d/jenkins-version-simulated-lts.yaml
+++ b/updatecli/updatecli.d/jenkins-version-simulated-lts.yaml
@@ -95,3 +95,4 @@ actions:
       labels:
         - dependencies
         - jenkins-version
+        - skip-changelog


### PR DESCRIPTION
This PR keeps simulated LTS `JENKINS_VERSION` and `WAR_SHA` up to date, tracking only the initial LTS version of new release line (2.xxx.1) as sufficient in that case.

It also takes care of `LTS_JENKINS_VERSION` value in tests, introduced in #2184.

> [!NOTE]
> This PR can be merged when we want, but not the resulting updatecli pull request, at least not until the incoming LTS release including support for JDK25 cf https://github.com/jenkinsci/docker/pull/2163 body & https://github.com/jenkinsci/docker/blob/52d8ee8b73d046decfcbf97cd16582e187c86fa2/Jenkinsfile#L35

Similar to:
- #2171 

Ref:
- https://github.com/jenkinsci/docker/issues/2165#issuecomment-3695127761

### Testing done

New test following up the fixups[^1][^2] of the default `JENKINS_VERSION` manifest:

```
updatecli diff --debug --clean --config ./updatecli/updatecli.d/jenkins-version-simulated-lts.yaml --values ./updatecli/values.github-action.yaml
```

<details>

> ```diff
> --- tests/bake.bats
> +++ tests/bake.bats
> @@ -6,7 +6,7 @@
>  load test_helpers
>  
>  SUT_DESCRIPTION="docker bake"
> -LTS_JENKINS_VERSION="2.504.3"
> +LTS_JENKINS_VERSION="2.528.1"
>  
>  @test "[${SUT_DESCRIPTION}: tags] Default tags unchanged" {
>    assert_matches_golden expected_tags make --silent tags
> 
> ```
> 
> ⚠ - 1 file(s) updated with "LTS_JENKINS_VERSION=\"2.528.1\"":
>         * tests/bake.bats
> 
> ```diff
> --- Jenkinsfile
> +++ Jenkinsfile
> @@ -33,7 +33,7 @@
>          'PUBLISH=false',
>          'TAG_NAME=2.504.3',
>          // TODO: replace by the first LTS based on 2.534+ when available
> -        'JENKINS_VERSION=2.504.3',
> +        'JENKINS_VERSION=2.528.1',
>          'WAR_SHA=ea8883431b8b5ef6b68fe0e5817c93dc0a11def380054e7de3136486796efeb0',
>          // Filter out golden file based testing
>          // To filter out all tests, set BATS_FLAGS="--filter-tags none"
> 
> ```
> 
> ⚠ - 1 file(s) updated with "'JENKINS_VERSION=2.528.1'":
>         * Jenkinsfile
> 
> ```diff
> --- tests/golden/expected_tags_latest_lts.txt
> +++ tests/golden/expected_tags_latest_lts.txt
> @@ -1,27 +1,27 @@
> -docker.io/jenkins/jenkins:2.504.3 (debian_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-alpine (alpine_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-alpine-jdk17 (alpine_jdk17)
> -docker.io/jenkins/jenkins:2.504.3-alpine-jdk21 (alpine_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-alpine-jdk25 (alpine_jdk25)
> -docker.io/jenkins/jenkins:2.504.3-jdk17 (debian_jdk17)
> -docker.io/jenkins/jenkins:2.504.3-jdk21 (debian_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-jdk25 (debian_jdk25)
> -docker.io/jenkins/jenkins:2.504.3-lts (debian_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-lts-alpine (alpine_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-lts-jdk17 (debian_jdk17)
> -docker.io/jenkins/jenkins:2.504.3-lts-jdk21 (debian_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-lts-jdk25 (debian_jdk25)
> -docker.io/jenkins/jenkins:2.504.3-lts-rhel-ubi9-jdk17 (rhel_jdk17)
> -docker.io/jenkins/jenkins:2.504.3-lts-rhel-ubi9-jdk21 (rhel_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-lts-rhel-ubi9-jdk25 (rhel_jdk25)
> -docker.io/jenkins/jenkins:2.504.3-lts-slim (debian-slim_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-rhel-ubi9-jdk17 (rhel_jdk17)
> -docker.io/jenkins/jenkins:2.504.3-rhel-ubi9-jdk21 (rhel_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-rhel-ubi9-jdk25 (rhel_jdk25)
> -docker.io/jenkins/jenkins:2.504.3-slim (debian-slim_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-slim-jdk17 (debian-slim_jdk17)
> -docker.io/jenkins/jenkins:2.504.3-slim-jdk21 (debian-slim_jdk21)
> -docker.io/jenkins/jenkins:2.504.3-slim-jdk25 (debian-slim_jdk25)
> +docker.io/jenkins/jenkins:2.528.1- (debian_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--alpine (alpine_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--alpine-jdk17 (alpine_jdk17)
> +docker.io/jenkins/jenkins:2.528.1--alpine-jdk21 (alpine_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--alpine-jdk25 (alpine_jdk25)
> +docker.io/jenkins/jenkins:2.528.1--jdk17 (debian_jdk17)
> +docker.io/jenkins/jenkins:2.528.1--jdk21 (debian_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--jdk25 (debian_jdk25)
> +docker.io/jenkins/jenkins:2.528.1--lts (debian_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--lts-alpine (alpine_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--lts-jdk17 (debian_jdk17)
> +docker.io/jenkins/jenkins:2.528.1--lts-jdk21 (debian_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--lts-jdk25 (debian_jdk25)
> +docker.io/jenkins/jenkins:2.528.1--lts-rhel-ubi9-jdk17 (rhel_jdk17)
> +docker.io/jenkins/jenkins:2.528.1--lts-rhel-ubi9-jdk21 (rhel_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--lts-rhel-ubi9-jdk25 (rhel_jdk25)
> +docker.io/jenkins/jenkins:2.528.1--lts-slim (debian-slim_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--rhel-ubi9-jdk17 (rhel_jdk17)
> +docker.io/jenkins/jenkins:2.528.1--rhel-ubi9-jdk21 (rhel_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--rhel-ubi9-jdk25 (rhel_jdk25)
> +docker.io/jenkins/jenkins:2.528.1--slim (debian-slim_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--slim-jdk17 (debian-slim_jdk17)
> +docker.io/jenkins/jenkins:2.528.1--slim-jdk21 (debian-slim_jdk21)
> +docker.io/jenkins/jenkins:2.528.1--slim-jdk25 (debian-slim_jdk25)
>  docker.io/jenkins/jenkins:lts (debian_jdk21)
>  docker.io/jenkins/jenkins:lts-alpine (alpine_jdk21)
>  docker.io/jenkins/jenkins:lts-alpine-jdk17 (alpine_jdk17)
> 
> ```
> 
> ⚠ - 1 file(s) updated with ":2.528.1-":
>         * tests/golden/expected_tags_latest_lts.txt
> 
> ```diff
> --- Jenkinsfile
> +++ Jenkinsfile
> @@ -34,7 +34,7 @@
>          'TAG_NAME=2.504.3',
>          // TODO: replace by the first LTS based on 2.534+ when available
>          'JENKINS_VERSION=2.504.3',
> -        'WAR_SHA=ea8883431b8b5ef6b68fe0e5817c93dc0a11def380054e7de3136486796efeb0',
> +        'WAR_SHA=d630dca265f75a8d581f127a9234f1679d4b0800a8f370d03ad4a154ceb7295b',
>          // Filter out golden file based testing
>          // To filter out all tests, set BATS_FLAGS="--filter-tags none"
>          'BATS_FLAGS=--filter-tags "\\!test-type:golden-file"'
> 
> ```
> 
> ⚠ - 1 file(s) updated with "'WAR_SHA=d630dca265f75a8d581f127a9234f1679d4b0800a8f370d03ad4a154ceb7295b'":
>         * Jenkinsfile
> 
> SUMMARY:
> 
> ⚠ Bump simulated LTS `JENKINS_VERSION` version:
>         Source:
>                 ✔ [latestVersion] Get latest Jenkins Core LTS release version (.1 only)
>                 ✔ [latestWarSha] Get latest Jenkins Core LTS sha256 checksum
>         Condition:
>                 ✔ [isDockerImagePublished] Check if the docker image has been published
>         Target:
>                 ⚠ [updateJenkinsVersionInGoldenFiles] Update value of JENKINS_VERSION in LTS golden file
>                       * Repository: https://github.com/jenkinsci/docker.git (branch: master)
>                 ⚠ [updateJenkinsVersionInJenkinsfile] Update default value of simulated LTS JENKINS_VERSION in Jenkinsfile
>                       * Repository: https://github.com/jenkinsci/docker.git (branch: master)
>                 ⚠ [updateJenkinsVersionInTests] Update default value of LTS_JENKINS_VERSION in tests
>                       * Repository: https://github.com/jenkinsci/docker.git (branch: master)
>                 ⚠ [updateWarSha] Update default value of simulated LTS WAR_SHA in Jenkinsfile
>                       * Repository: https://github.com/jenkinsci/docker.git (branch: master)
> 
> 
> Run Summary
> ===========
> Pipeline(s) run:
>   * Changed:    1
>   * Failed:     0
>   * Skipped:    0
>   * Succeeded:  0
>   * Total:      1

</details>

</default>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->

[^1]: #2198
[^2]: #2200 