### PR TITLE
chore(updatecli): remove docker compose target from JDK17 manifest

### DIFF
--- a/updatecli/updatecli.d/jdk17.yaml
+++ b/updatecli/updatecli.d/jdk17.yaml
@@ -38,7 +38,7 @@ conditions:
         - windows/x64
 
 targets:
-  ## Global config files
+  ## Global config file
   setJDK17VersionDockerBake:
     name: "Bump JDK17 version for Linux images in the docker-bake.hcl file"
     kind: hcl
@@ -49,18 +49,6 @@ targets:
     spec:
       file: docker-bake.hcl
       path: variable.JAVA17_VERSION.default
-    scmid: default
-  setJDK17VersionWindowsDockerCompose:
-    name: "Bump JDK17 version in build-windows.yaml"
-    kind: yaml
-    transformers:
-      - replacer:
-          from: "+"
-          to: "_"
-    spec:
-      files:
-        - build-windows.yaml
-      key: $.services.jdk17.build.args.JAVA_VERSION
     scmid: default
   ## Dockerfiles
   setJDK17Version:


### PR DESCRIPTION
This PR removes Windows Docker Compose target for JDK17 manifest as it does not contain JDK17 image definition anymore.

Follow-up of:
- #2179 

Ref:
- #2187 

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
