### PR TITLE
fix(alpine,debian) Install `git-lfs` config at system scope

### DIFF
--- a/alpine/hotspot/Dockerfile
+++ b/alpine/hotspot/Dockerfile
@@ -69,7 +69,7 @@ RUN apk add --no-cache \
     ttf-dejavu \
     tzdata \
     unzip \
-  && git lfs install
+  && git lfs install --skip-repo --system
 
 ENV LANG=C.UTF-8
 

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -82,6 +82,7 @@ RUN arch=$(uname -m | sed -e 's/x86_64/amd64/g' -e 's/aarch64/arm64/g') \
   && curl -L -s -o git-lfs.tgz "https://github.com/git-lfs/git-lfs/releases/download/v${GIT_LFS_VERSION}/git-lfs-linux-${arch}-v${GIT_LFS_VERSION}.tar.gz" \
   && tar xzf git-lfs.tgz \
   && bash git-lfs-*/install.sh \
+  && git lfs install --skip-repo --system \
   && rm -rf git-lfs*
 
 ENV LANG=C.UTF-8

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -68,8 +68,7 @@ RUN dnf install --disableplugin=subscription-manager --setopt=install_weak_deps=
         unzip \
         which \
         tzdata \
-    && dnf clean --disableplugin=subscription-manager all \
-    && git lfs install --skip-repo --system
+    && dnf clean --disableplugin=subscription-manager all
 
 ARG user=jenkins
 ARG group=jenkins

--- a/rhel/Dockerfile
+++ b/rhel/Dockerfile
@@ -68,7 +68,8 @@ RUN dnf install --disableplugin=subscription-manager --setopt=install_weak_deps=
         unzip \
         which \
         tzdata \
-    && dnf clean --disableplugin=subscription-manager all
+    && dnf clean --disableplugin=subscription-manager all \
+    && git lfs install --skip-repo --system
 
 ARG user=jenkins
 ARG group=jenkins

--- a/tests/runtime.bats
+++ b/tests/runtime.bats
@@ -146,6 +146,18 @@ runInScriptConsole() {
   assert 'Europe/Madrid' get-timezone-value
 }
 
+@test "[${SUT_DESCRIPTION}] git-lfs is configured system-wide for all users" {
+  # LFS filters must not be empty when running as the jenkins user (default)
+  run docker run --rm "${SUT_IMAGE}" sh -c 'git lfs env | grep "git config filter.lfs"'
+  assert_success
+  refute_output --regexp 'git config filter\.lfs\.\w+ = ""'
+
+  # /etc/gitconfig must contain the LFS filter section
+  run docker run --rm "${SUT_IMAGE}" cat /etc/gitconfig
+  assert_success
+  assert_output --partial '[filter "lfs"]'
+}
+
 @test "[${SUT_DESCRIPTION}] ensure that 'ps' command is available" {
   command -v ps # Check for binary presence in the current PATH
 }


### PR DESCRIPTION
Fixes #2322

Install git-lfs filter configuration at system scope by running:

```bash
git lfs install --skip-repo --system
````

after git-lfs installation.

This ensures the LFS filter configuration is written to `/etc/gitconfig` and is available to all users, including the `jenkins` user. Previously, the configuration was only applied for the user running the installation step during image build.

Related: jenkinsci/docker-agents#1111

### Testing done

* Built Alpine image locally and verified:

  * `git lfs env` shows populated `filter.lfs.*` values for the `jenkins` user
  * `/etc/gitconfig` contains the LFS filter configuration
  * LFS content is fetched correctly from an LFS-enabled repository

* Built Debian image locally and verified:

  * `git lfs env` shows populated `filter.lfs.*` values for the `jenkins` user
  * `/etc/gitconfig` contains the LFS filter configuration

<img width="1234" height="1066" alt="Screenshot From 2026-06-02 13-24-00" src="https://github.com/user-attachments/assets/503abcce-afc2-4ddb-8e98-520f61818f7c" />
<img width="1084" height="556" alt="Screenshot From 2026-06-02 13-33-20" src="https://github.com/user-attachments/assets/a1bdbe16-c47c-45a6-a0f4-688a9e88ef02" />
<img width="1097" height="1054" alt="Screenshot From 2026-06-02 13-33-30" src="https://github.com/user-attachments/assets/30e07300-123b-4804-80ab-5fd5c77f1e3f" />



### Submitter checklist

* [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
* [x] Ensure that the pull request title represents the desired changelog entry
* [x] Please describe what you did
* [x] Link to relevant issues in GitHub or Jira
* [x] Link to relevant pull requests, esp. upstream and downstream changes
* [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

