### PR TITLE
chore(updatecli): add missing target and relax match pattern in `JENKINS_VERSION` manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -98,3 +98,4 @@ actions:
       labels:
         - dependencies
         - jenkins-version
+        - skip-changelog


### PR DESCRIPTION
This change fixes the manifest by adding the missing target updating `WAR_SHA` value in the Dockerfiles, and by relaxing the match pattern used for golden files to also update the short tags.

It also adds `skip-changelog` label to the `action`, as bumps from this manifest are equivalent to a noop in term of content in the published image.

Amends:
- https://github.com/jenkinsci/docker/pull/2171
- https://github.com/jenkinsci/docker/pull/2200

Ref:
- https://github.com/jenkinsci/docker/pull/2199#pullrequestreview-3667875153
- https://github.com/jenkinsci/docker/issues/2165

### Testing done

```
updatecli diff --debug --clean --config ./updatecli/updatecli.d/jenkins-version.yaml --values ./updatecli/values.github-action.yaml
```

```diff
--- tests/golden/expected_tags.txt
+++ tests/golden/expected_tags.txt
@@ -1,4 +1,4 @@
-docker.io/jenkins/jenkins:2.534 (debian_jdk21)
+docker.io/jenkins/jenkins:2.546 (debian_jdk21)
 docker.io/jenkins/jenkins:2.546-alpine (alpine_jdk21)
 docker.io/jenkins/jenkins:2.546-alpine-jdk21 (alpine_jdk21)
 docker.io/jenkins/jenkins:2.546-alpine-jdk25 (alpine_jdk25)

--- tests/golden/expected_tags_latest_weekly.txt
+++ tests/golden/expected_tags_latest_weekly.txt
@@ -1,4 +1,4 @@
-docker.io/jenkins/jenkins:2.534 (debian_jdk21)
+docker.io/jenkins/jenkins:2.546 (debian_jdk21)
 docker.io/jenkins/jenkins:2.546-alpine (alpine_jdk21)
 docker.io/jenkins/jenkins:2.546-alpine-jdk21 (alpine_jdk21)
 docker.io/jenkins/jenkins:2.546-alpine-jdk25 (alpine_jdk25)
```

> 🐋 On (Docker)file "alpine/hotspot/Dockerfile":
> ⚠ The line #101, matched by the keyword "ARG" and the matcher "WAR_SHA", is changed from "ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228" to "ARG WAR_SHA=f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983".
> 
> 🐋 On (Docker)file "debian/Dockerfile":
> ⚠ The line #115, matched by the keyword "ARG" and the matcher "WAR_SHA", is changed from "ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228" to "ARG WAR_SHA=f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983".
> 
> 🐋 On (Docker)file "rhel/Dockerfile":
> ⚠ The line #105, matched by the keyword "ARG" and the matcher "WAR_SHA", is changed from "ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228" to "ARG WAR_SHA=f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983".
> 
> 🐋 On (Docker)file "windows/windowsservercore/hotspot/Dockerfile":
> ⚠ The line #104, matched by the keyword "ARG" and the matcher "WAR_SHA", is changed from "ARG WAR_SHA=fcf13a8ebbe69d678608cc4b3885ece7d7e697d6da4c3691025a06968ddef228" to "ARG WAR_SHA=f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983".

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
