### PR TITLE
chore(github): run `updatecli` workflow only on commits or PRs targeting `master` branch

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -6,11 +6,10 @@ on:
     # Run once per week (to avoid alert fatigue)
     - cron: '0 2 * * 1' # Every Monday at 2am UTC
   push:
-  push:
     branches:
       - master
   pull_request:
-    branches-ignore:
+    branches:
       - master
 jobs:
   updatecli:


### PR DESCRIPTION
Follow-up of:
- https://github.com/jenkinsci/docker/issues/2195#issuecomment-3751071440

Ref:
- https://github.com/jenkinsci/docker/issues/2220

### Testing done

Checked that the `updatecli` GitHub Action workflow isn't triggered when this pull request was targeting current `stable-2.541`:

> <img width="866" height="259" alt="image" src="https://github.com/user-attachments/assets/24576efa-0765-41eb-b33e-c65f154bfd9e" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
