### PR TITLE
chore(updatecli): add `pester` manifest

### DIFF
--- a/updatecli/updatecli.d/pester.yaml
+++ b/updatecli/updatecli.d/pester.yaml
@@ -1,0 +1,50 @@
+name: Bump `pester` version
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: "{{ .github.user }}"
+      email: "{{ .github.email }}"
+      owner: "{{ .github.owner }}"
+      repository: "{{ .github.repository }}"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      branch: "{{ .github.branch }}"
+
+sources:
+  lastVersion:
+    kind: githubrelease
+    name: Get latest `pester` version
+    spec:
+      owner: pester
+      repository: pester
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+      versionfilter:
+        kind: semver
+    transformers:
+      - trimprefix: "v"
+
+targets:
+  updateVersion:
+    name: Update `pester` version in make.ps1
+    kind: file
+    spec:
+      file: make.ps1
+      matchpattern: >
+        PesterVersion = (.*)
+      replacepattern: >
+        PesterVersion = '{{ source "lastVersion" }}',
+    scmid: default
+
+actions:
+  default:
+    kind: github/pullrequest
+    title: Bump `pester` version to {{ source "lastVersion" }}
+    scmid: default
+    spec:
+      labels:
+        - dependencies
+        - pester
+        - windows


### PR DESCRIPTION
Follow-up of:
- #2409 

### Testing done

<details><summary>updatecli diff --config updatecli/updatecli.d/pester.yaml --values updatecli/values.github-action.yaml</summary>

```
+++++++++++
+ PREPARE +
+++++++++++

Loading Pipeline "updatecli/updatecli.d/pester.yaml"

SCM repository retrieved: 1


++++++++++++++++++
+ AUTO DISCOVERY +
++++++++++++++++++



++++++++++++
+ PIPELINE +
++++++++++++


#########################
# BUMP `PESTER` VERSION #
#########################

Pipeline ID	: 4973f68e76e9827dad8a1869c9f87ad1b9ab44862fbe987e1bf1f6ad3b22805a
Dry Run		: enabled

source: lastVersion
-------------------

Searching for version matching pattern "*"
✔ GitHub release version "6.1.0" found matching pattern "*" of kind "semver"
[transformers]
✔ Result correctly transformed from "6.1.0" to "6.1.0"

target: updateVersion
---------------------

Repository	: github.com/jenkinsci/docker@master

"make.ps1" updated with [dry run] content "PesterVersion = '6.1.0',\n"

--- make.ps1
+++ make.ps1
@@ -12,7 +12,7 @@
     # Print the build and publish command instead of executing them if set
     [switch] $DryRun = $false,
     # Pester version to install and use for tests
-    [String] $PesterVersion = '5.3.3',
+    [String] $PesterVersion = '6.1.0',
     # Output debug info for tests: 'empty' (no additional test output), 'debug' (test cmd & stderr output), 'verbose' (test cmd, stderr, stdout output)
     [String] $TestsDebug = ''
 )


⚠ - 1 file(s) updated with "PesterVersion = '6.1.0',\n":
	* make.ps1


ACTIONS
========

---
Pipeline Name	: Bump `pester` version
Pipeline ID	: 4973f68e76e9827dad8a1869c9f87ad1b9ab44862fbe987e1bf1f6ad3b22805a
Dry run		: true
Repository	: github.com/jenkinsci/docker@master
Action		: Bump `pester` version to 6.1.0
---

An action of kind "github/pullrequest" is expected.

=============================

SUMMARY:

⚠ Bump `pester` version:
	Source:
		✔ [lastVersion] Get latest `pester` version
	Target:
		⚠ [updateVersion] Update `pester` version in make.ps1
		      * Repository: https://github.com/jenkinsci/docker.git (branch: master)


Run Summary
===========
Pipeline(s) run:
  * Changed:	1
  * Failed:	0
  * Skipped:	0
  * Succeeded:	0
  * Total:	1
```

</details>

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
