### PR TITLE
Revert "hotfix: pass `-SkipPublisherCheck` parameter to Pester module installation"

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -259,8 +259,7 @@ if ($target -eq 'test') {
         $mod = Get-InstalledModule -Name Pester -MinimumVersion 5.3.0 -MaximumVersion 5.3.3 -ErrorAction SilentlyContinue
         if ($null -eq $mod) {
             Write-Host '= TEST: Pester 5.3.x not found: installing...'
-            # TODO: remove -SkipPublisherCheck when Pester 3.4.0 isn't present by default in Windows agents images anymore
-            Install-Module -Force -Name Pester -MaximumVersion 5.3.3 -Scope CurrentUser -SkipPublisherCheck
+            Install-Module -Force -Name Pester -MaximumVersion 5.3.3 -Scope CurrentUser
         }
 
         Import-Module Pester


### PR DESCRIPTION
Reverts jenkinsci/docker#2309

Follow-up of:
- https://github.com/jenkins-infra/packer-images/pull/2652

Ref:
- https://github.com/jenkinsci/docker/issues/2308