### PR TITLE
fix: prevent images publication if not latest Weekly or LTS

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -12,6 +12,7 @@ set -eu -o pipefail
 : "${DOCKERHUB_ORGANISATION:=jenkins}"
 : "${DOCKERHUB_REPO:=jenkins}"
 : "${BAKE_TARGET:=linux}"
+: "${BYPASS_LATEST_PUBLICATION_ONLY:=false}"
 
 export JENKINS_REPO="${DOCKERHUB_ORGANISATION}/${DOCKERHUB_REPO}"
 
@@ -76,6 +77,16 @@ else
     LATEST_LTS="false"
 fi
 
+if [[ "${LATEST_WEEKLY}" == "false" && "${LATEST_LTS}" == "false" ]]; then
+    if [[ "${BYPASS_LATEST_PUBLICATION_ONLY}" == "false" ]]; then
+        echo "ERROR: ${JENKINS_VERSION} is neither the lastest Weekly nor the latest LTS version, not publishing any image"
+        exit 1
+    else
+        echo "WARNING: ${JENKINS_VERSION} is neither the lastest Weekly nor the latest LTS version"
+        echo 'As BYPASS_LATEST_PUBLICATION_ONLY has been set to "true", still proceeding to its publication'
+    fi
+fi
+
 build_opts=("--pull")
 metadata_suffix="publish"
 if test "${dry_run}" == "true"; then
@@ -100,6 +111,9 @@ Using the following settings:
 * COMMIT_SHA: ${COMMIT_SHA}
 * LATEST_WEEKLY: ${LATEST_WEEKLY}
 * LATEST_LTS: ${LATEST_LTS}
+* latest_weekly_version: ${latest_weekly_version}
+* latest_lts_version: ${latest_lts_version}
+* BYPASS_ONLY_LATEST_PUBLICATION: ${BYPASS_ONLY_LATEST_PUBLICATION}
 * BUILD_METADATA_PATH: ${BUILD_METADATA_PATH}
 * BAKE_TARGET: ${BAKE_TARGET}
 * BAKE OPTIONS:

--- a/HACKING.adoc
+++ b/HACKING.adoc
@@ -164,6 +164,9 @@ Using the following settings:
 * COMMIT_SHA: 1c72a9383191562eb3c44838aeeadad0839c2c92
 * LATEST_WEEKLY: false
 * LATEST_LTS: true
+* latest_weekly_version: 2.545
+* latest_lts_version: 2.528.3
+* BYPASS_ONLY_LATEST_PUBLICATION: false
 * BUILD_METADATA_PATH: target/build-result-metadata_linux_dry-run.json
 [+] Building 104.6s (59/73)
 <...snip...>
@@ -181,6 +184,9 @@ Using the following settings:
 * COMMIT_SHA: aaf4e7faf887b7ac4879c3bf540ede48220cca9f
 * LATEST_WEEKLY: false
 * LATEST_LTS: true
+* latest_weekly_version: 2.545
+* latest_lts_version: 2.528.3
+* BYPASS_ONLY_LATEST_PUBLICATION: false
 * BUILD_METADATA_PATH: target/build-result-metadata_debian_jdk25_dry-run.json
 * BAKE TARGET: debian_jdk25
 * BUILDX OPTIONS:
@@ -231,6 +237,9 @@ Using the following settings:
 
 You can also pass the `-d` option (debug) to see traces from the script.
 
+If you need to publish images with a JENKINS_VERSION which is not the latest Weekly nor the latest LTS from Artifactory,
+set `BYPASS_LATEST_PUBLICATION_ONLY` to `true`.
+
 === Using an overridden target repository on Docker Hub
 
 Create a new dedicated target repository in your Docker Hub account, and use it like follows (note the absence of `-d` option):
@@ -248,6 +257,9 @@ Using the following settings:
 * COMMIT_SHA: aaf4e7faf887b7ac4879c3bf540ede48220cca9f
 * LATEST_WEEKLY: false
 * LATEST_LTS: true
+* latest_weekly_version: 2.545
+* latest_lts_version: 2.528.3
+* BYPASS_ONLY_LATEST_PUBLICATION: false
 * BUILD_METADATA_PATH: target/build-result-metadata_linux_publish.json
 * BAKE TARGET: linux
 * BUILDX OPTIONS:


### PR DESCRIPTION
This change prevents the publication of images if `JENKINS_VERSION` is not the latest Weekly nor the latest LTS, to avoid unexpectedly republishing old tags.

In case we would need to publish an image with a `JENKINS_VERSION` not in https://repo.jenkins-ci.org/releases/org/jenkins-ci/main/jenkins-war/maven-metadata.xml, `BYPASS_ONLY_LATEST_PUBLICATION` can be set to `true`.

Ref:
- Thread in `#jenkinsci/release` gitter channel: https://matrix.to/#/!JlkqzpdEnsUUuVtjgE:matrix.org/$Umz_fnStdhmzhPD4RGasDXt8L_nIHD4jiB8wxCR-9Qg?via=matrix.org&via=gitter.im

### Testing done

<details><summary>.ci/publish.sh</summary>

```bash
# No JENKINS_VERSION set, using the one currently defined in the repository (no exit as expected)
$ .ci/publish.sh -n 
Using the following settings:
* JENKINS_REPO: jenkins/jenkins
* JENKINS_VERSION: 2.550
* COMMIT_SHA: 37b46e7ac2ba61131f417987d566f57506d7e02f
* LATEST_WEEKLY: true
* LATEST_LTS: false
* latest_weekly_version: 2.550
* latest_lts_version: 2.541.1
* BYPASS_ONLY_LATEST_PUBLICATION: false
<snip>

# Old Weekly version
$ JENKINS_VERSION=2.123 .ci/publish.sh   
ERROR: 2.123 is neither the lastest Weekly nor the latest LTS version, not publishing any image

# Old Weekly version with bypass
$ BYPASS_ONLY_LATEST_PUBLICATION=true JENKINS_VERSION=2.123 .ci/publish.sh
WARNING: 2.123 is neither the lastest Weekly nor the latest LTS version
As BYPASS_ONLY_LATEST_PUBLICATION has been set to "true", still proceeding to its publication
Using the following settings:
* JENKINS_REPO: jenkins/jenkins
* JENKINS_VERSION: 2.123
* COMMIT_SHA: 37b46e7ac2ba61131f417987d566f57506d7e02f
* LATEST_WEEKLY: false
* LATEST_LTS: false
* latest_weekly_version: 2.550
* latest_lts_version: 2.541.1
* BYPASS_ONLY_LATEST_PUBLICATION: true
<snip>

# Old LTS version
$ JENKINS_VERSION=2.123.4 .ci/publish.sh
ERROR: 2.123.4 is neither the lastest Weekly nor the latest LTS version, not publishing any image

# Old LTS version with bypass
$ BYPASS_ONLY_LATEST_PUBLICATION=true JENKINS_VERSION=2.123.4 .ci/publish.sh
WARNING: 2.123.4 is neither the lastest Weekly nor the latest LTS version
As BYPASS_ONLY_LATEST_PUBLICATION has been set to "true", still proceeding to its publication
Using the following settings:
* JENKINS_REPO: jenkins/jenkins
* JENKINS_VERSION: 2.123.4
* COMMIT_SHA: 37b46e7ac2ba61131f417987d566f57506d7e02f
* LATEST_WEEKLY: false
* LATEST_LTS: false
* latest_weekly_version: 2.550
* latest_lts_version: 2.541.1
* BYPASS_ONLY_LATEST_PUBLICATION: true
<snip>

# Current LTS version
$ JENKINS_VERSION=2.541.1 .ci/publish.sh
Using the following settings:
* JENKINS_REPO: jenkins/jenkins
* JENKINS_VERSION: 2.541.1
* COMMIT_SHA: 61cc78de5ccbcfb230da57f1d52b2d76c7ce620e
* LATEST_WEEKLY: false
* LATEST_LTS: true
* latest_weekly_version: 2.550
* latest_lts_version: 2.541.1
* BYPASS_ONLY_LATEST_PUBLICATION: false
<snip>
```

</details>

<details><summary>./make.ps1</summary>

```powershell
$ pwsh

# No JENKINS_VERSION set, using the one currently defined in the repository (no exit as expected)
PS> ./make.ps1 -Target publish                        
yq (https://github.com/mikefarah/yq/) version v4.47.1
= PREPARE: Checking if 2.550 is latest Weekly or LTS...
latest Weekly version: 2.550
latest LTS version: 2.541.1
= PREPARE: Initialize the docker compose file 'build-windows_windowsservercore-ltsc2022.yaml' containing the image definitions.
= PREPARE: Docker compose file generation for windowsservercore-ltsc2022
= PREPARE: List of images and tags to be processed:
<snip>
= PUBLISH: push all images and tags
<snip, publication>

# Old Weekly version
PS> $env:JENKINS_VERSION = "2.123"        
PS> ./make.ps1 -Target publish                        
yq (https://github.com/mikefarah/yq/) version v4.47.1
= PREPARE: Checking if 2.123 is latest Weekly or LTS...
latest Weekly version: 2.550
latest LTS version: 2.541.1
WARNING: 2.123 is neither the lastest Weekly nor the latest LTS version
= PREPARE: Initialize the docker compose file 'build-windows_windowsservercore-ltsc2022.yaml' containing the image definitions.
<snip>
= PUBLISH: push all images and tags
ERROR: 2.123 is neither the lastest Weekly nor the latest LTS version

# Old Weekly version with bypass
PS> $env:JENKINS_VERSION = "2.123"
PS> $env:BYPASS_ONLY_LATEST_PUBLICATION = $true    
PS> ./make.ps1 -Target publish                        
yq (https://github.com/mikefarah/yq/) version v4.47.1
= PREPARE: Checking if 2.123 is latest Weekly or LTS...
latest Weekly version: 2.550
latest LTS version: 2.541.1
WARNING: 2.123 is neither the lastest Weekly nor the latest LTS version
= PREPARE: Initialize the docker compose file 'build-windows_windowsservercore-ltsc2022.yaml' containing the image definitions.
<snip>
= PUBLISH: push all images and tags
WARNING: as BYPASS_ONLY_LATEST_PUBLICATION has been set to "true", still proceeding to publication
<snip, publication>

# Old LTS version
PS> $env:JENKINS_VERSION = "2.123.4"          
PS> ./make.ps1 -Target publish      
yq (https://github.com/mikefarah/yq/) version v4.47.1
= PREPARE: Checking if 2.123.4 is latest Weekly or LTS...
latest Weekly version: 2.550
latest LTS version: 2.541.1
WARNING: 2.123.4 is neither the lastest Weekly nor the latest LTS version
= PREPARE: Initialize the docker compose file 'build-windows_windowsservercore-ltsc2022.yaml' containing the image definitions.
<snip>
= PUBLISH: push all images and tags
ERROR: 2.123.4 is neither the lastest Weekly nor the latest LTS version

# Current LTS version
PS> $env:JENKINS_VERSION = "2.541.1"                  
PS> ./make.ps1 -Target publish      
yq (https://github.com/mikefarah/yq/) version v4.47.1
= PREPARE: Checking if 2.541.1 is latest Weekly or LTS...
latest Weekly version: 2.550
latest LTS version: 2.541.1
= PREPARE: Initialize the docker compose file 'build-windows_windowsservercore-ltsc2022.yaml' containing the image definitions.
<snip>
= PUBLISH: push all images and tags
<snip, publication>
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
