### PR TITLE
fix: do not skip plugin upgrades on maintenance-branch version bumps

### DIFF
--- a/jenkins-support
+++ b/jenkins-support
@@ -4,7 +4,7 @@
 
 # compare if version1 < version2
 versionLT() {
-    local normalized_version1 normalized_version2 first_part_of_1 first_char_other_part_of_1 first_part_of_2
+    local normalized_version1 normalized_version2 first_part_of_1 other_part_of_1 first_char_other_part_of_1 first_part_of_2 other_part_of_2 first_char_other_part_of_2
 
     # Quick check for equality
     if [ "$1" = "$2" ]; then
@@ -18,18 +18,34 @@ versionLT() {
     other_part_of_1=${normalized_version1#*.}
     first_char_other_part_of_1=${other_part_of_1:0:1}
     first_part_of_2=${normalized_version2%%.*}
+    other_part_of_2=${normalized_version2#*.}
+    first_char_other_part_of_2=${other_part_of_2:0:1}
 
 
-    # Security fix backport special case
+    # Security fix backport / maintenance-branch special case.
     # Ex: 3894.vd0f0248b_a_fc4 < 3894.3896.vca_2c931e7935
     # -> normal incrementals version includes a "v" as first char of second part
     # -> security fix backport adds the backport source first part as second part
     # https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/3894.vd0f0248b_a_fc4
     # https://github.com/jenkinsci/workflow-cps-plugin/releases/tag/3894.3896.vca_2c931e7935
+    #
+    # Whenever the first parts match and exactly one of the two "second parts"
+    # starts with "v", that side is the older one regardless of argument order.
+    # The check has to be symmetric: copy_reference_file() calls versionLT()
+    # with the image version as $1 and the installed version as $2, so the
+    # original one-sided check missed the "image is the 4-part backport,
+    # installed is the 3-part normal release" direction. In that direction the
+    # function would otherwise fall through to `sort --version-sort`, which
+    # ranks the older "<base>.v<sha>" form *after* the newer
+    # "<base>.<buildnum>.v<sha>" form (because "v" sorts after digits in
+    # ASCII), and the entrypoint would silently skip the upgrade.
+    # Tracked at https://github.com/jenkinsci/docker/issues/2328
     if [[ "$first_part_of_1" = "$first_part_of_2" ]]; then
-        # If the second part of $version1 starts with a "v", then $version1 is older
-        if [[ "$first_char_other_part_of_1" == "v" ]]; then
+        if [[ "$first_char_other_part_of_1" == "v" && "$first_char_other_part_of_2" != "v" ]]; then
             return 0
+        fi
+        if [[ "$first_char_other_part_of_2" == "v" && "$first_char_other_part_of_1" != "v" ]]; then
+            return 1
         fi
     fi
 

--- a/tests/functions.bats
+++ b/tests/functions.bats
@@ -34,6 +34,21 @@ SUT_DESCRIPTION="${IMAGE}-functions"
   # workflow-cps-plugin, security fix backport of an older release, published later than a newer normal release
   run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 4106.4108.v841a_e1819d4d 4151.v5406e29e3c90"
   assert_success
+  ## https://github.com/jenkinsci/docker/issues/2328
+  ## Reverse-direction cases: image is the 4-part backport / maintenance release, installed is the 3-part normal release.
+  ## copy_reference_file() calls versionLT(image, container) at this site, so the workaround has to handle both argument orders.
+  # workflow-cps-plugin, reverse-direction
+  run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 3894.3896.vca_2c931e7935 3894.vd0f0248b_a_fc4"
+  assert_failure
+  # github-branch-source-plugin, 1967.x security maintenance branch
+  run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 1967.1969.v205fd594c821 1967.vdea_d580c1a_b_a_"
+  assert_failure
+  # workflow-job-plugin, same shape
+  run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 1571.1580.v18e46842c125 1571.vb_423c255d6d9"
+  assert_failure
+  # role-strategy-plugin, reverse-direction
+  run docker run --rm $SUT_IMAGE bash -c "source /usr/local/bin/jenkins-support && versionLT 587.588.v850a_20a_30162 587.v2872c41fa_e51"
+  assert_failure
 }
 
 @test "[${SUT_DESCRIPTION}] permissions are propagated from override file" {


### PR DESCRIPTION
Fix `versionLT` to correctly account for newer maintenance-version from the image vs. what's currently installed in the container.

This fixes the **first** part of the problem reported in https://github.com/jenkinsci/docker/issues/2328, see the issue for details.

### Testing done

Added test cases - failing on master, passing with the fix.


### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
