### PR TITLE
Remove a trailing space from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run -p 8080:8080 -p 50000:50000 --restart=on-failure jenkins/jenkins:lts-
 ```
 
 NOTE: Read the section [_Connecting agents_](#connecting-agents) below for the role of the `50000` port mapping.
-NOTE: Read the section [_DNS Configuration_](#dns-configuration) in case you see the message "This Jenkins instance appears to be offline." 
+NOTE: Read the section [_DNS Configuration_](#dns-configuration) in case you see the message "This Jenkins instance appears to be offline."
 
 This will store the workspace in `/var/jenkins_home`.
 All Jenkins data lives in there - including plugins and configuration.


### PR DESCRIPTION
## Remove a trailing space from README

No benefit to a trailing space character on one line of the README.

### Testing done

None.  Change is harmless

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
