### PR TITLE
chore(pipeline): don't use `s390x` permanent agent

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,9 +18,9 @@ def envVars = ['PUBLISH=true']
 def architecturesAndCiJioAgentLabels = [
     'amd64': 'docker && amd64',
     'arm64': 'arm64docker',
-    // No corresponding agent, using qemu
+    // Using qemu
     'ppc64le': 'docker && amd64',
-    's390x': 's390xdocker',
+    's390x': 'docker && amd64',
 ]
 
 // Set to true in a replay to simulate a LTS build on ci.jenkins.io


### PR DESCRIPTION
This PR updates the pipeline to use an `amd64` agent and `qemu` to build `s390x` images.

Amends:
- #2155 

Ref:
- https://github.com/jenkinsci/docker/issues/2154#issuecomment-3709445653

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
