### PR TITLE
Use plugin installation manager tool 2.14.0

### DIFF
--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -208,7 +208,7 @@ Using the following settings:
         "DEBIAN_VERSION": "20251117",
         "JAVA_VERSION": "25.0.1_8",
         "JENKINS_VERSION": "2.528.3",
-        "PLUGIN_CLI_VERSION": "2.13.2",
+        "PLUGIN_CLI_VERSION": "2.14.0",
         "WAR_URL": "https://get.jenkins.io/war-stable/2.528.3/jenkins.war"
       },
       "tags": [

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -112,7 +112,7 @@ ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
 
-ARG PLUGIN_CLI_VERSION=2.13.2
+ARG PLUGIN_CLI_VERSION=2.14.0
 ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${PLUGIN_CLI_VERSION}/jenkins-plugin-manager-${PLUGIN_CLI_VERSION}.jar
 RUN curl -fsSL ${PLUGIN_CLI_URL} -o /opt/jenkins-plugin-manager.jar \
   && echo "$(curl -fsSL "${PLUGIN_CLI_URL}.sha256")  /opt/jenkins-plugin-manager.jar" >/tmp/jpm_sha \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -125,7 +125,7 @@ ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
 
-ARG PLUGIN_CLI_VERSION=2.13.2
+ARG PLUGIN_CLI_VERSION=2.14.0
 ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${PLUGIN_CLI_VERSION}/jenkins-plugin-manager-${PLUGIN_CLI_VERSION}.jar
 RUN curl -fsSL ${PLUGIN_CLI_URL} -o /opt/jenkins-plugin-manager.jar \
   && echo "$(curl -fsSL "${PLUGIN_CLI_URL}.sha256")  /opt/jenkins-plugin-manager.jar" >/tmp/jpm_sha \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -36,7 +36,7 @@ variable "LATEST_LTS" {
 }
 
 variable "PLUGIN_CLI_VERSION" {
-  default = "2.13.2"
+  default = "2.14.0"
 }
 
 variable "COMMIT_SHA" {

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -116,7 +116,7 @@ ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 RUN chown -R ${user} "$JENKINS_HOME" "$REF"
 
-ARG PLUGIN_CLI_VERSION=2.13.2
+ARG PLUGIN_CLI_VERSION=2.14.0
 ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${PLUGIN_CLI_VERSION}/jenkins-plugin-manager-${PLUGIN_CLI_VERSION}.jar
 RUN curl -fsSL ${PLUGIN_CLI_URL} -o /opt/jenkins-plugin-manager.jar \
   && echo "$(curl -fsSL "${PLUGIN_CLI_URL}.sha256")  /opt/jenkins-plugin-manager.jar" >/tmp/jpm_sha \

--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -127,7 +127,7 @@ ENV JENKINS_UC=https://updates.jenkins.io
 ENV JENKINS_UC_EXPERIMENTAL=https://updates.jenkins.io/experimental
 ENV JENKINS_INCREMENTALS_REPO_MIRROR=https://repo.jenkins-ci.org/incrementals
 
-ARG PLUGIN_CLI_VERSION=2.13.2
+ARG PLUGIN_CLI_VERSION=2.14.0
 ARG PLUGIN_CLI_URL=https://github.com/jenkinsci/plugin-installation-manager-tool/releases/download/${PLUGIN_CLI_VERSION}/jenkins-plugin-manager-${PLUGIN_CLI_VERSION}.jar
 RUN $sha256sum = [System.Text.Encoding]::UTF8.GetString((Invoke-WebRequest -Uri ($env:PLUGIN_CLI_URL + '.sha256') -UseBasicParsing).Content); `
     Invoke-WebRequest -Uri "$env:PLUGIN_CLI_URL" -OutFile C:/ProgramData/Jenkins/jenkins-plugin-manager.jar; `


### PR DESCRIPTION
## Use plugin installation manager tool 2.14.0

Recently released.  More details are available in the [changelog](https://github.com/jenkinsci/plugin-installation-manager-tool/releases/tag/2.14.0).

### Testing done

* Confirmed 2.14.0 is well behaved with a few local tests
* make build
* make test

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant pull requests, esp. upstream and downstream changes
