### PR TITLE
backport: show docker bake args and targets before publication (#2211)

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -11,6 +11,7 @@ set -eu -o pipefail
 
 : "${DOCKERHUB_ORGANISATION:=jenkins}"
 : "${DOCKERHUB_REPO:=jenkins}"
+: "${BAKE_TARGET:=linux}"
 
 export JENKINS_REPO="${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}"
 
@@ -78,14 +79,15 @@ fi
 build_opts=("--pull")
 metadata_suffix="publish"
 if test "${dry_run}" == "true"; then
-    build_opts+=("--load")
+    build_opts+=("--set=*.output=type=cacheonly")
     metadata_suffix="dry-run"
 else
     build_opts+=("--push")
 fi
 
 # Save build result metadata
-BUILD_METADATA_PATH="target/build-result-metadata_${metadata_suffix}.json"
+mkdir -p target
+BUILD_METADATA_PATH="target/build-result-metadata_${BAKE_TARGET}_${metadata_suffix}.json"
 build_opts+=("--metadata-file=${BUILD_METADATA_PATH}")
 
 WAR_SHA="$(curl --disable --fail --silent --show-error --location "https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/${JENKINS_VERSION}/jenkins-war-${JENKINS_VERSION}.war.sha256")"
@@ -101,6 +103,12 @@ Using the following settings:
 * LATEST_WEEKLY: ${LATEST_WEEKLY}
 * LATEST_LTS: ${LATEST_LTS}
 * BUILD_METADATA_PATH: ${BUILD_METADATA_PATH}
+* BAKE_TARGET: ${BAKE_TARGET}
+* BAKE OPTIONS:
+$(printf '  %s\n' "${build_opts[@]}")
+
+* RESOLVED BAKE CONFIG:
+$(docker buildx bake --file docker-bake.hcl --print "${BAKE_TARGET}")
 EOF
 
-docker buildx bake --file docker-bake.hcl "${build_opts[@]}" linux
+docker buildx bake --file docker-bake.hcl "${build_opts[@]}" "${BAKE_TARGET}"

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -149,17 +149,116 @@ In order to debug the controller, use the `-e DEBUG=true -p 5005:5005` when star
 Jenkins will be suspended on the startup in such case,
 and then it will be possible to attach a debugger from IDE to it.
 
-== Test the publishing using an overridden target repository on Docker Hub
+== Test images publication
 
-Create a new dedicated target repository in your Docker Hub account, and use it like follows:
+You can test the script used for publication in dry-run by setting an existing Jenkins Core version and by passing the `-n` option:
 
 [source,bash]
 --
-export DOCKERHUB_ORGANISATION=batmat
-export DOCKERHUB_REPO=test-jenkins
+$ export JENKINS_VERSION=2.528.3
+$ ./.ci/publish.sh -n
+Dry run, will not publish images
+Using the following settings:
+* JENKINS_REPO: jenkins/jenkins
+* JENKINS_VERSION: 2.528.3
+* WAR_SHA: bfa31f1e3aacebb5bce3d5076c73df97bf0c0567eeb8d8738f54f6bac48abd74
+* COMMIT_SHA: 1c72a9383191562eb3c44838aeeadad0839c2c92
+* LATEST_WEEKLY: false
+* LATEST_LTS: true
+* BUILD_METADATA_PATH: target/build-result-metadata_linux_dry-run.json
+[+] Building 104.6s (59/73)
+<...snip...>
+--
+
+Note that if you can set `BAKE_TARGET` to test the publication of a single target instead the default "linux" multiarch (heavy) build:
+
+[source,bash]
+--
+$ export BAKE_TARGET=debiand_jdk25
+$ ./.ci/publish.sh -n
+Using the following settings:
+* JENKINS_REPO: jenkins/jenkins
+* JENKINS_VERSION: 2.528.3
+* WAR_SHA: bfa31f1e3aacebb5bce3d5076c73df97bf0c0567eeb8d8738f54f6bac48abd74
+* COMMIT_SHA: aaf4e7faf887b7ac4879c3bf540ede48220cca9f
+* LATEST_WEEKLY: false
+* LATEST_LTS: true
+* BUILD_METADATA_PATH: target/build-result-metadata_debian_jdk25_dry-run.json
+* BAKE TARGET: debian_jdk25
+* BUILDX OPTIONS:
+  --pull
+  --set=*.output=type=cacheonly
+  --metadata-file=target/build-result-metadata_debian_jdk25_dry-run.json
+
+* RESOLVED BAKE CONFIG:
+{
+  "group": {
+    "default": {
+      "targets": [
+        "debian_jdk25"
+      ]
+    }
+  },
+  "target": {
+    "debian_jdk25": {
+      "context": ".",
+      "dockerfile": "debian/Dockerfile",
+      "args": {
+        "COMMIT_SHA": "aaf4e7faf887b7ac4879c3bf540ede48220cca9f",
+        "DEBIAN_RELEASE_LINE": "trixie",
+        "DEBIAN_VARIANT": "",
+        "DEBIAN_VERSION": "20251117",
+        "JAVA_VERSION": "25.0.1_8",
+        "JENKINS_VERSION": "2.528.3",
+        "PLUGIN_CLI_VERSION": "2.13.2",
+        "WAR_SHA": "bfa31f1e3aacebb5bce3d5076c73df97bf0c0567eeb8d8738f54f6bac48abd74",
+        "WAR_URL": "https://get.jenkins.io/war-stable/2.528.3/jenkins.war"
+      },
+      "tags": [
+        "docker.io/jenkins/jenkins:2.528.3-jdk25",
+        "docker.io/jenkins/jenkins:lts-jdk25",
+        "docker.io/jenkins/jenkins:2.528.3-lts-jdk25"
+      ],
+      "platforms": [
+        "linux/amd64",
+        "linux/arm64",
+        "linux/s390x",
+        "linux/ppc64le"
+      ]
+    }
+  }
+}
+[+] Building 104.6s (59/73)
+...
+--
+
+You can also pass the `-d` option (debug) to see traces from the script.
+
+=== Using an overridden target repository on Docker Hub
+
+Create a new dedicated target repository in your Docker Hub account, and use it like follows (note the absence of `-d` option):
+
+[source,bash]
+--
+$ export DOCKERHUB_ORGANISATION=jenkins4eval
+$ export DOCKERHUB_REPO=test-jenkins
 # The log below will help confirm this override was taken in account:
-./publish.sh
-Docker repository in Use:
-* JENKINS_REPO: batmat/test-jenkins
+$ ./.ci/publish.sh
+Using the following settings:
+* JENKINS_REPO: jenkins4eval/test-jenkins
+* JENKINS_VERSION: 2.528.3
+* WAR_SHA: bfa31f1e3aacebb5bce3d5076c73df97bf0c0567eeb8d8738f54f6bac48abd74
+* COMMIT_SHA: aaf4e7faf887b7ac4879c3bf540ede48220cca9f
+* LATEST_WEEKLY: false
+* LATEST_LTS: true
+* BUILD_METADATA_PATH: target/build-result-metadata_linux_publish.json
+* BAKE TARGET: linux
+* BUILDX OPTIONS:
+  --pull
+  --push
+  --metadata-file=target/build-result-metadata_linux_publish.json
+
+* RESOLVED BAKE CONFIG:
+{
 ...
 --

--- a/Makefile
+++ b/Makefile
@@ -186,8 +186,13 @@ test: prepare-test
 	@make --silent list | while read image; do make --silent "test-$${image}"; done
 
 # Set all required variables and publish all targets
+# Calling publish.sh with `-n` (dry-run) arg in case `PUBLISH` is not set to true
 publish: target
+ifeq ($(PUBLISH),true)
 	./.ci/publish.sh
+else
+	./.ci/publish.sh -n
+endif
 
 clean:
 	rm -rf tests/test_helper/bats-*; \


### PR DESCRIPTION
While comparing current `stable-2.541` to `master` after the merge of the first backport pull requests, I've noticed I've missed #2211 (merged after I've started preparing the backport).

Backport of:

Refs:
- https://github.com/jenkinsci/docker/compare/b4e60877a915fa749f18a2d8768cb0d7a22b8568..6f04bb29686a2df07ce21264c7995152bc396462
- https://github.com/jenkinsci/docker/pull/2211
- https://github.com/jenkinsci/docker/issues/2195

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
