### PR TITLE
chore(github): keep only `.github` managed by dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,50 +2,7 @@
 version: 2
 updates:
 
-# Alpine Linux
-
-- package-ecosystem: docker
-  directory: "alpine/hotspot"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  labels:
-  - dependencies
-  ignore:
-  # Ignore proposals to update to new versions of Java because updatecli takes care of that.
-  - dependency-name: "eclipse-temurin"
-
-# Debian Linux
-
-- package-ecosystem: docker
-  directory: "debian"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  labels:
-  - dependencies
-  ignore:
-  # Ignore proposals to update to new versions of Java because updatecli takes care of that.
-  - dependency-name: "eclipse-temurin"
-
-# RHEL UBI
-
-- package-ecosystem: docker
-  directory: "rhel"
-  schedule:
-    interval: weekly
-  open-pull-requests-limit: 2
-  target-branch: master
-  labels:
-    - dependencies
-  ignore:
-  # Ignore proposals to update to new versions of Java because updatecli takes care of that.
-  - dependency-name: "eclipse-temurin"
-
 # GitHub actions
-
 - package-ecosystem: "github-actions"
   target-branch: master
   directory: "/"


### PR DESCRIPTION
This change removes all images folders from dependabot config to keep only `.github` monitored, as it's the only thing (appart from rhel/ubi9)* it really updates since a few months already:

<details>

<img width="1245" height="1294" alt="image" src="https://github.com/user-attachments/assets/3db641b2-a256-4e9d-97cc-63ab54dcadff" />

</details>

*Image updates are taken care of by updatecli, and the remaining hardcoded (ie not using an `ARG`) "ubi9" tag that dependabot was updating was removed in #2159.

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
