### PR TITLE
chore(updatecli): track JDK21 version in Dockerfiles

### DIFF
--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -49,6 +49,23 @@ targets:
       file: docker-bake.hcl
       path: variable.JAVA21_VERSION.default
     scmid: default
+  setJDK21Version:
+    name: "Bump JDK21 version in Dockerfiles"
+    kind: dockerfile
+    transformers:
+      - replacer:
+          from: "+"
+          to: "_"
+    spec:
+      files:
+        - alpine/hotspot/Dockerfile
+        - debian/Dockerfile
+        - rhel/Dockerfile
+        - windows/windowsservercore/hotspot/Dockerfile
+      instruction:
+        keyword: ARG
+        matcher: JAVA_VERSION
+    scmid: default
 
 actions:
   default:


### PR DESCRIPTION
This changes restores the target updating all Dockerfiles for the main JDK (21).

Ref:
- https://github.com/jenkinsci/docker/pull/2334#issuecomment-4418448219

### Testing done
CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
