### PR TITLE
chore(ci/publish) ensure all docker bake build calls uses the same set of `--file` flags

### DIFF
--- a/.ci/publish.sh
+++ b/.ci/publish.sh
@@ -88,6 +88,7 @@ fi
 # Save build result metadata
 mkdir -p target
 BUILD_METADATA_PATH="target/build-result-metadata_${BAKE_TARGET}_${metadata_suffix}.json"
+bake_common_opts=("--file=docker-bake.hcl" "--file=docker-bake.override.json")
 build_opts+=("--metadata-file=${BUILD_METADATA_PATH}")
 
 COMMIT_SHA=$(git rev-parse HEAD)
@@ -103,11 +104,11 @@ Using the following settings:
 * BUILD_METADATA_PATH: ${BUILD_METADATA_PATH}
 * BAKE_TARGET: ${BAKE_TARGET}
 * BAKE OPTIONS:
-$(printf '  %s\n' "${build_opts[@]}")
+$(printf '  %s\n' "${build_opts[@]}" "${bake_common_opts[@]}")
 EOF
 
 echo '* RESOLVED BAKE CONFIG:'
-docker buildx bake --file docker-bake.hcl --file docker-bake.override.json --file docker-bake.override.json --progress=quiet --print "${BAKE_TARGET}"
+docker buildx bake "${bake_common_opts[@]}" --progress=quiet --print "${BAKE_TARGET}"
 
 if [[ "${CI:-false}" == "false" ]]; then
   read -rp "Confirm? [y/N] " answer
@@ -117,4 +118,4 @@ if [[ "${CI:-false}" == "false" ]]; then
   fi
 fi
 
-docker buildx bake --file docker-bake.hcl "${build_opts[@]}" "${BAKE_TARGET}"
+docker buildx bake "${bake_common_opts[@]}" "${build_opts[@]}" "${BAKE_TARGET}"


### PR DESCRIPTION
This PR is a fixup of https://github.com/jenkinsci/docker/pull/2420 which introduces 2 minor fixes in the publication script:

- Remove a duplicated flag (ref. https://github.com/jenkinsci/docker/pull/2420#discussion_r3659296113)
- Fix the publish script to ensure all its `docker buildx bake` CLI calls are using the same set of `--file` flags. I missed one which failed the weekly 2.575 publication, which is a dumb mistake.

Notes:

- This PR is "production" tested with a replay of `2.575` tag with only Linux + a curl of the updated `publish script from a Gist (https://gist.githubusercontent.com/dduportal/dc80aaf26b26f897ca10b2e03d6b5aa7/raw/9dc43766f735c2dfd36e70f8c15e05b306847134/gistfile1.txt) before running the `make publish` shell step.
- I've prevented CI to run (not testable on ci.jenkins.io) and the changelog to integrate this PR (no user-facing value as it does not change the controller container images)