### PR TITLE
backport(github): run `updatecli` workflow only on commits or PRs targeting `master` branch (#2215)

### DIFF
--- a/.github/workflows/updatecli.yaml
+++ b/.github/workflows/updatecli.yaml
@@ -6,7 +6,11 @@ on:
     # Run once per week (to avoid alert fatigue)
     - cron: '0 2 * * 1' # Every Monday at 2am UTC
   push:
+    branches:
+      - master
   pull_request:
+    branches:
+      - master
 jobs:
   updatecli:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Backport of #2215 to avoid `updatecli` failures on stable branches.

Refs:
- https://github.com/jenkinsci/docker/issues/2220
- https://github.com/jenkinsci/docker/issues/2195#issuecomment-3769503637

### Testing done

No failing `updatecli` status check:
> <img width="872" height="732" alt="image" src="https://github.com/user-attachments/assets/9c740b7d-a9ca-4cf3-af07-1d365e4bfece" />

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
