### PR TITLE
chore(updatecli): adapt `jenkins-version` manifest

### DIFF
--- a/updatecli/updatecli.d/jenkins-version.yaml
+++ b/updatecli/updatecli.d/jenkins-version.yaml
@@ -39,7 +39,7 @@ targets:
       path: variable.JENKINS_VERSION.default
   updateJenkinsVersionInDockerfiles:
     name: Update value of JENKINS_VERSION in Dockerfile
-    kind: file
+    kind: dockerfile
     scmid: default
     sourceid: latestVersion
     spec:
@@ -48,8 +48,9 @@ targets:
         - debian/Dockerfile
         - rhel/Dockerfile
         - windows/windowsservercore/hotspot/Dockerfile
-      matchpattern: :-(\d+\.\d+)}
-      replacepattern: :-{{ source "latestVersion" }}}
+      instruction:
+        keyword: "ARG"
+        matcher: "JENKINS_VERSION"
   updateJenkinsVersionInGoldenFiles:
     kind: file
     scmid: default
@@ -61,6 +62,15 @@ targets:
         - tests/golden/expected_tags_latest_weekly.txt
       matchpattern: :(\d+\.\d+)
       replacepattern: :{{ source "latestVersion" }}
+  updateJenkinsVersionInMakePs1:
+    name: Update value of $JenkinsVersion in make.ps1
+    kind: file
+    scmid: default
+    sourceid: latestVersion
+    spec:
+      file: make.ps1
+      matchpattern: JenkinsVersion = '(\d+\.\d+)'
+      replacepattern: JenkinsVersion = '{{ source "latestVersion" }}'
 
 actions:
   default:


### PR DESCRIPTION
Follow-up of:
- #2233

Also amends (for the missing make.ps1 target):
- #2171

Refs:
- #2203 

### Testing done

```
updatecli diff --config ./updatecli/updatecli.d/jenkins-version.yaml --values ./updatecli/values.github-action.yaml
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
