### PR TITLE
feat(linux): add `HEALTHCHECK` instruction

### DIFF
--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -125,6 +125,8 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -125,7 +125,7 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
@@ -144,7 +144,12 @@ ARG JENKINS_VERSION=2.549
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
+
+# Start period of 5m because Jenkins can be slow to start
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 # metadata labels
+
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Docker image" \

--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -125,8 +125,6 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-
-
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
@@ -144,12 +142,9 @@ ARG JENKINS_VERSION=2.549
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-
-# Start period of 5m because Jenkins can be slow to start
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
 
 # metadata labels
-
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Docker image" \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -138,6 +138,8 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -138,7 +138,7 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
@@ -157,7 +157,11 @@ ARG JENKINS_VERSION=2.549
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
+# Start period of 5m because Jenkins can be slow to start
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 # metadata labels
+
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Docker image" \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -138,8 +138,6 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-
-
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
@@ -157,11 +155,9 @@ ARG JENKINS_VERSION=2.549
 
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-# Start period of 5m because Jenkins can be slow to start
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
 
 # metadata labels
-
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Docker image" \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -129,8 +129,6 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-
-
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk
@@ -148,12 +146,9 @@ ARG JENKINS_VERSION=2.549
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
-
-# Start period of 5m because Jenkins can be slow to start
 HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
 
 # metadata labels
-
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Docker image" \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -129,7 +129,7 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
-HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
@@ -148,7 +148,12 @@ ARG JENKINS_VERSION=2.549
 
 ENTRYPOINT ["/sbin/tini", "--", "/usr/local/bin/jenkins.sh"]
 
+
+# Start period of 5m because Jenkins can be slow to start
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 # metadata labels
+
 LABEL \
     org.opencontainers.image.vendor="Jenkins project" \
     org.opencontainers.image.title="Official Jenkins Docker image" \

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -129,6 +129,8 @@ EXPOSE ${http_port}
 # will be used by attached agents:
 EXPOSE ${agent_port}
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=5m --retries=3 CMD curl -f http://localhost:8080/health || exit 1
+
 ENV COPY_REFERENCE_FILE_LOG=$JENKINS_HOME/copy_reference_file.log
 
 ENV JAVA_HOME=/opt/java/openjdk


### PR DESCRIPTION
Added `HEALTHCHECK` instruction to the `alpine`, `debian`, and `rhel` controller Dockerfiles to improve container orchestration and monitoring reliability. The healthcheck verifies that the Jenkins login page is accessible.

### Testing done

Validated that the `docker build` command successfully parses the Dockerfiles with the new `HEALTHCHECK` instruction.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed