### PR TITLE
chore(makefile): show targets before building them

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -178,7 +178,7 @@ stage('Build') {
                         // sanity check that proves all images build on declared platforms not already built in other stages
                         stage("Multi arch build - ${architecture}") {
                             infra.withDockerCredentials {
-                                sh "make docker-init listarch-${architecture} buildarch-${architecture}"
+                                sh "make docker-init buildarch-${architecture}"
                             }
                         }
                     }


### PR DESCRIPTION
This change shows targets before building or publishing them.

I'd like to ship this change to enforce checks and validation for the incoming LTS 2.541.1 release.

### Testing done

```
$ make list
+ make --silent showarch-arm64
+ jq -r '.target | keys[]'
+ make --silent show
+ jq --arg arch linux/arm64 '.target |= with_entries(select(.value.platforms | index($arch)))'
+ make --silent show-linux
+ docker buildx bake -f docker-bake.hcl --load --progress=quiet linux --print
+ jq
alpine_jdk21
alpine_jdk25
debian-slim_jdk21
debian-slim_jdk25
debian_jdk21
debian_jdk25
rhel_jdk21
rhel_jdk25
```

```json
$ make build-debian_jdk25
+ docker buildx bake -f docker-bake.hcl --load --progress=quiet debian_jdk25 --print
+ jq
{
  "group": {
    "default": {
      "targets": [
        "debian_jdk25"
      ]
    }
  },
  "target": {
    "debian_jdk25": {
      "context": ".",
      "dockerfile": "debian/Dockerfile",
      "args": {
        "COMMIT_SHA": "0c0a096d671efecce56707d88fc35cd601e847b1",
        "DEBIAN_RELEASE_LINE": "trixie",
        "DEBIAN_VARIANT": "",
        "DEBIAN_VERSION": "20251117",
        "JAVA_VERSION": "25.0.1_8",
        "JENKINS_VERSION": "2.546",
        "PLUGIN_CLI_VERSION": "2.13.2",
        "WAR_SHA": "f1b03ebf8fdb0ac893fbac9df9835d736ab9825399dc43de8a00d3f3913d8983",
        "WAR_URL": "https://get.jenkins.io/war/2.546/jenkins.war"
      },
      "tags": [
        "docker.io/jenkins/jenkins:2.546-jdk25"
      ],
      "platforms": [
        "linux/amd64",
        "linux/arm64",
        "linux/s390x",
        "linux/ppc64le"
      ],
      "output": [
        {
          "type": "docker"
        }
      ]
    }
  }
}
+ make --silent showarch-arm64
+ jq -r '.target | keys[]'
+ make --silent show
+ jq --arg arch linux/arm64 '.target |= with_entries(select(.value.platforms | index($arch)))'
+ make --silent show-linux
+ docker buildx bake -f docker-bake.hcl --load --progress=quiet linux --print
+ jq
+ docker buildx bake -f docker-bake.hcl --load --set '*.platform=linux/arm64' debian_jdk25
<...snip...>
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
