### PR TITLE
chore(updatecli): fix `rhel-latest-tag.sh` script

### DIFF
--- a/updatecli/scripts/rhel-latest-tag.sh
+++ b/updatecli/scripts/rhel-latest-tag.sh
@@ -50,14 +50,11 @@ fi
 # - The response is expected to be a JSON object containing repository data.
 # - The script uses `jq` to:
 #   1. Iterate over all repositories in the `data` array.
-#   2. Select repositories where at least one tag has the name "latest".
-#   3. From those repositories, select tags that:
-#      - Do not have the name "latest".
-#      - Contain a hyphen in their name (indicating a long-form tag).
-#   4. Extract the `name` of the matching tags.
-#   5. Sort the tag names uniquely (`sort -u`).
-#   6. Take the last tag in the sorted list (`tail -n 1`), which is assumed to be the most recent valid tag.
-latest_tag=$(echo "$response" | jq -r '.data[].repositories[] | select(.tags[].name == "latest") | .tags[] | select(.name != "latest" and (.name | contains("-"))) | .name' | sort -u | tail -n 1)
+#   2. Extract the `name` of all tags
+#   3. Filter on those containing a hyphen in their name (indicating a long-form tag).
+#   4. Sort the tag names uniquely (`sort -u`).
+#   5. Take the last tag in the sorted list (`tail -n 1`), which is assumed to be the most recent valid tag.
+latest_tag=$(echo "$response" | jq -r '.data[].repositories[].tags[].name' | grep '-' | sort -u | tail -n 1)
 
 
 # Check if the latest_tag is empty


### PR DESCRIPTION
This change simplifies the command to extract the latest tag name from RedHat API as it doesn't seem to mention any "latest" anymore.

Fix:
- #2343 

### Testing done

```bash
curl --silent --fail --location --connect-timeout 10 --retry 3 --retry-delay 2 --max-time 30 --header 'accept: application/json' 'https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.access.redhat.com/repository/ubi9/images?page_size=100&page=0&sort_by=last_update_date%5Bdesc%5D' | jq -r '.data[].repositories[].tags[].name' | grep '-' | sort -u | tail -n 1
9.7-1778461714
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
