### PR TITLE
fix(windows): use `gpgv` instead of `gpg` for signature verification

### DIFF
--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -68,8 +68,8 @@ RUN New-Item -ItemType Directory -Path C:/war | Out-Null ; `
 COPY jenkins.io-2026.key /war/jenkins-key.pub
 
 RUN & 'C:/Program Files/GnuPG/bin/gpg.exe' --version ; `
-    & 'C:/Program Files/GnuPG/bin/gpg.exe' --import C:/war/jenkins-key.pub ; `
-    & 'C:/Program Files/GnuPG/bin/gpg.exe' --verify --trust-model direct C:/war/jenkins.war.asc C:/war/jenkins.war
+    & 'C:/Program Files/GnuPG/bin/gpg.exe' --dearmor --output C:/war/jenkins-key.pgp C:/war/jenkins-key.pub ; `
+    & 'C:/Program Files/GnuPG/bin/gpgv.exe' --keyring C:/war/jenkins-key.pgp C:/war/jenkins.war.asc C:/war/jenkins.war
 
 FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION}" AS controller
 


### PR DESCRIPTION
This change uses `gpgv` for signature verification, stripped down version of `gpg` not using `keyboxd` daemon.

Note: GnuPG is only used in an intermediary image to verify Jenkins public key, and is not included in the final image.

Ref:
- https://github.com/jenkinsci/docker/issues/2396
- https://gpg4win.org/version4.2.html (introducing new keyboxd daemon)
- https://www.gnupg.org/documentation/manuals/gnupg/gpgv.html

### Testing done

CI

```
18:18:25  gpgv: Signature made 07/07/26 05:58:56 Coordinated Universal Time
18:18:25  gpgv:                using RSA key 5E386EADB55F01504CAE8BCF7198F4B714ABFC68
18:18:25  gpgv: Good signature from "Jenkins Project &lt;<a href="mailto:jenkinsci-board@googlegroups.com" rel="noopener noreferrer">jenkinsci-board@googlegroups.com</a>&gt;"
```

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
