### PR TITLE
chore: remove experimental status from CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,31 +1,12 @@
-CHANGELOG
+Changelog
 =========
 
 | See [GitHub releases](https://github.com/jenkinsci/docker/releases) |
 | --- |
 
-## Status
-
-We are doing experimental changelogs for Jenkins controller Docker packaging
-([discussion in the developer list](https://groups.google.com/forum/#!topic/jenkinsci-dev/KvV_UjU02gE)).
-These release notes represent changes in in the packaging, but not in the bundled WAR files.
+These release notes represent changes in the controller image content or packaging, but not in the bundled WAR files.
 Please refer to the [weekly changelog](https://jenkins.io/changelog/) and [LTS changelog](https://jenkins.io/changelog-stable/) for WAR file changelogs.
 
 ## Version scheme
 
-The repository follows the 3-digit scheme of [Jenkins LTS releases](https://jenkins.io/download/lts/).
-
-## Mapping of Docker packaging to Jenkins releases
-
-Both Weekly and LTS distributions follow the Continuous Delivery approach and pick up the most recent versions available by the time of the release Pipeline execution.
-In this repository we follow the Jenkins LTS releases and release packaging changelogs for them.
-There is no version mapping for Weekly releases, users should be using changelogs to track down the changes
-(see also [Issue #865](https://github.com/jenkinsci/docker/issues/865)).
-
-## Notable changes in Jenkins versions before 2.164.1
-
-Below you can find incomplete list of changes in Docker packaging for Jenkins releases
-
-### 2.99
-
-*  `/bin/tini` has been relocated to `/sbin/tini`, location defined by alpine
+The repository follows the scheme of Jenkins, 2-digit for [Weekly releases](https://jenkins.io/download/weekly/) and 3-digit for [LTS releases](https://jenkins.io/download/lts/).


### PR DESCRIPTION
This PR updates CHANGELOG.md as the versioning scheme in this repo is not experimental anymore and as https://github.com/jenkinsci/docker/issues/865 has been since completed.

It also removes the "previous changelog before 2.164.1" section as it contained only one entry, and as this version is from March 2019: if users are still on this version there is zero chance they'll ever consult this page.

Refs:
- https://groups.google.com/g/jenkinsci-dev/c/KvV_UjU02gE (2019 thread)
- https://www.jenkins.io/changelog-stable/2.164.1/

### Testing done

N/A

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
