### PR TITLE
feat: add linux/riscv64 platform to Debian images

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -20,6 +20,7 @@ def architecturesAndCiJioAgentLabels = [
     'arm64': 'arm64docker',
     // Using qemu
     'ppc64le': 'docker && amd64',
+    'riscv64': 'docker && amd64',
     's390x': 'docker && amd64',
 ]
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -276,7 +276,7 @@ function "platforms" {
     : is_debian_slim(distribution)
     ? (equal(17, jdk)
       ? ["linux/amd64"]
-    : ["linux/amd64", "linux/arm64"])
+    : ["linux/amd64", "linux/arm64", "linux/riscv64"])
 
     # RHEL
     : is_rhel(distribution)

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -283,7 +283,7 @@ function "platforms" {
     ? ["linux/amd64", "linux/arm64", "linux/ppc64le"]
 
     # Default (Debian)
-    : ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le"]
+    : ["linux/amd64", "linux/arm64", "linux/s390x", "linux/ppc64le", "linux/riscv64"]
   )
 }
 

--- a/tests/golden/expected_platforms.txt
+++ b/tests/golden/expected_platforms.txt
@@ -9,10 +9,12 @@ debian-slim_jdk25:linux/arm64
 debian_jdk21:linux/amd64
 debian_jdk21:linux/arm64
 debian_jdk21:linux/ppc64le
+debian_jdk21:linux/riscv64
 debian_jdk21:linux/s390x
 debian_jdk25:linux/amd64
 debian_jdk25:linux/arm64
 debian_jdk25:linux/ppc64le
+debian_jdk25:linux/riscv64
 debian_jdk25:linux/s390x
 rhel_jdk21:linux/amd64
 rhel_jdk21:linux/arm64

--- a/tests/golden/expected_platforms.txt
+++ b/tests/golden/expected_platforms.txt
@@ -4,8 +4,10 @@ alpine_jdk25:linux/amd64
 alpine_jdk25:linux/arm64
 debian-slim_jdk21:linux/amd64
 debian-slim_jdk21:linux/arm64
+debian-slim_jdk21:linux/riscv64
 debian-slim_jdk25:linux/amd64
 debian-slim_jdk25:linux/arm64
+debian-slim_jdk25:linux/riscv64
 debian_jdk21:linux/amd64
 debian_jdk21:linux/arm64
 debian_jdk21:linux/ppc64le


### PR DESCRIPTION
## Summary

- Add `linux/riscv64` to the default (Debian) platform list in the `platforms()` function of `docker-bake.hcl`
- Debian-only as discussed in #2272; Alpine, RHEL, and slim variants remain unchanged

## Context

Adoptium provides JDK 21 and 25 binaries for riscv64, and Debian Trixie supports the architecture natively. The `jdk-download-url.sh` script already handles riscv64 via `uname -m` without changes.

The Jenkins Docker agents already ship riscv64 images (jenkinsci/docker-agents#1168, released in v3355.v388858a_47b_33-16). This PR completes the set by adding riscv64 to the controller image.

## Test plan

- [ ] Verify `docker buildx bake debian --print` includes `linux/riscv64` in the platforms list
- [ ] Build Debian JDK21 image for riscv64 and verify Jenkins starts
- [ ] Confirm Alpine, RHEL, and slim targets are unchanged

Fixes #2272