### PR TITLE
chore(windows): switch Adoptium installation to ZIP archive instead of MSI

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -107,7 +107,7 @@ $(printf '  %s\n' "${build_opts[@]}")
 EOF
 
 echo '* RESOLVED BAKE CONFIG:'
-docker buildx bake --file docker-bake.hcl --progress=quiet --print "${BAKE_TARGET}"
+docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --file docker-bake.override.json --progress=quiet --print "${BAKE_TARGET}"
 
 if [[ "${CI:-false}" == "false" ]]; then
   read -rp "Confirm? [y/N] " answer

--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ check_cli = type "$(1)" >/dev/null 2>&1 || { echo "Error: command '$(1)' require
 ## Check if a given image exists in the current manifest docker-bake.hcl
 check_image = make --silent list | grep -w '$(1)' >/dev/null 2>&1 || { echo "Error: the image '$(1)' does not exist in manifest for the current platform '$(OS)/$(ARCH)'. Please check the output of 'make list'. Exiting." ; exit 1 ; }
 ## Base "docker buildx base" command to be reused everywhere
-bake_base_cli := docker buildx bake -f docker-bake.hcl --load
+bake_base_cli := docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --load
 ## Default bake target
 bake_default_target := all
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -171,7 +171,7 @@ target "windowsservercore" {
     WAR_URL            = war_url()
     COMMIT_SHA         = COMMIT_SHA
     PLUGIN_CLI_VERSION = PLUGIN_CLI_VERSION
-    JAVA_VERSION       = javaversion(jdk)
+    JAVA_ZIP_URL       = lookup(jdk_installer_urls["windows"]["amd64"], jdk, "Installer URL not found")
     JAVA_HOME          = "C:/openjdk-${jdk}"
     WINDOWS_VERSION    = windows_version
   }

--- a/docker-bake.override.json
+++ b/docker-bake.override.json
@@ -1,0 +1,15 @@
+{
+  "variable": {
+    "jdk_installer_urls": {
+      "default": {
+        "windows": {
+          "amd64": {
+            "17": "https://github.com/adoptium/temurin17-binaries/releases/download/jdk-17.0.19%2B10/OpenJDK17U-jdk_x64_windows_hotspot_17.0.19_10.zip",
+            "21": "https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.11%2B10/OpenJDK21U-jdk_x64_windows_hotspot_21.0.11_10.zip",
+            "25": "https://github.com/adoptium/temurin25-binaries/releases/download/jdk-25.0.3%2B9/OpenJDK25U-jdk_x64_windows_hotspot_25.0.3_9.zip"
+          }
+        }
+      }
+    }
+  }
+}

--- a/make.ps1
+++ b/make.ps1
@@ -188,7 +188,7 @@ function Initialize-DockerComposeFile {
     # - Use docker buildx bake to output image definitions from the "<windowsFlavor>" bake target
     # - Convert with yq to the format expected by docker compose
     # - Store the result in the docker compose file
-    docker buildx bake --progress=quiet --file=docker-bake.hcl $windowsFlavor --print |
+    docker buildx bake --progress=quiet --file=docker-bake.hcl --file docker-bake.override.json $windowsFlavor --print |
         yq --prettyPrint $yqMainQuery |
         yq $yqServicesQuery |
         Out-File -FilePath $DockerComposeFile
@@ -208,7 +208,7 @@ yq --version
 # Add 'lts-' prefix to LTS tags not including Jenkins version
 # Compared to weekly releases, LTS releases include an additional build number in their version
 $releaseLine = 'war'
-# Determine if the current JENKINS_VERSION corresponds to the latest Weekly or LTS version from Artifactory 
+# Determine if the current JENKINS_VERSION corresponds to the latest Weekly or LTS version from Artifactory
 $isJenkinsVersionLatest = Test-IsLatestJenkinsRelease -Version $JenkinsVersion
 
 if ($JenkinsVersion.Split('.').Count -eq 3) {

--- a/updatecli/updatecli.d/jdk21.yaml
+++ b/updatecli/updatecli.d/jdk21.yaml
@@ -61,7 +61,6 @@ targets:
         - alpine/hotspot/Dockerfile
         - debian/Dockerfile
         - rhel/Dockerfile
-        - windows/windowsservercore/hotspot/Dockerfile
       instruction:
         keyword: ARG
         matcher: JAVA_VERSION

--- a/windows/windowsservercore/hotspot/Dockerfile
+++ b/windows/windowsservercore/hotspot/Dockerfile
@@ -1,7 +1,6 @@
 # escape=`
 # hadolint shell=powershell
 
-ARG JAVA_VERSION=21.0.11_10
 ARG WINDOWS_VERSION=ltsc2022
 
 FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION}" AS jre-and-war
@@ -9,24 +8,26 @@ FROM mcr.microsoft.com/windows/servercore:"${WINDOWS_VERSION}" AS jre-and-war
 # $ProgressPreference: https://github.com/PowerShell/PowerShell/issues/2138#issuecomment-251261324
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
 
-ARG JAVA_VERSION=21.0.11_10
+ARG JAVA_ZIP_URL="Provided by docker-bake.hcl"
+ARG jdkTempHome='C:\openjdk'
+ARG jdkTemp='C:\jdktemp'
+ARG localArchive="${jdkTemp}\jdk.zip"
+RUN New-Item -ItemType Directory -Path $env:jdkTemp | Out-Null ; `
+    Invoke-WebRequest $env:JAVA_ZIP_URL -OutFile $env:localArchive ; `
+    Expand-Archive -Path $env:localArchive -DestinationPath $env:jdkTemp ; `
+    $expandedDir = Get-ChildItem -Path $env:jdkTemp -Directory | Where-Object { $_.Name -like 'jdk*' } ; `
+    Move-Item -Path $expandedDir.FullName -Destination $env:jdkTempHome -Force ; `
+    Remove-Item -Path $env:jdkTemp -Recurse | Out-Null  ; `
+    $CurrentPath = (Get-Itemproperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path).Path ; `
+    $NewPath = $CurrentPath + $(';{0}/bin' -f $env:jdkTempHome) ; `
+    Set-ItemProperty -path 'hklm:\system\currentcontrolset\control\session manager\environment' -Name Path -Value $NewPath
 
-RUN New-Item -ItemType Directory -Path C:\temp | Out-Null ; `
-    $javaMajorVersion = $env:JAVA_VERSION.substring(0,2) ; `
-    $msiUrl = 'https://api.adoptium.net/v3/installer/version/jdk-{0}/windows/x64/jdk/hotspot/normal/eclipse?project=jdk' -f $env:JAVA_VERSION.Replace('_', '%2B') ; `
-    Invoke-WebRequest $msiUrl -OutFile 'C:\temp\jdk.msi' ; `
-    $proc = Start-Process -FilePath 'msiexec.exe' -ArgumentList '/i', 'C:\temp\jdk.msi', '/L*V', 'C:\temp\OpenJDK.log', '/quiet', 'ADDLOCAL=FeatureEnvironment,FeatureJarFileRunWith,FeatureJavaHome',  "INSTALLDIR=C:\openjdk-${javaMajorVersion}" -Wait -Passthru ; `
-    $proc.WaitForExit() ; `
-    Remove-Item -Path C:\temp -Recurse | Out-Null
-
-RUN Write-Host 'javac --version' ; javac --version ; `
-    Write-Host 'java --version' ; java --version
-
-RUN $version = (jlink --version) ; `
+RUN Write-Host 'java --version' ; java --version ; `
+    Write-Host 'javac --version' ; javac --version ; `
+    $version = (jlink --version) ; `
     $javaMajorVersion = $version.Substring(0,2) ; `
     if ($javaMajorVersion -eq '25') { `
-        $openjdkFolder = 'openjdk-{0}' -f $javaMajorVersion ; `
-        Copy-Item -Path $openjdkFolder -Destination C:\javaruntime -Recurse ; `
+        Move-Item -Path $env:jdkTempHome -Destination C:\javaruntime ; `
     } else { `
         $options = '--compress=2' ; `
         switch ($version.Substring(0,3)) { `


### PR DESCRIPTION
Twin of https://github.com/jenkinsci/docker-ssh-agent/pull/668 and https://github.com/jenkinsci/docker-agents/pull/1263 (see https://github.com/jenkinsci/docker-agents/issues/1265 also)

This PR cherry-picks the switch of Windows JDK installation from MSI (hard to debug and prone to many errors while we only need an OpenJDK directory) to ZIP.

Notes (same as the twin PRs):

- A subsequent PR is needed to track installer URLs (e.g. version bumps) in the introduced JSON file
- No GPG verification (yet)
- No Linux (yet)
