### PR TITLE
Add environment variable substitution for reference configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,34 @@ COPY --chown=jenkins:jenkins custom.groovy /usr/share/jenkins/ref/init.groovy.d/
 
 If you need to maintain the entire init.groovy.d directory and have a persistent JENKINS_HOME you may run the docker image with `-e PRE_CLEAR_INIT_GROOVY_D=true`
 
+### Environment variable substitution for reference files
+
+By default, environment variable substitution is disabled to preserve backward compatibility.
+Set `JENKINS_ENABLE_ENV_SUBST=true` to enable it for configuration files copied from `/usr/share/jenkins/ref` to `$JENKINS_HOME` during container initialization.
+
+Supported syntax:
+- `${VAR}`
+- `${VAR:-default}`
+
+Supported file types: `.xml`, `.conf`, `.properties`, `.groovy`
+
+Example configuration file:
+```xml
+<jenkinsUrl>${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>
+<smtpHost>${SMTP_HOST}</smtpHost>
+```
+
+Example container startup:
+```bash
+docker run \
+  -e JENKINS_ENABLE_ENV_SUBST=true \
+  -e JENKINS_URL=https://jenkins.example.com \
+  -e SMTP_HOST=smtp.example.com \
+  jenkins/jenkins:lts-jdk21
+```
+> [!NOTE]
+> For most dynamic configuration use cases, [Jenkins Configuration as Code](https://www.jenkins.io/projects/jcasc/) remains the recommended approach.
+
 ## Preinstalling plugins
 
 ### Install plugins

--- a/jenkins-support
+++ b/jenkins-support
@@ -2,6 +2,32 @@
 
 : "${REF:="/usr/share/jenkins/ref"}"
 
+# Substitute environment variables in file content
+# Supports ${VAR} and ${VAR:-default} syntax
+substitute_env_vars() {
+    local file="$1"
+    local content
+    content=$(cat "${file}")
+    
+    # Loop until no more substitutions found
+    while [[ "${content}" =~ \$\{([A-Za-z_][A-Za-z0-9_]*)(:-([^}]*))?\} ]]; do
+        local var_name="${BASH_REMATCH[1]}"
+        local default_value="${BASH_REMATCH[3]}"
+        local full_match="${BASH_REMATCH[0]}"
+        
+        # Get variable value using indirect expansion, or use default if empty
+        local var_value="${!var_name:-}"
+        if [[ -z "${var_value}" && -n "${default_value}" ]]; then
+            var_value="${default_value}"
+        fi
+        
+        # Replace all occurrences
+        content="${content//${full_match}/${var_value}}"
+    done
+    
+    echo "${content}" > "${file}"
+}
+
 # compare if version1 < version2
 versionLT() {
     local normalized_version1 normalized_version2 first_part_of_1 other_part_of_1 first_char_other_part_of_1 first_part_of_2 other_part_of_2 first_char_other_part_of_2
@@ -150,6 +176,15 @@ copy_reference_file() {
             log=true
             mkdir -p "$JENKINS_HOME/${dir}"
             cp -pr "$(realpath "${f}")" "$JENKINS_HOME/${rel}";
+            
+            # Perform environment variable substitution on config files (opt-in)
+            if [[ "${JENKINS_ENABLE_ENV_SUBST:-false}" == "true" ]]; then
+                if [[ "$rel" == *.xml || "$rel" == *.conf || "$rel" == *.properties || "$rel" == *.groovy ]]; then
+                    if [[ -f "$JENKINS_HOME/${rel}" ]]; then
+                        substitute_env_vars "$JENKINS_HOME/${rel}"
+                    fi
+                fi
+            fi
         else
             action="SKIPPED"
         fi
@@ -162,3 +197,4 @@ copy_reference_file() {
         fi
     fi
 }
+

--- a/jenkins-support
+++ b/jenkins-support
@@ -197,4 +197,3 @@ copy_reference_file() {
         fi
     fi
 }
-

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -68,3 +68,44 @@ SUT_DESCRIPTION="${IMAGE}-functions"
   # Cleanup
   run docker volume rm "${volume_name}"
 }
+
+@test "[${SUT_DESCRIPTION}] substitute_env_vars replaces variable with env value" {
+  run docker run --rm $SUT_IMAGE bash -c "
+    source /usr/local/bin/jenkins-support
+    tmp=\$(mktemp)
+    echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > \$tmp
+    JENKINS_URL=http://prod.example.com substitute_env_vars \$tmp
+    cat \$tmp
+  "
+  assert_success
+  assert_output '<jenkinsUrl>http://prod.example.com</jenkinsUrl>'
+}
+
+@test "[${SUT_DESCRIPTION}] substitute_env_vars uses default when variable unset" {
+  run docker run --rm $SUT_IMAGE bash -c "
+    source /usr/local/bin/jenkins-support
+    tmp=\$(mktemp)
+    echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > \$tmp
+    unset JENKINS_URL
+    substitute_env_vars \$tmp
+    cat \$tmp
+  "
+  assert_success
+  assert_output '<jenkinsUrl>http://localhost:8080/</jenkinsUrl>'
+}
+
+@test "[${SUT_DESCRIPTION}] copy_reference_file skips substitution when JENKINS_ENABLE_ENV_SUBST is unset" {
+  run docker run --rm \
+    -e JENKINS_ENABLE_ENV_SUBST=false \
+    -e JENKINS_URL=http://prod.example.com \
+    --volume "$(mktemp -d):/var/jenkins_home" \
+    $SUT_IMAGE bash -c "
+      mkdir -p /usr/share/jenkins/ref
+      echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > /usr/share/jenkins/ref/test.xml
+      source /usr/local/bin/jenkins-support
+      copy_reference_file /usr/share/jenkins/ref/test.xml
+      cat /var/jenkins_home/test.xml
+    "
+  assert_success
+  assert_output '<jenkinsUrl>${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>'
+}

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -70,11 +70,14 @@ SUT_DESCRIPTION="${IMAGE}-functions"
 }
 
 @test "[${SUT_DESCRIPTION}] substitute_env_vars replaces variable with env value" {
+  local volume_name
+  volume_name="subst_replace_${BATS_TEST_NUMBER}"
+  run bash -c "docker volume rm -f ${volume_name}; docker volume create ${volume_name}"
   run docker run --rm \
     -e JENKINS_ENABLE_ENV_SUBST=true \
     -e JENKINS_URL=http://prod.example.com \
-    --volume "$(mktemp -d):/var/jenkins_home" \
-    $SUT_IMAGE bash -c "
+    --volume "${volume_name}:/var/jenkins_home" \
+    "${SUT_IMAGE}" bash -c "
       mkdir -p /usr/share/jenkins/ref
       echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > /usr/share/jenkins/ref/test.xml
       source /usr/local/bin/jenkins-support
@@ -83,27 +86,37 @@ SUT_DESCRIPTION="${IMAGE}-functions"
     "
   assert_success
   assert_output '<jenkinsUrl>http://prod.example.com</jenkinsUrl>'
+  run docker volume rm "${volume_name}"
 }
 
 @test "[${SUT_DESCRIPTION}] substitute_env_vars uses default when variable unset" {
-  run docker run --rm $SUT_IMAGE bash -c "
-    source /usr/local/bin/jenkins-support
-    tmp=\$(mktemp)
-    echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > \$tmp
-    unset JENKINS_URL
-    substitute_env_vars \$tmp
-    cat \$tmp
-  "
+  local volume_name
+  volume_name="subst_default_${BATS_TEST_NUMBER}"
+  run bash -c "docker volume rm -f ${volume_name}; docker volume create ${volume_name}"
+  run docker run --rm \
+    -e JENKINS_ENABLE_ENV_SUBST=true \
+    --volume "${volume_name}:/var/jenkins_home" \
+    "${SUT_IMAGE}" bash -c "
+      mkdir -p /usr/share/jenkins/ref
+      echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > /usr/share/jenkins/ref/test.xml
+      source /usr/local/bin/jenkins-support
+      copy_reference_file /usr/share/jenkins/ref/test.xml
+      cat /var/jenkins_home/test.xml
+    "
   assert_success
   assert_output '<jenkinsUrl>http://localhost:8080/</jenkinsUrl>'
+  run docker volume rm "${volume_name}"
 }
 
 @test "[${SUT_DESCRIPTION}] copy_reference_file skips substitution when JENKINS_ENABLE_ENV_SUBST is unset" {
+  local volume_name
+  volume_name="subst_skip_${BATS_TEST_NUMBER}"
+  run bash -c "docker volume rm -f ${volume_name}; docker volume create ${volume_name}"
   run docker run --rm \
     -e JENKINS_ENABLE_ENV_SUBST=false \
     -e JENKINS_URL=http://prod.example.com \
-    --volume "$(mktemp -d):/var/jenkins_home" \
-    $SUT_IMAGE bash -c "
+    --volume "${volume_name}:/var/jenkins_home" \
+    "${SUT_IMAGE}" bash -c "
       mkdir -p /usr/share/jenkins/ref
       echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > /usr/share/jenkins/ref/test.xml
       source /usr/local/bin/jenkins-support
@@ -112,4 +125,5 @@ SUT_DESCRIPTION="${IMAGE}-functions"
     "
   assert_success
   assert_output '<jenkinsUrl>${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>'
+  run docker volume rm "${volume_name}"
 }

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -70,13 +70,17 @@ SUT_DESCRIPTION="${IMAGE}-functions"
 }
 
 @test "[${SUT_DESCRIPTION}] substitute_env_vars replaces variable with env value" {
-  run docker run --rm $SUT_IMAGE bash -c "
-    source /usr/local/bin/jenkins-support
-    tmp=\$(mktemp)
-    echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > \$tmp
-    JENKINS_URL=http://prod.example.com substitute_env_vars \$tmp
-    cat \$tmp
-  "
+  run docker run --rm \
+    -e JENKINS_ENABLE_ENV_SUBST=true \
+    -e JENKINS_URL=http://prod.example.com \
+    --volume "$(mktemp -d):/var/jenkins_home" \
+    $SUT_IMAGE bash -c "
+      mkdir -p /usr/share/jenkins/ref
+      echo '<jenkinsUrl>\${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' > /usr/share/jenkins/ref/test.xml
+      source /usr/local/bin/jenkins-support
+      copy_reference_file /usr/share/jenkins/ref/test.xml
+      cat /var/jenkins_home/test.xml
+    "
   assert_success
   assert_output '<jenkinsUrl>http://prod.example.com</jenkinsUrl>'
 }


### PR DESCRIPTION
Implements environment variable substitution for configuration files copied from `/usr/share/jenkins/ref/` to `$JENKINS_HOME` during container initialization.

### Problem

Users frequently need to parameterize Jenkins configuration files (XML, properties) with values that vary across environments (URLs, credentials, feature flags). The current implementation copies reference files verbatim, requiring workarounds like Groovy init scripts for dynamic configuration.

### Solution

Added `substitute_env_vars()` function to `jenkins-support` that processes configuration files after copying. Supports standard shell substitution syntax:

- `${VAR}` - Replaced with environment variable value
- `${VAR:-default}` - Replaced with env var or default if unset

Applied to `.xml`, `.conf`, `.properties` and `.groovy` files during `copy_reference_file()` execution.

<!-- Please describe your pull request here. -->


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

Manual verification performed with the following scenarios:

**Scenario 1: Full environment substitution**
```bash
docker run -e JENKINS_URL=http://prod.company.com \
           -e SMTP_HOST=smtp.company.com \
           jenkins/jenkins:lts

```
Result: All placeholders replaced with provided values.

**Scenario 2: Partial substitution with defaults**
```bash
docker run -e JENKINS_URL=http://custom.com jenkins/jenkins:lts
```
Result: JENKINS_URL substituted, SMTP_HOST used default value from ${SMTP_HOST:-smtp.default.com}.

**Scenario 3: No environment variables**
```bash
docker run jenkins/jenkins:lts
```
Result: All placeholders used default values from ${VAR:-default} syntax.

**Before Fix:**
<img width="1920" height="967" alt="Screenshot from 2026-02-08 23-57-33" src="https://github.com/user-attachments/assets/42ad69b7-129c-4ac1-95e3-f86541d70c7b" />

**After Fix:**
<img width="1920" height="967" alt="Screenshot from 2026-02-09 01-12-25" src="https://github.com/user-attachments/assets/3079c961-9574-4276-9cfb-1b0371a35270" />

Closes #448


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
