### PR TITLE
Remove overlapping directory in Dependabot definition for Debian

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,18 +30,6 @@ updates:
   # Ignore proposals to update to new versions of Java because updatecli takes care of that.
   - dependency-name: "eclipse-temurin"
 
-- package-ecosystem: docker
-  directory: "debian"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  labels:
-  - dependencies
-  ignore:
-  # Ignore proposals to update to new versions of Java because updatecli takes care of that.
-  - dependency-name: "eclipse-temurin"
-
 # RHEL UBI
 
 - package-ecosystem: docker


### PR DESCRIPTION
## Remove overlapping directory in Dependabot definition for Debian

Amends #2160 that adapted to the removal of separate trixie and trixie-slim Dockerfile definitions.

We haven't received dependabot updates since that change (25 Dec 2025).

Fixes this message from Dependabot:

<img width="1417" height="427" alt="screencapture-github-jenkinsci-docker-network-updates-2026-01-19-06_22_35-edit" src="https://github.com/user-attachments/assets/b46290a2-e043-4519-b90d-9b61bd9baf81" />


### Testing done

None.  Requires Dependabot run on GitHub.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
