### PR TITLE
Initialize Git LFS for jenkins user

### DIFF
--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -132,6 +132,7 @@ COPY --from=jre-and-war /javaruntime $JAVA_HOME
 COPY --from=jre-and-war /war/jenkins.war /usr/share/jenkins/jenkins.war
 
 USER ${user}
+RUN git lfs install
 
 COPY jenkins-support /usr/local/bin/jenkins-support
 COPY jenkins.sh /usr/local/bin/jenkins.sh


### PR DESCRIPTION
Git LFS was initialized before switching to the `jenkins` user, which applies the configuration only for the root user.

This change initializes Git LFS after switching to the `jenkins` user so Git LFS configuration is available in the Jenkins runtime environment.
