### PR TITLE
chore(windows): disable docker compose parallelism

### DIFF
--- a/make.ps1
+++ b/make.ps1
@@ -222,7 +222,7 @@ if([String]::IsNullOrWhiteSpace($env:WAR_URL)) {
 
 $dockerComposeFile = 'build-windows_{0}.yaml' -f $ImageType
 $baseDockerCmd = 'docker-compose --file={0}' -f $dockerComposeFile
-$baseDockerBuildCmd = '{0} build --parallel 1 --pull' -f $baseDockerCmd
+$baseDockerBuildCmd = '{0} build --parallel=1 --pull' -f $baseDockerCmd
 
 # Generate the docker compose file if it doesn't exists or if the parameter OverwriteDockerComposeFile is set
 if ((Test-Path $dockerComposeFile) -and -not $OverwriteDockerComposeFile) {

--- a/make.ps1
+++ b/make.ps1
@@ -222,7 +222,7 @@ if([String]::IsNullOrWhiteSpace($env:WAR_URL)) {
 
 $dockerComposeFile = 'build-windows_{0}.yaml' -f $ImageType
 $baseDockerCmd = 'docker-compose --file={0}' -f $dockerComposeFile
-$baseDockerBuildCmd = '{0} build --pull' -f $baseDockerCmd
+$baseDockerBuildCmd = '{0} build --parallel 1 --pull' -f $baseDockerCmd
 
 # Generate the docker compose file if it doesn't exists or if the parameter OverwriteDockerComposeFile is set
 if ((Test-Path $dockerComposeFile) -and -not $OverwriteDockerComposeFile) {


### PR DESCRIPTION
This change tries to alleviate `hcs::CreateComputeSystem: Incorrect function` errors encountered when building Windows 2025 images, and stalling Windows 2022 images.

Ref:
- https://github.com/jenkinsci/docker/issues/2382
- https://github.com/jenkinsci/docker/issues/2383

### Testing done

CI

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
