### PR TITLE
Add environment variable substitution support to `jenkins-support.psm1` (Windows parity)

### DIFF
--- a/jenkins-support.psm1
+++ b/jenkins-support.psm1
@@ -106,6 +106,28 @@ function Get-PluginVersion($archive) {
     return $version.Trim()
 }
 
+# Substitute environment variables in file content
+# Supports ${VAR} and ${VAR:-default} syntax
+# Enabled only when JENKINS_ENABLE_ENV_SUBST=true
+function Invoke-EnvVarSubstitution($file) {
+    $content = Get-Content -Raw $file
+    $pattern = '\$\{([A-Za-z_][A-Za-z0-9_]*)(:-([^}]*))?\}'
+    $content = [regex]::Replace($content, $pattern, {
+        param($match)
+        $varName = $match.Groups[1].Value
+        $defaultValue = $match.Groups[3].Value
+        $varValue = [System.Environment]::GetEnvironmentVariable($varName)
+        if ([string]::IsNullOrEmpty($varValue)) {
+            if (![string]::IsNullOrEmpty($defaultValue)) {
+                return $defaultValue
+            }
+            return ''
+        }
+        return $varValue
+    })
+    Set-Content -Path $file -Value $content -NoNewline
+}
+
 # Copy files from C:/ProgramData/Jenkins/Reference/ into $JENKINS_HOME
 # So the initial JENKINS-HOME is set with expected content.
 # Don't override, as this is just a reference setup, and use from UI
@@ -208,6 +230,15 @@ function Copy-ReferenceFile($file) {
                 New-Item -ItemType Directory (Join-Path $env:JENKINS_HOME (Split-Path -Parent $rel))
             }
             Copy-Item $file (Join-Path $env:JENKINS_HOME $rel)
+            # Perform environment variable substitution on config files (opt-in)
+            if ((Get-EnvOrDefault 'JENKINS_ENABLE_ENV_SUBST' 'false') -eq 'true') {
+                if ($rel -match '\.(xml|conf|properties|groovy)$') {
+                    $destFile = Join-Path $env:JENKINS_HOME $rel
+                    if (Test-Path $destFile) {
+                        Invoke-EnvVarSubstitution $destFile
+                    }
+                }
+            }
         } else {
             $action="SKIPPED"
         }

--- a/tests/functions.Tests.ps1
+++ b/tests/functions.Tests.ps1
@@ -95,6 +95,24 @@ Describe "[functions > $global:TEST_TAG] Copy-ReferenceFile" -Skip:(-not $global
     $stdout | Should -Match "test.override"
   }
 
+  It 'substitute_env_vars replaces variable with env value' {
+    $exitCode, $stdout, $stderr = Run-Program 'docker' "run --rm -e JENKINS_ENABLE_ENV_SUBST=true -e JENKINS_URL=http://prod.example.com $global:SUT_IMAGE powershell -C `"Import-Module -DisableNameChecking -Force C:/ProgramData/Jenkins/jenkins-support.psm1 ; `$tmp = New-TemporaryFile ; Set-Content -Path `$tmp -Value '<jenkinsUrl>`${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' ; Invoke-EnvVarSubstitution `$tmp ; Get-Content `$tmp`""
+    $exitCode | Should -Be 0
+    $stdout | Should -Match 'http://prod.example.com'
+  }
+
+  It 'substitute_env_vars uses default when variable unset' {
+    $exitCode, $stdout, $stderr = Run-Program 'docker' "run --rm -e JENKINS_ENABLE_ENV_SUBST=true $global:SUT_IMAGE powershell -C `"Import-Module -DisableNameChecking -Force C:/ProgramData/Jenkins/jenkins-support.psm1 ; `$tmp = New-TemporaryFile ; Set-Content -Path `$tmp -Value '<jenkinsUrl>`${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' ; Invoke-EnvVarSubstitution `$tmp ; Get-Content `$tmp`""
+    $exitCode | Should -Be 0
+    $stdout | Should -Match 'http://localhost:8080/'
+  }
+
+  It 'copy_reference_file skips substitution when JENKINS_ENABLE_ENV_SUBST is unset' {
+    $exitCode, $stdout, $stderr = Run-Program 'docker' "run --rm -e JENKINS_ENABLE_ENV_SUBST=false -e JENKINS_URL=http://prod.example.com $global:SUT_IMAGE powershell -C `"Import-Module -DisableNameChecking -Force C:/ProgramData/Jenkins/jenkins-support.psm1 ; `$tmp = New-TemporaryFile ; Set-Content -Path `$tmp -Value '<jenkinsUrl>`${JENKINS_URL:-http://localhost:8080/}</jenkinsUrl>' ; if((Get-EnvOrDefault 'JENKINS_ENABLE_ENV_SUBST' 'false') -eq 'true') { Invoke-EnvVarSubstitution `$tmp } ; Get-Content `$tmp`""
+    $exitCode | Should -Be 0
+    $stdout | Should -Match '\$\{JENKINS_URL:-http://localhost:8080/\}'
+  }
+
   It 'cleanup container' {
     Cleanup $global:SUT_CONTAINER | Out-Null
   }


### PR DESCRIPTION
Windows parity for #2250, suggested by @lemeurherve upon merging.

PR #2250 added `JENKINS_ENABLE_ENV_SUBST=true` support to `jenkins-support` for Linux containers. This brings the same behavior to `jenkins-support.psm1` for Windows containers.

Adds `Invoke-EnvVarSubstitution` function supporting `${VAR}` and `${VAR:-default}` syntax, applied to `.xml`, `.conf`, `.properties`, and `.groovy` files during `Copy-ReferenceFile` execution. Opt-in only — existing users see zero behavior change on upgrade.

Closes #2350

<!-- Please describe your pull request here. -->

### Testing done

Added three Pester tests to `tests/functions.Tests.ps1` covering:
- Variable substitution when `JENKINS_ENABLE_ENV_SUBST=true` and env var is set
- Default value fallback when env var is unset
- Placeholders left untouched when flag is disabled

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
