### PR TITLE
hotfix: pass `-SkipPublisherCheck` parameter to Pester module installation

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -259,7 +259,8 @@ if ($target -eq 'test') {
         $mod = Get-InstalledModule -Name Pester -MinimumVersion 5.3.0 -MaximumVersion 5.3.3 -ErrorAction SilentlyContinue
         if ($null -eq $mod) {
             Write-Host '= TEST: Pester 5.3.x not found: installing...'
-            Install-Module -Force -Name Pester -MaximumVersion 5.3.3 -Scope CurrentUser
+            # TODO: remove -SkipPublisherCheck when Pester 3.4.0 isn't present by default in Windows agents images anymore
+            Install-Module -Force -Name Pester -MaximumVersion 5.3.3 -Scope CurrentUser -SkipPublisherCheck
         }
 
         Import-Module Pester


### PR DESCRIPTION
This change skips (for now) the signing certificate check for Pester, incompatible between the 3.4.0 version installed by default by Microsoft and the newer ones.

The long term fix is to remove the default 3.4.0 Pester module from agent images. (Only used in our docker image repositories AFAIK)

Ref:
- https://pester.dev/docs/v4/introduction/installation#installing-from-psgallery-windows-10-or-windows-server-2016
- https://github.com/jenkinsci/docker/issues/2308


### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
