### PR TITLE
chore(tests): rename `LTS_JENKINS_VERSION` in bake tests

### DIFF
--- a/tests/bake.bats
+++ b/tests/bake.bats
@@ -6,7 +6,7 @@
 load test_helpers
 
 SUT_DESCRIPTION="docker bake"
-JENKINS_LTS_VERSION="2.504.3"
+LTS_JENKINS_VERSION="2.504.3"
 
 @test "[${SUT_DESCRIPTION}: tags] Default tags unchanged" {
   assert_matches_golden expected_tags make --silent tags
@@ -15,7 +15,7 @@ JENKINS_LTS_VERSION="2.504.3"
   assert_matches_golden expected_tags_latest_weekly make --silent tags LATEST_WEEKLY=true
 }
 @test "[${SUT_DESCRIPTION}: tags] Latest LTS tags unchanged" {
-  assert_matches_golden expected_tags_latest_lts make --silent tags LATEST_LTS=true JENKINS_VERSION="${JENKINS_LTS_VERSION}"
+  assert_matches_golden expected_tags_latest_lts make --silent tags LATEST_LTS=true JENKINS_VERSION="${LTS_JENKINS_VERSION}"
 }
 
 @test "[${SUT_DESCRIPTION}: platforms] Platforms per target unchanged" {


### PR DESCRIPTION
This PR updates this variable name, forgot to transplant https://github.com/jenkinsci/docker/pull/2178/changes/a4c0d57c65b35768eff00c9381873dfe6188f85f when extracting https://github.com/jenkinsci/docker/pull/2184 from https://github.com/jenkinsci/docker/pull/2178.

### Testing done

`bats ./tests/bake.bats`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
