### PR TITLE
chore: remove obsolete Windows flavor TODO comment

### DIFF
--- a/tests/test_helpers.psm1
+++ b/tests/test_helpers.psm1
@@ -66,7 +66,6 @@ function Retry-Command {
 }
 
 function Get-SutImage {
-    # TODO: don't hardcode Windows flavor
     $DOCKERFILE = 'windows/windowsservercore/hotspot/Dockerfile'
     $IMAGETAG = Get-EnvOrDefault 'CONTROLLER_TAG' ''
 


### PR DESCRIPTION
This PR removes the obsolete `# TODO: don't hardcode Windows flavor` comment in `tests/test_helpers.psm1`.

As confirmed by the maintainers, this repository will strictly only ever build the `windowsservercore` flavor of Windows. Therefore, a dynamic implementation is not needed and the TODO comment was left by mistake. 

This PR simply deletes the comment to prevent future confusion.

### Testing done

No functional changes were made, only a comment was removed.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
