### PR TITLE
chore(updatecli): fix default `JENKINS_VERSION` manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -44,7 +44,7 @@ targets:
       path: variable.JENKINS_VERSION.default
   updateJenkinsVersionInDockerfiles:
     name: Update value of JENKINS_VERSION in Dockerfile
-    kind: dockerfile
+    kind: file
     scmid: default
     sourceid: latestVersion
     spec:
@@ -53,9 +53,8 @@ targets:
         - debian/Dockerfile
         - rhel/Dockerfile
         - windows/windowsservercore/hotspot/Dockerfile
-      instruction:
-        keyword: ARG
-        matcher: JENKINS_VERSION
+      matchpattern: :-(\d+\.\d+)}
+      replacepattern: :-{{ source "latestVersion" }}}
   updateJenkinsVersionInGoldenFiles:
     kind: file
     scmid: default
@@ -65,7 +64,8 @@ targets:
       files:
         - tests/golden/expected_tags.txt
         - tests/golden/expected_tags_latest_weekly.txt
-      matchpattern: (\d+\.\d+)
+      matchpattern: :(\d+\.\d+)-
+      replacepattern: :{{ source "latestVersion" }}-
   updateWarShaInDockerBake:
     name: Update default value of WAR_SHA in docker-bake.hcl
     kind: hcl
@@ -78,7 +78,7 @@ targets:
 actions:
   default:
     kind: github/pullrequest
-    title: Bump default `JENKINS_VERSION` to {{ source "latestVersion" }}
+    title: Bump default `JENKINS_VERSION` to Weekly {{ source "latestVersion" }}
     scmid: default
     spec:
       labels:


### PR DESCRIPTION
This change fixes the manifest by updating the version from the env var substitution below the `ARG` instead of adding it to the `ARG` itself in Dockerfiles, and restricts the search pattern to avoid matching Alpine version in golden files.

Amends:
- https://github.com/jenkinsci/docker/pull/2171

Ref:
- https://github.com/jenkinsci/docker/pull/2199#pullrequestreview-3667875153
- https://github.com/jenkinsci/docker/issues/2165

### Testing done

<details><summary>updatecli diff --debug --clean --config ./updatecli/updatecli.d/jenkins-version.yaml --values ./updatecli/values.github-action.yaml</summary>

<pre>

+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "./updatecli/updatecli.d/jenkins-version.yaml"
DEBUG: pipelineid undefined, we'll try to generate one
DEBUG: using pipeline name to generate the pipelineid
DEBUG: Loaded 1 pipeline configuration(s) from "./updatecli/updatecli.d/jenkins-version.yaml"
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

SCM repository retrieved: 1
DEBUG: cloning git repository: https://github.com/jenkinsci/docker.git in /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker
Enumerating objects: 13655, done.
Counting objects: 100% (24/24), done.
Compressing objects: 100% (16/16), done.
Total 13655 (delta 16), reused 9 (delta 8), pack-reused 13631 (from 3)
DEBUG: Fetching remote branches for resetting local ones
DEBUG: Enumerating objects: 12887, done.
Counting objects: 100% (4400/4400), done.
Compressing objects: 100% (2072/2072), done.
Total 12887 (delta 4027), reused 2328 (delta 2328), pack-reused 8487 (from 3)


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


##########################################
# BUMP DEFAULT `JENKINS_VERSION` VERSION #
##########################################

Pipeline ID     : 9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f
Dry Run         : enabled
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

source: latestVersion
---------------------

DEBUG: URL detected for file "https://updates.jenkins.io/latestCore.txt"
DEBUG: HTTP GET to "https://updates.jenkins.io/latestCore.txt" got a response with code 200
DEBUG: Reading line 1 of the content returned from url "https://updates.jenkins.io/latestCore.txt"
DEBUG: URL detected for location "https://updates.jenkins.io/latestCore.txt"
DEBUG: HTTP GET to "https://updates.jenkins.io/latestCore.txt" got a response with code 200
DEBUG: Reading content returned from the url "https://updates.jenkins.io/latestCore.txt"
✔ content: found from file "https://updates.jenkins.io/latestCore.txt":
2.546
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

source: latestWarSha
--------------------

DEBUG: No shell success criteria defined, updatecli fallbacks to historical workflow
DEBUG:  command: /bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/fc13a81bfe9070b62da80ff3658e81ac3e572a3d6061937ad61f63f14d5c13d0.sh
DEBUG: Environment variables
DEBUG:  * PATH=/opt/homebrew/opt/python@3.12/bin:/Users/vv/.bin:/Users/vv/.docker/bin:/usr/local/bin:/Users/vv/.asdf/shims:/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/opt/homebrew/opt/python@3.12/bin:/Users/vv/.bin:/Users/vv/.docker/bin:/Users/vv/.asdf/shims
DEBUG:  * HOME=/Users/vv
DEBUG:  * USER=vv
DEBUG:  * LOGNAME=vv
DEBUG:  * SHELL=/bin/zsh
DEBUG:  * LANG=en_US.UTF-8
DEBUG:  * LC_ALL=en_US.UTF-8
DEBUG:  * UPDATECLI_PIPELINE_STAGE=source
The shell 🐚 command "/bin/sh /var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/bin/fc13a81bfe9070b62da80ff3658e81ac3e572a3d6061937ad61f63f14d5c13d0.sh" ran successfully with the following output:
----
f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983
----
DEBUG: command stderr output was:
----
----
✔ shell command executed successfully
DEBUG: No shell success criteria defined, updatecli fallbacks to historical workflow
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

condition: isDockerImagePublished
---------------------------------

✔ docker image jenkins/jenkins:2.546 found
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

target: updateJenkinsVersionInDockerBake
----------------------------------------

Repository      : github.com/jenkinsci/docker@master

DEBUG: checkout git branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f", based on "master"
DEBUG: Checking if branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" diverged from "master":
DEBUG:  all good,branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" is ahead of "master"
DEBUG: Relative path detected: changing from "docker-bake.hcl" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/docker-bake.hcl"
⚠ - changes detected:
        path "variable.JENKINS_VERSION.default" updated from "2.534" to "2.546" in file "docker-bake.hcl"
DEBUG: no changelog detected
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

target: updateJenkinsVersionInGoldenFiles
-----------------------------------------

Repository      : github.com/jenkinsci/docker@master

DEBUG: checkout git branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f", based on "master"
DEBUG: Checking if branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" diverged from "master":
DEBUG:  all good,branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" is ahead of "master"
DEBUG: Relative path detected: changing from "tests/golden/expected_tags.txt" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/tests/golden/expected_tags.txt"
DEBUG: Relative path detected: changing from "tests/golden/expected_tags_latest_weekly.txt" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/tests/golden/expected_tags_latest_weekly.txt"
DEBUG: Extracted current version "2.534" from capture group in file "tests/golden/expected_tags.txt"
DEBUG: Match found for pattern ":(\\d+\\.\\d+)-" in file "tests/golden/expected_tags.txt"
DEBUG: Match found for pattern ":(\\d+\\.\\d+)-" in file "tests/golden/expected_tags_latest_weekly.txt"
"tests/golden/expected_tags.txt" updated with [dry run] content ":2.546-"

```
--- tests/golden/expected_tags.txt
+++ tests/golden/expected_tags.txt
@@ -1,11 +1,11 @@
 docker.io/jenkins/jenkins:2.534 (debian_jdk21)
-docker.io/jenkins/jenkins:2.534-alpine (alpine_jdk21)
-docker.io/jenkins/jenkins:2.534-alpine-jdk21 (alpine_jdk21)
-docker.io/jenkins/jenkins:2.534-alpine-jdk25 (alpine_jdk25)
-docker.io/jenkins/jenkins:2.534-jdk21 (debian_jdk21)
-docker.io/jenkins/jenkins:2.534-jdk25 (debian_jdk25)
-docker.io/jenkins/jenkins:2.534-rhel-ubi9-jdk21 (rhel_jdk21)
-docker.io/jenkins/jenkins:2.534-rhel-ubi9-jdk25 (rhel_jdk25)
-docker.io/jenkins/jenkins:2.534-slim (debian-slim_jdk21)
-docker.io/jenkins/jenkins:2.534-slim-jdk21 (debian-slim_jdk21)
-docker.io/jenkins/jenkins:2.534-slim-jdk25 (debian-slim_jdk25)
+docker.io/jenkins/jenkins:2.546-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:2.546-alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:2.546-alpine-jdk25 (alpine_jdk25)
+docker.io/jenkins/jenkins:2.546-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:2.546-jdk25 (debian_jdk25)
+docker.io/jenkins/jenkins:2.546-rhel-ubi9-jdk21 (rhel_jdk21)
+docker.io/jenkins/jenkins:2.546-rhel-ubi9-jdk25 (rhel_jdk25)
+docker.io/jenkins/jenkins:2.546-slim (debian-slim_jdk21)
+docker.io/jenkins/jenkins:2.546-slim-jdk21 (debian-slim_jdk21)
+docker.io/jenkins/jenkins:2.546-slim-jdk25 (debian-slim_jdk25)

```

"tests/golden/expected_tags_latest_weekly.txt" updated with [dry run] content ":2.546-"

```
--- tests/golden/expected_tags_latest_weekly.txt
+++ tests/golden/expected_tags_latest_weekly.txt
@@ -1,14 +1,14 @@
 docker.io/jenkins/jenkins:2.534 (debian_jdk21)
-docker.io/jenkins/jenkins:2.534-alpine (alpine_jdk21)
-docker.io/jenkins/jenkins:2.534-alpine-jdk21 (alpine_jdk21)
-docker.io/jenkins/jenkins:2.534-alpine-jdk25 (alpine_jdk25)
-docker.io/jenkins/jenkins:2.534-jdk21 (debian_jdk21)
-docker.io/jenkins/jenkins:2.534-jdk25 (debian_jdk25)
-docker.io/jenkins/jenkins:2.534-rhel-ubi9-jdk21 (rhel_jdk21)
-docker.io/jenkins/jenkins:2.534-rhel-ubi9-jdk25 (rhel_jdk25)
-docker.io/jenkins/jenkins:2.534-slim (debian-slim_jdk21)
-docker.io/jenkins/jenkins:2.534-slim-jdk21 (debian-slim_jdk21)
-docker.io/jenkins/jenkins:2.534-slim-jdk25 (debian-slim_jdk25)
+docker.io/jenkins/jenkins:2.546-alpine (alpine_jdk21)
+docker.io/jenkins/jenkins:2.546-alpine-jdk21 (alpine_jdk21)
+docker.io/jenkins/jenkins:2.546-alpine-jdk25 (alpine_jdk25)
+docker.io/jenkins/jenkins:2.546-jdk21 (debian_jdk21)
+docker.io/jenkins/jenkins:2.546-jdk25 (debian_jdk25)
+docker.io/jenkins/jenkins:2.546-rhel-ubi9-jdk21 (rhel_jdk21)
+docker.io/jenkins/jenkins:2.546-rhel-ubi9-jdk25 (rhel_jdk25)
+docker.io/jenkins/jenkins:2.546-slim (debian-slim_jdk21)
+docker.io/jenkins/jenkins:2.546-slim-jdk21 (debian-slim_jdk21)
+docker.io/jenkins/jenkins:2.546-slim-jdk25 (debian-slim_jdk25)
 docker.io/jenkins/jenkins:alpine (alpine_jdk21)
 docker.io/jenkins/jenkins:alpine-jdk21 (alpine_jdk21)
 docker.io/jenkins/jenkins:alpine-jdk25 (alpine_jdk25)

```

⚠ - 2 file(s) updated with ":2.546-":
        * tests/golden/expected_tags.txt
        * tests/golden/expected_tags_latest_weekly.txt
DEBUG: no changelog detected
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

target: updateJenkinsVersionInDockerfiles
-----------------------------------------

Repository      : github.com/jenkinsci/docker@master

DEBUG: checkout git branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f", based on "master"
DEBUG: Checking if branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" diverged from "master":
DEBUG:  all good,branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" is ahead of "master"
DEBUG: Relative path detected: changing from "alpine/hotspot/Dockerfile" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/alpine/hotspot/Dockerfile"
DEBUG: Relative path detected: changing from "debian/Dockerfile" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/debian/Dockerfile"
DEBUG: Relative path detected: changing from "rhel/Dockerfile" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/rhel/Dockerfile"
DEBUG: Relative path detected: changing from "windows/windowsservercore/hotspot/Dockerfile" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/windows/windowsservercore/hotspot/Dockerfile"
DEBUG: Extracted current version "2.534" from capture group in file "alpine/hotspot/Dockerfile"
DEBUG: Match found for pattern ":-(\\d+\\.\\d+)" in file "alpine/hotspot/Dockerfile"
DEBUG: Match found for pattern ":-(\\d+\\.\\d+)" in file "debian/Dockerfile"
DEBUG: Match found for pattern ":-(\\d+\\.\\d+)" in file "rhel/Dockerfile"
DEBUG: Match found for pattern ":-(\\d+\\.\\d+)" in file "windows/windowsservercore/hotspot/Dockerfile"
"alpine/hotspot/Dockerfile" updated with [dry run] content ":-2.546"

```
--- alpine/hotspot/Dockerfile
+++ alpine/hotspot/Dockerfile
@@ -95,7 +95,7 @@
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.534}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.546}
 
 # jenkins.war checksum, download will be validated using it
 ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228

```

"debian/Dockerfile" updated with [dry run] content ":-2.546"

```
--- debian/Dockerfile
+++ debian/Dockerfile
@@ -109,7 +109,7 @@
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.534}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.546}
 
 # jenkins.war checksum, download will be validated using it
 ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228

```

"rhel/Dockerfile" updated with [dry run] content ":-2.546"

```
--- rhel/Dockerfile
+++ rhel/Dockerfile
@@ -99,7 +99,7 @@
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.534}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.546}
 
 # jenkins.war checksum, download will be validated using it
 ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228

```

"windows/windowsservercore/hotspot/Dockerfile" updated with [dry run] content ":-2.546"

```
--- windows/windowsservercore/hotspot/Dockerfile
+++ windows/windowsservercore/hotspot/Dockerfile
@@ -98,7 +98,7 @@
 
 # jenkins version being bundled in this docker image
 ARG JENKINS_VERSION
-ENV JENKINS_VERSION=${JENKINS_VERSION:-2.534}
+ENV JENKINS_VERSION=${JENKINS_VERSION:-2.546}
 
 # jenkins.war checksum, download will be validated using it
 ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228

```

⚠ - 4 file(s) updated with ":-2.546":
        * alpine/hotspot/Dockerfile
        * debian/Dockerfile
        * rhel/Dockerfile
        * windows/windowsservercore/hotspot/Dockerfile
DEBUG: no changelog detected
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

target: updateWarShaInDockerBake
--------------------------------

Repository      : github.com/jenkinsci/docker@master

DEBUG: checkout git branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f", based on "master"
DEBUG: Checking if branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" diverged from "master":
DEBUG:  all good,branch "updatecli_master_9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f" is ahead of "master"
DEBUG: Relative path detected: changing from "docker-bake.hcl" to absolute path from SCM: "/var/folders/tp/wg7m13056jjgb2z1_jv07j1r0000gn/T/updatecli/github/jenkinsci/docker/docker-bake.hcl"
⚠ - changes detected:
        path "variable.WAR_SHA.default" updated from "fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228" to "f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983" in file "docker-bake.hcl"
DEBUG: No shell success criteria defined, updatecli fallbacks to historical workflow
DEBUG: no changelog detected


ACTIONS
========
DEBUG: using GitHub token from environment variable UPDATECLI_GITHUB_TOKEN

---
Pipeline Name   : Bump default `JENKINS_VERSION` version
Pipeline ID     : 9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f
Dry run         : true
Repository      : github.com/jenkinsci/docker@master
Action          : Bump default `JENKINS_VERSION` to Weekly 2.546
---

DEBUG: No CI pipeline detected (unknown CI Engine)
An action of kind "github/pullrequest" is expected.
DEBUG: The expected action would have the following information:
        |
        |       ##Title:
        |       Bump default `JENKINS_VERSION` to Weekly 2.546
        |       ##Report:
        |
        |       <Action id="9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f">
        |           <h3>Bump default `JENKINS_VERSION` version</h3>
        |           <details id="69099f532ccdbf043afe24134c120f483d9b9d4061fbd969abbdce57d15ba862">
        |               <summary>Update value of JENKINS_VERSION in (weekly) golden files</summary>
        |               <p>2 file(s) updated with &#34;:2.546-&#34;:&#xA;&#x9;* tests/golden/expected_tags.txt&#xA;&#x9;* tests/golden/expected_tags_latest_weekly.txt&#xA;</p>
        |           </details>
        |           <details id="71147510a5911f125d22464d05007a85f97b7036734e889ad4d33af546e9f155">
        |               <summary>Update value of JENKINS_VERSION in Dockerfile</summary>
        |               <p>4 file(s) updated with &#34;:-2.546&#34;:&#xA;&#x9;* alpine/hotspot/Dockerfile&#xA;&#x9;* debian/Dockerfile&#xA;&#x9;* rhel/Dockerfile&#xA;&#x9;* windows/windowsservercore/hotspot/Dockerfile&#xA;</p>
        |           </details>
        |           <details id="d67d0be7f0c28001c2171edb66ebfa342a4a7412d832810ac631267bde10a31f">
        |               <summary>Update default value of JENKINS_VERSION in docker-bake.hcl</summary>
        |               <p>changes detected:&#xA;&#x9;path &#34;variable.JENKINS_VERSION.default&#34; updated from &#34;2.534&#34; to &#34;2.546&#34; in file &#34;docker-bake.hcl&#34;</p>
        |           </details>
        |           <details id="ee995e5a1950b142221aa3c504d48a94715756646de25e3ad16bddfdb8b1abab">
        |               <summary>Update default value of WAR_SHA in docker-bake.hcl</summary>
        |               <p>changes detected:&#xA;&#x9;path &#34;variable.WAR_SHA.default&#34; updated from &#34;fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228&#34; to &#34;f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983&#34; in file &#34;docker-bake.hcl&#34;</p>
        |           </details>
        |       </Action>
        |
        |       =====
        |
DEBUG: The expected action would have the following information:
        |
        |       ##Title:
        |       Bump default `JENKINS_VERSION` to Weekly 2.546
        |
        |
        |       ##Report:
        |
        |       <Action id="9d0d7648ae1697150c1ed0caf71e31295a764a760d497c32bc26b381fb04263f">
        |           <h3>Bump default `JENKINS_VERSION` version</h3>
        |           <details id="69099f532ccdbf043afe24134c120f483d9b9d4061fbd969abbdce57d15ba862">
        |               <summary>Update value of JENKINS_VERSION in (weekly) golden files</summary>
        |               <p>2 file(s) updated with &#34;:2.546-&#34;:&#xA;&#x9;* tests/golden/expected_tags.txt&#xA;&#x9;* tests/golden/expected_tags_latest_weekly.txt&#xA;</p>
        |           </details>
        |           <details id="71147510a5911f125d22464d05007a85f97b7036734e889ad4d33af546e9f155">
        |               <summary>Update value of JENKINS_VERSION in Dockerfile</summary>
        |               <p>4 file(s) updated with &#34;:-2.546&#34;:&#xA;&#x9;* alpine/hotspot/Dockerfile&#xA;&#x9;* debian/Dockerfile&#xA;&#x9;* rhel/Dockerfile&#xA;&#x9;* windows/windowsservercore/hotspot/Dockerfile&#xA;</p>
        |           </details>
        |           <details id="d67d0be7f0c28001c2171edb66ebfa342a4a7412d832810ac631267bde10a31f">
        |               <summary>Update default value of JENKINS_VERSION in docker-bake.hcl</summary>
        |               <p>changes detected:&#xA;&#x9;path &#34;variable.JENKINS_VERSION.default&#34; updated from &#34;2.534&#34; to &#34;2.546&#34; in file &#34;docker-bake.hcl&#34;</p>
        |           </details>
        |           <details id="ee995e5a1950b142221aa3c504d48a94715756646de25e3ad16bddfdb8b1abab">
        |               <summary>Update default value of WAR_SHA in docker-bake.hcl</summary>
        |               <p>changes detected:&#xA;&#x9;path &#34;variable.WAR_SHA.default&#34; updated from &#34;fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228&#34; to &#34;f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983&#34; in file &#34;docker-bake.hcl&#34;</p>
        |           </details>
        |       </Action>
        |
        |       =====
        |

=============================

SUMMARY:

⚠ Bump default `JENKINS_VERSION` version:
        Source:
                ✔ [latestVersion] Get latest Jenkins Core release version
                ✔ [latestWarSha] Get latest Jenkins Core sha256 checksum
        Condition:
                ✔ [isDockerImagePublished] Check if the docker image has been published
        Target:
                ⚠ [updateJenkinsVersionInDockerBake] Update default value of JENKINS_VERSION in docker-bake.hcl
                      * Repository: https://github.com/jenkinsci/docker.git (branch: master)
                ⚠ [updateJenkinsVersionInDockerfiles] Update value of JENKINS_VERSION in Dockerfile
                      * Repository: https://github.com/jenkinsci/docker.git (branch: master)
                ⚠ [updateJenkinsVersionInGoldenFiles] Update value of JENKINS_VERSION in (weekly) golden files
                      * Repository: https://github.com/jenkinsci/docker.git (branch: master)
                ⚠ [updateWarShaInDockerBake] Update default value of WAR_SHA in docker-bake.hcl
                      * Repository: https://github.com/jenkinsci/docker.git (branch: master)


Run Summary
===========
Pipeline(s) run:
  * Changed:    1
  * Failed:     0
  * Skipped:    0
  * Succeeded:  0
  * Total:      1
</pre>

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
